### PR TITLE
Rework GitHub API interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ brew install hugo
 
 ### To run locally
 
+You'll need to get a fine-grained GitHub API token which allows read-only access to all public CYF repos from [this page](https://github.com/settings/tokens?type=beta).
+
 ```bash
-npm i && hugo server
+npm i
+CYF_CURRICULUM_GITHUB_BEARER_TOKEN=your_github_api_token hugo server
 ```
 
 ### To create a new module

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,6 @@ title = "CodeYourFuture Curriculum"
 languageLang = "en"
 sectionPagesMenu = "main"
 enableEmoji = true
-ignoreErrors = ["error-remote-getjson"]
 
 [menus]
     [[menus.secondary]]
@@ -43,3 +42,12 @@ guessSyntax = true
 unsafe = true
 hardWraps = true
 disableKinds = ["taxonomy", "term"]
+
+[caches.getjson]
+# Disable caching of fetches - we want every build to get up to date content for issues, so that if people make clarifications or fixes to issues, we pick them up.
+maxAge = 0
+
+[security.funcs]
+# Allow accessing a GitHub bearer token to avoid rate limits when doing HTTP fetches to the GitHub API.
+# This can be generated at https://github.com/settings/tokens?type=beta and needs read-only access to all public CYF GitHub repos.
+getenv = ["^CYF_CURRICULUM_GITHUB_BEARER_TOKEN$"]

--- a/layouts/partials/block-issue.html
+++ b/layouts/partials/block-issue.html
@@ -1,7 +1,11 @@
 {{/* This block expects the github issue api */}}
 {{ $blockData := .Page.Scratch.Get "blockData" }}
 
-{{ $response := getJSON $blockData.api }}
+{{ $headers := (dict) }}
+{{ if ne (os.Getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN") "" }}
+{{ $headers = merge $headers (dict "Authorization" (printf "Bearer %s" (getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN"))) }}
+{{ end }}
+{{ $response := getJSON $blockData.api $headers }}
 
 {{ if $response }}
   <section class="c-block">

--- a/layouts/partials/block-pd.html
+++ b/layouts/partials/block-pd.html
@@ -1,6 +1,10 @@
 {{ $blockData := .Page.Scratch.Get "blockData" }}
 
-{{ $response := getJSON $blockData.api }}
+{{ $headers := (dict) }}
+{{ if ne (os.Getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN") "" }}
+{{ $headers = merge $headers (dict "Authorization" (printf "Bearer %s" (getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN"))) }}
+{{ end }}
+{{ $response := getJSON $blockData.api $headers }}
 
 {{ if $response }}
   {{ $decodedContent := $response.content | base64Decode }}

--- a/layouts/partials/block-readme.html
+++ b/layouts/partials/block-readme.html
@@ -1,5 +1,9 @@
 {{ $blockData := .Page.Scratch.Get "blockData" }}
-{{ $response := getJSON $blockData.api }}
+{{ $headers := (dict) }}
+{{ if ne (os.Getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN") "" }}
+{{ $headers = merge $headers (dict "Authorization" (printf "Bearer %s" (getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN"))) }}
+{{ end }}
+{{ $response := getJSON $blockData.api $headers }}
 
 {{ if $response }}
   <section class="c-block">

--- a/layouts/partials/byline.html
+++ b/layouts/partials/byline.html
@@ -8,7 +8,11 @@
   {{ $src = replace $src
     "/tree/main" "/commits?path"
   }}
-  {{ $commitList := getJSON $src }}
+  {{ $headers := (dict) }}
+  {{ if ne (os.Getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN") "" }}
+  {{ $headers = merge $headers (dict "Authorization" (printf "Bearer %s" (getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN"))) }}
+  {{ end }}
+  {{ $commitList := getJSON $src $headers }}
   {{ $tempArrayToDeDupe := slice }}
   {{ range $commitList }}
     {{ with .committer }}

--- a/layouts/partials/issues.html
+++ b/layouts/partials/issues.html
@@ -2,9 +2,13 @@
 {{ $issues := print .Site.Params.orgapi $repo "/issues" }}
 {{ $filter := .Params.backlog_filter }}
 <!-- api call -->
-{{ $commitObject := getJSON $issues }}
+{{ $headers := (dict) }}
+{{ if ne (os.Getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN") "" }}
+{{ $headers = merge $headers (dict "Authorization" (printf "Bearer %s" (getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN"))) }}
+{{ end }}
+{{ $commitObject := getJSON $issues $headers }}
 <!-- if no object show error -->
-{{ if $commitObject }}
+{{ if ne $commitObject nil }}
   <!-- range over issues list and pull out useful data -->
   {{ range $commitObject }}
     <!-- only show open issues -->
@@ -23,6 +27,9 @@
       {{ end }}
       <!-- now show the issue -->
       {{ if $showIssue }}
+        {{ if strings.Contains .body "_No response_" }}
+          {{ warnf "Issue %s contains _No response_ - please edit the issue to remove it." .html_url }}
+        {{ end }}
         <details class="c-issue">
           <summary class="c-issue__title e-heading__3">
             {{ .title }} <a class="c-issue__link" href="{{ .html_url }}">🔗</a>
@@ -44,5 +51,5 @@
     {{ end }}
   {{ end }}
 {{ else }}
-  <h3>Error, fetch failed</h3>
+  {{ errorf "Error, fetch of %s failed: %v" $issues $commitObject }}
 {{ end }}

--- a/layouts/partials/lastmod.html
+++ b/layouts/partials/lastmod.html
@@ -8,7 +8,11 @@
 <!-- api call -->
 {{ $api:="https://api.github.com/repos/CodeYourFuture/immersive-go-course/commits" }}
 {{ $url := print $api "?path=" $p }}
-{{ $commitObject := getJSON $url }}
+{{ $headers := (dict) }}
+{{ if ne (os.Getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN") "" }}
+{{ $headers = merge $headers (dict "Authorization" (printf "Bearer %s" (getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN"))) }}
+{{ end }}
+{{ $commitObject := getJSON $url $headers }}
 <!-- range over commit -->
 {{ range first 1 $commitObject }}
   <h3 class="c-lastmod e-heading__6">

--- a/layouts/partials/objectives-parsed.html
+++ b/layouts/partials/objectives-parsed.html
@@ -1,4 +1,8 @@
-{{ $response := getJSON .blockData.api }}
+{{ $headers := (dict) }}
+{{ if ne (os.Getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN") "" }}
+{{ $headers = merge $headers (dict "Authorization" (printf "Bearer %s" (getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN"))) }}
+{{ end }}
+{{ $response := getJSON .blockData.api $headers }}
 {{ $type := .blockData.type }}
 {{ $decodedContent := $response.content | base64Decode }}
 {{/* Find fenced objectives in text */}}


### PR DESCRIPTION
* Disable caching - we want every build to get up to date content for issues, so that if people make clarifications or fixes to issues, we pick them up.
* Allow specifying a GitHub access token when using the GitHub API - otherwise we will hit rate limits (due to a lack of inter-build caching). Unfortunately it's not trivial to make _all_ API requests use auth from one simple function - I'll work out how to simplify this in the future (probably by upstreaming support to Hugo to specify an environment variable to use as a bearer token). For now, though, we'll just copy-and-paste the auth header code.
* Stop ignoring errors on fetch - fetch errors lead to missing content and incorrect builds. Now that we're nearing production, we need to fix these if they come up, rather than ignoring them.
* Warn if fetched issues contain `_No response` placeholders - those issues should be edited in GitHub issues. When we fix them all, I'll upgrade these to errors, to avoid slipping.

Note: I also created the empty repo https://github.com/CodeYourFuture/Module-Final-Projects so that the fetch to /issues of it wouldn't fail, because that was causing build errors with this new not-ignoring-errors way. Hurrah for discovering issues 🎉 

Relates to #59