### PR TITLE
Feature: Wikilinks (sorta_

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,37 +1,68 @@
+{{ $src := .Destination }}
 {{ $alt := .PlainText | safeHTML }}
 {{ $caption := "" }}
+
 {{ with .Title }}
   {{ $caption = . | safeHTML }}
 {{ end }}
 
-{{ with .Page.Resources.GetMatch (printf "%s" (.Destination | safeURL)) }}
-  {{ $image := . }}
-  {{ $small := (cond (gt $image.Width 480) ($image.Resize "480x webp q75") $image) }}
-  {{ $medium := (cond (gt $image.Width 768) ($image.Resize "768x webp q75") $image) }}
-  {{ $big := (cond (gt $image.Width 1024) ($image.Resize "1024x webp q75") $image) }}
+{{/* Check if the source is an external link */}}
+{{ $isExternal := or (strings.HasPrefix $src "http://") (strings.HasPrefix $src "https://") }}
+
+{{/* Define an image variable and a flag to indicate if it's a resource */}}
+{{ $image := "" }}
+{{ $isResource := false }}
+{{ $srcset := "" }}
+
+{{/* If it's not an external link, look for the image in Page resources */}}
+{{ if not $isExternal }}
+  {{ with .Page.Resources.GetMatch (printf "%s" $src) }}
+    {{ $image = . }}
+    {{ $isResource = true }}
+  {{ end }}
+{{ end }}
+
+{{/* If the image is still not found, use the path directly (assuming the image is in the /pictures directory) */}}
+{{- if and (not $image) (not $isExternal) -}}
+  {{ $path := (path.Join "/pictures" $src) }}
+  {{ $image = (dict "RelPermalink" $path "Width" 0 "Height" 0) }}
+{{- end -}}
+
+{{/* Handle external images directly */}}
+{{- if $isExternal -}}
+  {{ $image = (dict "RelPermalink" $src "Width" 0 "Height" 0) }}
+{{- end -}}
+
+{{/* If the image is found, resize it based on the screen width and display it in the figure */}}
+{{ if $image }}
+  {{/* Extract the file extension from the image URL */}}
+  {{ $ext := path.Ext $src }}
+
+  {{/* Perform resizing operations only if $image is a real image resource and not a GIF */}}
+  {{ if and $isResource (ne $ext ".gif") }}
+    {{ $small := (cond (gt $image.Width 480) ($image.Resize "480x webp q75") $image) }}
+    {{ $medium := (cond (gt $image.Width 768) ($image.Resize "768x webp q75") $image) }}
+    {{ $big := (cond (gt $image.Width 1024) ($image.Resize "1024x webp q75") $image) }}
+    {{ $srcset := printf "%s 480w, %s 768w, %s 1024w" $small.RelPermalink $medium.RelPermalink $big.RelPermalink }}
+  {{ else }}
+    {{/* If $image isn't a real resource or is a GIF, don't try to generate srcset */}}
+    {{ $srcset := $image.RelPermalink }}
+  {{ end }}
 
 
   <figure>
-    <a href="{{ $image.RelPermalink }}">
-      <img
-        loading="lazy"
-        src="{{ $image.RelPermalink }}"
-        srcset="
-          {{ $small.RelPermalink }}  480w,
-          {{ $medium.RelPermalink }}  768w,
-          {{ $big.RelPermalink }} 1024w
-        "
-        sizes="(max-width: 480px) 480px, (max-width: 768px) 768px, 1024px"
-        width="{{ $image.Width }}"
-        height="{{ $image.Height }}"
-        alt="{{ if $alt }}
-          {{ $alt }}
-        {{ else if $caption }}
-          {{ $caption | markdownify | plainify }}
-        {{ else }}
-          &nbsp;
-        {{ end }}" />
-    </a>
+    <img
+      loading="lazy"
+      src="{{ $image.RelPermalink }}"
+      srcset="{{ $srcset }}"
+      sizes="(max-width: 480px) 480px, (max-width: 768px) 768px, 1024px"
+      width="{{ $image.Width }}"
+      height="{{ $image.Height }}"
+      alt="{{ if $alt }}
+        {{ $alt }}
+      {{ else }}
+        &nbsp;
+      {{ end }}" />
     {{ with $caption }}
       <figcaption>{{ . | markdownify }}</figcaption>
     {{ end }}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,25 @@
+{{/* This is scarfed directly from Bep https://portable-hugo-links.netlify.app/
+  It allegedly makes a version of wikilinks that still works on Github
+  * [Rel Link](../p2.md)
+  * [Section Link](/section/p2.md)
+  * [Section Link With Anchor](/section/d1.md#anchor)
+  to replace the Hugo shortcode rel-ref
+*/}}
+
+{{ $link := .Destination }}
+{{ $isRemote := strings.HasPrefix $link "http" }}
+{{- if not $isRemote -}}
+  {{ $url := urls.Parse .Destination }}
+  {{- if $url.Path -}}
+    {{ $fragment := "" }}
+    {{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
+    {{- with .Page.GetPage $url.Path }}
+      {{ $link = printf "%s%s" .RelPermalink $fragment }}
+    {{ end }}
+  {{ end -}}
+{{- end -}}
+<a
+  href="{{ $link | safeURL }}"
+  {{ with .Title }}title="{{ . }}"{{ end }}
+  >{{ .Text | safeHTML }}</a
+>


### PR DESCRIPTION
## What does this change?

Module: all
Week(s): all

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

I used this example to build this: https://github.com/bep/portable-hugo-links

Improving link handling to remove/reduce dependency on Hugo shortcodes (which won't work or show up on Github). It's not actually wikilinks [[]] but plain md links without using https://gohugo.io/content-management/shortcodes/#ref-and-relref

This necessitated also some rework of the image render hook so I improved that quite a lot as well. This feature depends on the local-block bugfix pr as it's all about links and destinations. #43 

Using this feature now you should be able to use relative links and assume hugo will figure stuff out. This means that writing, for example, in 

content/blocks/telephone

you can write [Prep](databases/prep)

and then if you show that content on, say, fundamentals/sprint/1/day-plan

Then the link will go to databases/prep

So it's always relative to the rendered context.  You can also still use rel refs with ../. Example usage below


[Prep](databases/prep) 
[Local Prep](../prep) 

![local bundle asset](icecream-robots.webp "This is a caption")
![external gif](https://images.ctfassets.net/gw5wr8vzz44g/29ExmDybOIAqEuGMMAcs0w/a1d28f10aa9bbc18279eb7466f47acd4/ustwo_Thinks_crop.gif)
![fallback to assets](worried_robots_pencil_books.webp)

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
