### PR TITLE
Explicitly reference the What Is GitHub tab

### DIFF
--- a/content/fundamentals/prep/index.md
+++ b/content/fundamentals/prep/index.md
@@ -45,6 +45,8 @@ Your Github account name should look something like this: https://github.com/Sal
 {{</note>}}
 
 When prospective employers are looking at your Github portfolio, **you need them to know who you are**: not your online identity, but the name you put on your job application. Don’t use cute handles on your Github, even though some mentors do. They are not applying for entry level developer roles.
+
+To find out more about what GitHub is used for, watch the video in the "What is GitHub" tab above.
 {{% /tab %}}
 
 {{<tab name="What is GitHub">}}


### PR DESCRIPTION
## What does this change?

Module: Fundamentals
Week(s): Prep

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

Adds an explicit reference to the "What is GitHub" tab on the Fundamentals prep page, to make the tab more obvious and prevent it from being missed.

Discussed  in https://github.com/CodeYourFuture/curriculum/issues/54#issuecomment-1586124881. I'll defer to Sally on how to visually punch up the tab though.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

@SallyMcGrath 
@illicitonion 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
