### PR TITLE
combine the two Tocs

### DIFF
--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -5,6 +5,9 @@
 }}
   {{ $hasTOC = true }}
 {{ end }}
+{{ if (and (or (eq .Layout "prep") (eq .Layout "day-plan")) (gt .Params.blocks 1)) }}
+  {{ $hasTOC = true }}
+{{ end }}
 <header
   class="c-page-header {{ if $headerClass }}
     {{ $headerClass }}
@@ -46,19 +49,6 @@
           >📎</a
         >
         {{ .Page.TableOfContents }}
-      </section>
-    {{ end }}
-
-
-    <!--handmade TOC-->
-    {{ if or (eq .Layout "prep") (eq .Layout "day-plan") }}
-      <section class="c-page-header__toc c-toc" id="toc">
-        <a
-          id="top"
-          class="c-toc__top e-button e-button--icon e-heading__3"
-          href="#skip-link"
-          >📎</a
-        >
         <ol>
           {{ range .Params.blocks }}
             <li><a href="#{{ .name | urlize }}">{{ .name }}</a></li>
@@ -66,5 +56,6 @@
         </ol>
       </section>
     {{ end }}
+
   </div>
 </header>

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -48,12 +48,18 @@
           href="#skip-link"
           >📎</a
         >
-        {{ .Page.TableOfContents }}
-        <ol>
-          {{ range .Params.blocks }}
-            <li><a href="#{{ .name | urlize }}">{{ .name }}</a></li>
-          {{ end }}
-        </ol>
+        {{ if and
+          (gt .Page.WordCount 400) (.Page.TableOfContents)
+        }}
+          {{ .Page.TableOfContents }}
+        {{ end }}
+        {{ if gt .Params.blocks 1 }}
+          <ol>
+            {{ range .Params.blocks }}
+              <li><a href="#{{ .name | urlize }}">{{ .name }}</a></li>
+            {{ end }}
+          </ol>
+        {{ end }}
       </section>
     {{ end }}
 


### PR DESCRIPTION
we never want an empty toc printing over a populated one! 
given a day plan or prep page
when the page content is over 400 words
print the auto TOC before the block toc

given a day plan or prep page
when there are 1 or fewer blocks
do not show the TOC