### PR TITLE
changed root from syllabus to curriculum

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,7 +26,7 @@ org = "https://github.com/CodeYourFuture"
 repo = "https://github.com/CodeYourFuture/curriculum/"
 tree = "https://github.com/CodeYourFuture/curriculum/tree/main/"
 edit = "https://github.com/CodeYourFuture/curriculum/edit/main/"
-root = "syllabus"
+root = "curriculum"
 orgapi = "https://api.github.com/repos/CodeYourFuture/"
 
 [markup]


### PR DESCRIPTION
Bugfix

config had syllabus as root so pull from github was not working

note: I will likely abstract this out of the templates at some point