### PR TITLE
swap top link to toc 

### DIFF
--- a/assets/styles/04-components/page-header.scss
+++ b/assets/styles/04-components/page-header.scss
@@ -79,4 +79,8 @@
       display: none;
     }
   }
+
+  &__toc {
+    scroll-margin-top: calc(2 * var(--header-height));
+  }
 }

--- a/assets/styles/04-components/toc.scss
+++ b/assets/styles/04-components/toc.scss
@@ -9,6 +9,14 @@
   max-height: 25vh;
   overflow-y: auto;
 
+  // When scrolling into view, add a bit of spacing above to give room for
+  // sticky header.
+  // Calculate the height of the header, summing:
+  //   45px (rough logo height - magic number since height isn't defined)
+  //   --theme-spacing--1 * 2 (padding around logo)
+  //   --theme-spacing-2 (some extra breathing room)
+  scroll-margin-block-start: calc(calc(calc(var(--theme-spacing--1) * 2) + 45px) + var(--theme-spacing--2));
+
   ol {
     color: var(--theme-color--ink);
     padding-right: var(--theme-spacing--gutter);

--- a/assets/styles/layout/header.scss
+++ b/assets/styles/layout/header.scss
@@ -37,3 +37,9 @@
     gap: var(--theme-spacing--gutter);
   }
 }
+// post header height to other elements
+:root {
+  --header-height: calc(
+    var(--theme-spacing--touchtarget) + calc(var(--theme-spacing--1) * 2)
+  );
+}

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -45,7 +45,7 @@
         <a
           id="top"
           class="c-toc__top e-button e-button--icon e-heading__3"
-          href="#skip-link"
+          href="#toc"
           >📎</a
         >
         {{ if and

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -41,26 +41,28 @@
     {{ end }}
     <!--TOC-->
     {{ if $hasTOC }}
-      <section class="c-page-header__toc c-toc" id="toc">
-        <a
-          id="top"
-          class="c-toc__top e-button e-button--icon e-heading__3"
-          href="#toc"
-          >📎</a
-        >
-        {{ if and
-          (gt .Page.WordCount 400) (.Page.TableOfContents)
-        }}
-          {{ .Page.TableOfContents }}
-        {{ end }}
-        {{ if gt .Params.blocks 1 }}
-          <ol>
-            {{ range .Params.blocks }}
-              <li><a href="#{{ .name | urlize }}">{{ .name }}</a></li>
-            {{ end }}
-          </ol>
-        {{ end }}
-      </section>
+      <div class="c-page-header__toc" id="toc">
+        <section class="c-toc">
+          <a
+            id="top"
+            class="c-toc__top e-button e-button--icon e-heading__3"
+            href="#toc"
+            >📎</a
+          >
+          {{ if and
+            (gt .Page.WordCount 400) (.Page.TableOfContents)
+          }}
+            {{ .Page.TableOfContents }}
+          {{ end }}
+          {{ if gt .Params.blocks 1 }}
+            <ol>
+              {{ range .Params.blocks }}
+                <li><a href="#{{ .name | urlize }}">{{ .name }}</a></li>
+              {{ end }}
+            </ol>
+          {{ end }}
+        </section>
+      </div>
     {{ end }}
 
   </div>


### PR DESCRIPTION
this is a fairly standard accessibility helper I don't think it's a good idea to remove, but def should link to the correct fragment!

fixes #48