### PR TITLE
pass the page object correctly to local blocks

### DIFF
--- a/layouts/partials/block-data.html
+++ b/layouts/partials/block-data.html
@@ -12,6 +12,7 @@
 */}}
 {{ $name := .name | default "warning: name is empty" }}
 {{ $src := .src | default "warning: src is empty" }}
+{{/* We need to know what page this block is on */}}
 {{ $p := .page }}
 
 {{/* Initialize the blockData map */}}

--- a/layouts/partials/block-data.html
+++ b/layouts/partials/block-data.html
@@ -12,6 +12,7 @@
 */}}
 {{ $name := .name | default "warning: name is empty" }}
 {{ $src := .src | default "warning: src is empty" }}
+{{ $p := .page }}
 
 {{/* Initialize the blockData map */}}
 {{ .Scratch.Set "blockData" (dict) }}
@@ -28,7 +29,7 @@
 
 {{ if eq $src "module" }}
   {{ .Scratch.SetInMap "blockData" "type" "local_module" }}
-  {{ .Scratch.SetInMap "blockData" "api" (printf "%s/blocks/%s" $.Page.Section $name) }}
+  {{ .Scratch.SetInMap "blockData" "api" (printf "%s/blocks/%s" $p.Page.Section $name) }}
 {{ end }}
 
 {{ if "github" | in $src }}


### PR DESCRIPTION
so we can access the .Section

https://gohugo.io/variables/page/#section-variables-and-methods

Local blocks had disappeared since I refactored the block data
For ex fundamentals/sprints/1/day-plan/#user-stories were blank

This was because the .Page object belongs to the scope, so when passing the scope in this way we need to do $variable.Page.Section - we can't do $variable.Section as $variable is not .Page in this context.

I would like to further refactor this but so many PRs are building up I am loath to do more there. Will leave until Search has been looked at.

