### PR TITLE
move the comment to the end

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,11 +1,3 @@
-{{/* This is scarfed directly from Bep https://portable-hugo-links.netlify.app/
-  It allegedly makes a version of wikilinks that still works on GitHub
-  * [Rel Link](../p2.md)
-  * [Section Link](/section/p2.md)
-  * [Section Link With Anchor](/section/d1.md#anchor)
-  to replace the Hugo shortcode rel-ref
-*/}}
-
 {{ $link := .Destination }}
 {{ $isRemote := strings.HasPrefix $link "http" }}
 {{- if not $isRemote -}}
@@ -21,5 +13,13 @@
 <a
   href="{{ $link | safeURL }}"
   {{ with .Title }}title="{{ . }}"{{ end }}
-  >{{ .Text | safeHTML }}</a
->
+  >{{ .Text | safeHTML }}
+</a>
+{{- /* This is scarfed directly from Bep https://portable-hugo-links.netlify.app/
+  It allegedly makes a version of wikilinks that still works on Github
+  * [Rel Link](../p2.md)
+  * [Section Link](/section/p2.md)
+  * [Section Link With Anchor](/section/d1.md#anchor)
+  to replace the Hugo shortcode rel-ref
+  */
+-}}


### PR DESCRIPTION
## What does this change?

Module: all
Week(s): all

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

I moved the comment to the end and added whitespace eaters (-) as the blockquote formatting suggested to me that an angle bracket was breaking out into the markdownify rendering

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
