### PR TITLE
range over correct thing in objectives

### DIFF
--- a/layouts/partials/objectives-block.html
+++ b/layouts/partials/objectives-block.html
@@ -1,7 +1,7 @@
 <ul class="c-objectives__list">
-  {{ range . }}
+  {{ range $key, $value := .Objectives }}
     <li class="c-objectives__item">
-      <label><input type="checkbox" />{{ . }}</label>
+      <label><input type="checkbox" />{{ $value }}</label>
     </li>
   {{ end }}
 </ul>


### PR DESCRIPTION
range over correct thing in objectives, so we don't have a garbled mess saying FALSE, MAP
coming up, fixing the success view which is somehow now blank
but thought I would get this in so it's not blocking as per Mitch's comment on the fundamentals PR