### PR TITLE
Remove blocks iframe

### DIFF
--- a/content/fundamentals/blocks/cyf-blocks-requirements/index.md
+++ b/content/fundamentals/blocks/cyf-blocks-requirements/index.md
@@ -22,5 +22,3 @@ Let's all look through the interface together now, and do one exercise as a grou
 - Everybody open the interface on their own computer as well
 - Complete all steps of the first exercise
   {{</note>}}
-
-  {{<iframe src="https://blocks.codeyourfuture.io/">}}


### PR DESCRIPTION
It makes the page pretty busy and cluttered Instead, folks can just follow the link already in the tile.

I tried hiding it behind a `<details>` tag and I think it made things less clear rather than more :)

Fixes #66 