### PR TITLE
Feature: pass objectives to objective block

### DIFF
--- a/layouts/_default/_markup/render-codeblock-objectives.html
+++ b/layouts/_default/_markup/render-codeblock-objectives.html
@@ -1,5 +1,11 @@
-<!-- todo: parse these objectives and render with valid html-->
-<section class="c-objectives">
-  <h3 class="c-objectives__title e-heading__2">Learning Objectives</h3>
-  {{- .Inner | safeHTML | markdownify }}
-</section>
+{{ $items := slice }}
+{{ $objectives := split .Inner "\n" }}
+{{ range $objectives }}
+  {{ $objective := replace . "- [ ] " "" }}
+  {{ if ne (trim $objective " ") "" }}
+    {{ $items = $items | append $objective }}
+  {{ end }}
+{{ end }}
+{{ with $items }}
+  {{ partial "objectives-block" . }}
+{{ end }}


### PR DESCRIPTION
## What does this change?

Module: all
Week(s): all

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

addresses #45

I don't think we should try to hijack task lists here, but fix the markup in GFM - I opened an issue about it some time ago anyway

But we can mark up task lists as objectives pretty easily so let's do that? 

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
