### PR TITLE
Highlight lines in CM6

### DIFF
--- a/assets/scripts/cm6.ts
+++ b/assets/scripts/cm6.ts
@@ -3,10 +3,25 @@ import { basicSetup } from "codemirror";
 import { indentWithTab } from "@codemirror/commands";
 import { javascript } from "@codemirror/lang-javascript";
 
+import { lineHighlighter } from "./highlight-lines";
+
+// List of all possible options: https://github.com/gohugoio/hugo/blob/master/markup/highlight/highlight.go#L37-L48
+// But for now we just support line highlighting
+interface CodeBlockOptions {
+  hl_lines?: [number, number];
+}
+
 const containers: NodeListOf<HTMLElement> =
   document.querySelectorAll("[data-cm-editor]");
 
 containers.forEach((container) => {
+  let options: CodeBlockOptions = {};
+  try {
+    options = JSON.parse(container.dataset.options);
+  } catch {
+    console.error("Invalid .Options on CM6 editor");
+  }
+
   const view = new EditorView({
     extensions: [
       // Enable "basic" functionality, see https://codemirror.net/docs/ref/#codemirror.basicSetup
@@ -16,6 +31,8 @@ containers.forEach((container) => {
       theme(),
       // Enable JS specific features (syntax highlighting, autocomplete, etc)
       javascript(),
+      // Enable highlighting of specific lines
+      lineHighlighter(options.hl_lines),
     ],
     // Set up the initial doc to be the contents of the original container
     doc: container.innerText,

--- a/assets/scripts/cm6.ts
+++ b/assets/scripts/cm6.ts
@@ -3,7 +3,8 @@ import { basicSetup } from "codemirror";
 import { indentWithTab } from "@codemirror/commands";
 import { javascript } from "@codemirror/lang-javascript";
 
-const containers = document.querySelectorAll("[data-cm-editor]");
+const containers: NodeListOf<HTMLElement> =
+  document.querySelectorAll("[data-cm-editor]");
 
 containers.forEach((container) => {
   const view = new EditorView({
@@ -13,7 +14,7 @@ containers.forEach((container) => {
       // Enable indenting via Tab, see https://codemirror.net/examples/tab/
       keymap.of([indentWithTab]),
       theme(),
-      // Enable JS specific features
+      // Enable JS specific features (syntax highlighting, autocomplete, etc)
       javascript(),
     ],
     // Set up the initial doc to be the contents of the original container

--- a/assets/scripts/highlight-lines.ts
+++ b/assets/scripts/highlight-lines.ts
@@ -12,11 +12,9 @@ const highlightedLine = Decoration.line({ class: "hl_line" });
 // Define a ViewPlugin that controls how the highlightedLine Decoration is
 // applied to the view
 const highlightLinesPlugin = ViewPlugin.define(
-  (view) => {
-    return {
-      decorations: Decoration.set(highlightLines(view)),
-    };
-  },
+  (view) => ({
+    decorations: highlightLines(view),
+  }),
   {
     decorations: (viewPlugin) => viewPlugin.decorations,
   }
@@ -27,6 +25,9 @@ function highlightLines(view: EditorView) {
 
   // Pull the highlighted line numbers from the facet
   const lines = view.state.facet(highlightedLineNumbers);
+
+  // Don't show any decorations if there are no highlighted line numbers
+  if (!lines && !lines.length) return Decoration.none;
 
   for (const line of lines) {
     // Hugo gives us a start line and an end line. For CM6 we need to generate a
@@ -47,7 +48,7 @@ function highlightLines(view: EditorView) {
     }
   }
 
-  return decorations;
+  return Decoration.set(decorations);
 }
 
 // Helper function to generate an array of line numbers between a start and end
@@ -59,7 +60,7 @@ function range(start, end) {
 
 // Define a facet for storing the highlighted lines, that is an array of a
 // starting line number and an ending line number
-const highlightedLineNumbers: Facet<[number?, number?]> = Facet.define({
+const highlightedLineNumbers: Facet<[number, number]> = Facet.define({
   // Since we only have 1 place this can be configured, we just always take the
   // first input value
   combine: ([val]) => val,
@@ -71,7 +72,7 @@ const highlightLinesTheme = EditorView.baseTheme({
   ".hl_line": { backgroundColor: "hsl(60deg 100% 90% / 0.8)" },
 });
 
-export function lineHighlighter(lines: [number?, number?] = []) {
+export function lineHighlighter(lines: [number, number]) {
   return [
     // Configure the highlighted lines
     highlightedLineNumbers.of(lines),

--- a/assets/scripts/highlight-lines.ts
+++ b/assets/scripts/highlight-lines.ts
@@ -1,0 +1,81 @@
+import {
+  EditorView,
+  ViewPlugin,
+  Decoration,
+  type DecorationSet,
+} from "@codemirror/view";
+import { type Range, Facet } from "@codemirror/state";
+
+// Define a Line Decoration that applies a class to the relevant line
+const highlightedLine = Decoration.line({ class: "hl_line" });
+
+// Define a ViewPlugin that controls how the highlightedLine Decoration is
+// applied to the view
+const highlightLinesPlugin = ViewPlugin.define(
+  (view) => {
+    return {
+      decorations: Decoration.set(highlightLines(view)),
+    };
+  },
+  {
+    decorations: (viewPlugin) => viewPlugin.decorations,
+  }
+);
+
+function highlightLines(view: EditorView) {
+  let decorations: Range<Decoration>[] = [];
+
+  // Pull the highlighted line numbers from the facet
+  const lines = view.state.facet(highlightedLineNumbers);
+
+  for (const line of lines) {
+    // Hugo gives us a start line and an end line. For CM6 we need to generate a
+    // line decoration between the start and end lines (inclusive)
+    // Calculate each line in-between and generate a line decoration
+
+    const [fromLine, toLine] = line;
+
+    // For whatever reason Hugo seems to be zero-indexing line numbers,
+    // so convert to 1-indexing for CM6
+    const linesBetween = range(fromLine + 1, toLine + 1);
+
+    for (const lineBetween of linesBetween) {
+      // Calculate the line position in the CM6 offset coords system
+      const { from } = view.state.doc.line(lineBetween);
+      // Create a Line Decoration for the line position
+      decorations.push(highlightedLine.range(from));
+    }
+  }
+
+  return decorations;
+}
+
+// Helper function to generate an array of line numbers between a start and end
+function range(start, end) {
+  return Array(end - start + 1)
+    .fill(null)
+    .map((_, idx) => start + idx);
+}
+
+// Define a facet for storing the highlighted lines, that is an array of a
+// starting line number and an ending line number
+const highlightedLineNumbers: Facet<[number?, number?]> = Facet.define({
+  // Since we only have 1 place this can be configured, we just always take the
+  // first input value
+  combine: ([val]) => val,
+  static: true,
+});
+
+// Define a theme that styles the highlighted lines
+const highlightLinesTheme = EditorView.baseTheme({
+  ".hl_line": { backgroundColor: "hsl(60deg 100% 90% / 0.8)" },
+});
+
+export function lineHighlighter(lines: [number?, number?] = []) {
+  return [
+    // Configure the highlighted lines
+    highlightedLineNumbers.of(lines),
+    highlightLinesPlugin,
+    highlightLinesTheme,
+  ];
+}

--- a/layouts/_default/_markup/render-codeblock-js.html
+++ b/layouts/_default/_markup/render-codeblock-js.html
@@ -1,3 +1,3 @@
 <h4 class="is-invisible">Interactive code block</h4>
 {{/* Must be a pre to preserve line breaks */}}
-<pre data-cm-editor>{{ .Inner }}</pre>
+<pre data-cm-editor data-options="{{ .Options | jsonify }}" >{{ .Inner }}</pre>

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -34,7 +34,7 @@
 </footer>
 {{ $scripts := resources.Get "scripts/app.js" | resources.Minify }}
 {{ $menuButton := resources.Get "scripts/random-emoji.js" | resources.Minify }}
-{{ $codemirror := resources.Get "scripts/cm6.js" | js.Build | resources.Minify }}
+{{ $codemirror := resources.Get "scripts/cm6.ts" | js.Build }}
 <script src="{{ $scripts.Permalink }}" defer></script>
 <script src="{{ $menuButton.Permalink }}"></script>
 <script src="{{ $codemirror.Permalink }}"></script>


### PR DESCRIPTION
## Description

<!-- Add a description of what your PR changes here -->

Highlight specific lines of a code block when using CM6. This was raised as a feature request in https://github.com/CodeYourFuture/curriculum/issues/9.

![Capture-2023-05-28-231010](https://github.com/CodeYourFuture/curriculum/assets/424411/320994b3-6245-4ac4-ac36-eba058f23532)

I also took the liberty of converting the CM6 code to TypeScript. This is mostly because CM6 itself is written in TS, as is most of the documentation, and so it makes sense to follow that. Frustratingly I still get a type error in VSCode, but it's spurious (at least in browsers that aren't 10+ years old). Hints on how to get rid of this would be welcome.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

@Dedekind561 @SallyMcGrath since you requested it :D

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
