### PR TITLE
Feature: compile and extract objectives from github

### DIFF
--- a/layouts/_default/success.html
+++ b/layouts/_default/success.html
@@ -24,16 +24,16 @@
         {{ $prep := .Site.GetPage (printf "%sprep/index.md"
           .CurrentSection.RelPermalink)
         }}
-         {{ $dayplan := .Site.GetPage (printf "%sday-plan/index.md"
+        {{ $dayplan := .Site.GetPage (printf "%sday-plan/index.md"
           .CurrentSection.RelPermalink)
         }}
         {{ $blocks := slice }}
-{{/* append non-nil blocks */}}
+        {{/* append non-nil blocks */}}
         {{ range $prep.Params.blocks }}
           {{ if . }}{{ $blocks = $blocks | append . }}{{ end }}
         {{ end }}
         {{ range $dayplan.Params.blocks }}
-          {{ if . }} {{ $blocks = $blocks | append . }} {{ end }}
+          {{ if . }}{{ $blocks = $blocks | append . }}{{ end }}
         {{ end }}
         {{/* Deduplicate blocks */}}
         {{ $blocks = $blocks | uniq }}
@@ -48,9 +48,14 @@
           {{/* Retrieve the blockData from Scratch */}}
           {{ $blockData := $.Page.Scratch.Get "blockData" }}
           {{/* Depending on the type of block, call the appropriate partial */}}
-          {{/*  {{ if or (eq $blockData.type "readme") (eq $blockData.type "pd") }}
+          {{ if or (eq $blockData.type "readme") (eq $blockData.type "pd") }}
+            <h5>
+              <a href="{{ $blockData.sot }}" class="c-objectives__link">
+                {{ $blockData.name }} 🔗
+              </a>
+            </h5>
             {{ partial "objectives-parsed" (dict "blockData" $blockData "pageContext" $pageContext) }}
-          {{ end }}  */}}
+          {{ end }}
           {{ if or (eq $blockData.type "local_module") (eq $blockData.type "local_course") }}
             {{ partial "objectives-lookup.html" (dict "blockData" $blockData "pageContext" $pageContext) }}
           {{ end }}

--- a/layouts/partials/block-data.html
+++ b/layouts/partials/block-data.html
@@ -32,14 +32,20 @@
 {{ end }}
 
 {{ if "github" | in $src }}
-  {{/* https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-a-repository-readme-for-a-directory */}}
+  {{/* Change base URL to api.github.com */}}
   {{ $newSrc := replace $src "https://github.com/CodeYourFuture/" "https://api.github.com/repos/CodeYourFuture/" }}
+
   {{ if (in $src "issues") }}
     {{ .Scratch.SetInMap "blockData" "type" "issue" }}
   {{ else }}
-    {{ $newSrc = replace $newSrc "/tree/main" "/readme/" }}
+    {{/* For repositories and individual README files, use readme API endpoint
+      https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-a-repository-readme-for-a-directory
+    */}}
+    {{ $newSrc = replace $newSrc "/tree/main" "/readme" }}
+    {{ $newSrc = replace $newSrc "/blob/main/README.md" "/readme" }}
     {{ .Scratch.SetInMap "blockData" "type" "readme" }}
   {{ end }}
+
   {{ .Scratch.SetInMap "blockData" "api" $newSrc }}
 {{ end }}
 

--- a/layouts/partials/block-readme.html
+++ b/layouts/partials/block-readme.html
@@ -1,5 +1,4 @@
 {{ $blockData := .Page.Scratch.Get "blockData" }}
-
 {{ $response := getJSON $blockData.api }}
 
 {{ if $response }}

--- a/layouts/partials/objectives-lookup.html
+++ b/layouts/partials/objectives-lookup.html
@@ -2,5 +2,6 @@
 {{ $pageContext := .pageContext }}
 {{ $localBlock := $pageContext.GetPage $scope.blockData.api }}
 {{ with $localBlock.Params.Objectives }}
+  <h5>{{ $scope.blockData.name }}</h5>
   {{ partial "objectives-block.html" . }}
 {{ end }}

--- a/layouts/partials/objectives-parsed.html
+++ b/layouts/partials/objectives-parsed.html
@@ -1,23 +1,38 @@
-{{ $resp := .resp }}
-{{ $decodedContent := $resp.content | base64Decode }}
-{{ $regex := "```objectives\\s*([^`]*?)\\s*```" }}
-{{ $blocks := findRE $regex $decodedContent }}
-{{ $allObjectives := slice }}
-<!-- build a list of all objectives -->
-{{ range $blocks }}
-  {{ $blockContent := replaceRE "```objectives\\s*|\\s*```" "" . }}
-  {{ $objectives := split $blockContent "- [ ]" }}
+{{ $response := getJSON .blockData.api }}
+{{ $type := .blockData.type }}
+{{ $decodedContent := $response.content | base64Decode }}
+{{/* Find fenced objectives in text */}}
+{{ $regexFence := "```objectives\\s*([^`]*?)\\s*```" }}
+{{ $rawBlocks := findRE $regexFence $decodedContent }}
+
+{{ $blocks := slice }}
+{{ range $rawBlocks }}
+  {{ $blockContent := . | replaceRE "^```objectives\\s*|\\s*```$" "" }}
+  {{ $objectives := split $blockContent "\n" }}
   {{ range $objectives }}
-    {{ if ne . "" }}
-      {{ $allObjectives = $allObjectives | append . }}
+    {{ $objective := replace . "- [ ] " "" }}
+    {{ if ne (trim $objective " ") "" }}
+      {{ $blocks = $blocks | append $objective }}
     {{ end }}
   {{ end }}
 {{ end }}
-<!--output list-->
-{{ if gt (len $allObjectives ) 0 }}
-  {{ with $allObjectives }}
+
+{{/* Parse front matter if blockData type is pd */}}
+{{ if eq $type "pd" }}
+  {{ $contentParts := split $decodedContent "---" }}
+  {{ if gt (len $contentParts) 2 }}
+    {{ $frontMatter := index $contentParts 1 }}
+    {{ $parsedFrontMatter := $frontMatter | transform.Unmarshal }}
+    {{ if isset $parsedFrontMatter "objectives" }}
+      {{ $blocks = $blocks | append $parsedFrontMatter.objectives }}
+    {{ end }}
+  {{ end }}
+
+{{ end }}
+
+{{/* Output list */}}
+{{ if gt (len $blocks) 0 }}
+  {{ with $blocks }}
     {{ partial "objectives-block.html" . }}
   {{ end }}
-{{ else }}
-  <p>No objectives defined</p>
 {{ end }}


### PR DESCRIPTION
## What does this change?

Module: all
Week(s): all / success pages

## Checklist

- [ x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x ] I have run my code to check it works
- [x ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

I know I must be stopped - I really did want all this as modules instead but it just doesn't work, so here I am writing 40 line templates. I'm sorry :/ 

this code grabs anything marked up as objectives eg codefenced as objectives in any read me and also grabs anything marked up as objectives in pd front matter

the main acrobatics are in objectives-parsed

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
