### PR TITLE
Add npm run dev script to run Hugo and PageFind

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The CYF curriculum website",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "hugo && npx pagefind --source 'public' --serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What does this change?

Module: N/A
Week(s): N/A

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

After #41, when running `hugo server` for local development, you get the following error:

```
localhost/:91     GET http://localhost:1313/_pagefind/pagefind-ui.css net::ERR_ABORTED 404 (Not Found)
localhost/:132     GET http://localhost:1313/_pagefind/pagefind-ui.js net::ERR_ABORTED 404 (Not Found)
(index):136 Uncaught ReferenceError: PagefindUI is not defined
    at (index):136:5
```

Which I think is slightly annoying, so I've add an NPM script which automates the commands as described in the README.

I did leave off the `rm -rf public` bit as I thought this might affect build caching? It seems to work fine? I'm happy to put back if necessary.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

@SallyMcGrath 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
