### PR TITLE
video don't have markdown...

### DIFF
--- a/layouts/_default/success.html
+++ b/layouts/_default/success.html
@@ -34,14 +34,16 @@
           so, for each block, print the objectives only
         */}}
         {{ range $blocks }}
-          <section class="c-objectives">
-            <h3 class="c-objectives__title">
-              {{ .name }}
-            </h3>
-            {{ partial "block.html" (dict "block" . "Page"
-              $.Page)
-            }}
-          </section>
+          {{ if not "youtube" | in .Params.src }}
+            <section class="c-objectives">
+              <h3 class="c-objectives__title">
+                {{ .name }}
+              </h3>
+              {{ partial "block.html" (dict "block" . "Page"
+                $.Page)
+              }}
+            </section>
+          {{ end }}
         {{ end }}
       </section>
     </confetti-checkboxes>


### PR DESCRIPTION
probably  don't want to try to read objectives from a video file - skip over this code if the block type is a youtube video

Without this check, this page would print blank blocks if youtube was in the block array