### PR TITLE
Add `npm i` as part of "to run locally"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ brew install hugo
 ### To run locally
 
 ```bash
-hugo server
+npm i && hugo server
 ```
 
 ### To create a new module


### PR DESCRIPTION
If you don't `npm i` first, you get errors about missing npm modules.