### PR TITLE
Fix CM6 highlight lines throwing

### DIFF
--- a/assets/scripts/highlight-lines.ts
+++ b/assets/scripts/highlight-lines.ts
@@ -21,7 +21,7 @@ function highlightLines(state, lines: [number, number][]) {
   let decorations: Range<Decoration>[] = [];
 
   // Don't show any decorations if there are no highlighted line numbers
-  if (!lines && !lines.length) return Decoration.none;
+  if (!lines || !lines.length) return Decoration.none;
 
   for (const line of lines) {
     // Hugo gives us a start line and an end line. For CM6 we need to generate a


### PR DESCRIPTION
## What does this change?

Module: N/A
Week(s): N/A

## Description

<!-- Add a description of what your PR changes here -->

Fixes CM6 codeblocks without highlights that were throwing an error.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

@CodeYourFuture/global-syllabus 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
