### PR TITLE
Filter out PRs and bug reports on backlog

### DIFF
--- a/create_module.sh
+++ b/create_module.sh
@@ -39,6 +39,7 @@ emoji= '📝'
 menu_level = ['module']
 weight = $MENU_ORDER
 backlog= 'Module-$MODULE_NAME'
+backlog_filter= '$MODULE_NAME'
 +++
 
 " > $MODULE_DIR/$file/index.md


### PR DESCRIPTION
add label filter to main module backlog
existing modules will need to be manually updated
empty modules can be re-created

check on Module-Databases / backlog to see problem and resolution

this depends on adding the module label to issues, so may also need to check this is created by default on coursework issue forms (I think it is)