### PR TITLE
Revision: remove spurious minutes

### DIFF
--- a/layouts/partials/block-data.html
+++ b/layouts/partials/block-data.html
@@ -24,6 +24,12 @@
 {{/* Set the source of truth */}}
 {{ .Scratch.SetInMap "blockData" "sot" $src }}
 
+{{/* Prep and Day Plan want times */}}
+{{ .Scratch.SetInMap "blockData" "showTime" false }}
+{{ if or (eq $p.Page.Layout "day-plan") (eq $p.Page.Layout "prep") }}
+  {{ .Scratch.SetInMap "blockData" "showTime" true }}
+{{ end }}
+
 {{/* Default block */}}
 {{ .Scratch.SetInMap "blockData" "type" "local_course" }}
 {{ .Scratch.SetInMap "blockData" "api" (printf "blocks/%s" $name) }}

--- a/layouts/partials/block-issue.html
+++ b/layouts/partials/block-issue.html
@@ -11,6 +11,7 @@
         id="{{ $blockData.name |urlize }}">
         <a href="{{ $response.html_url }}">{{ $blockData.name }} 🔗</a>
       </h2>
+      {{/* TODO - lookup time from label dictionary */}}
       {{ range $response.labels }}
         {{ if in .name "Size" }}
           <time class="c-block__time" datetime="P60M">{{ .name }}</time>

--- a/layouts/partials/block-local.html
+++ b/layouts/partials/block-local.html
@@ -8,11 +8,7 @@
     <h2 class="c-block__title e-heading__2" id="{{ $blockData.name |urlize }}">
       {{ $block.Title }}
     </h2>
-    <time
-      class="c-block__time"
-      datetime="P{{ $block.Params.time | default 60 }}M"
-      >{{ $block.Params.time }} minutes</time
-    >
+    {{ partial "time.html" (dict "blockData" $blockData "time" $block.Params.time) }}
   </header>
   {{ with $block.Params.Objectives }}
     <details>

--- a/layouts/partials/block-pd.html
+++ b/layouts/partials/block-pd.html
@@ -23,9 +23,7 @@
       <h2 class="c-block__title e-heading__2" id="{{ $blockData |urlize }}">
         <a href="{{ $response.html_url }}">{{ $parsedFrontMatter.title }} 🔗</a>
       </h2>
-      <time class="c-block__time" datetime="P{{ $parsedFrontMatter.time }}M"
-        >{{ $parsedFrontMatter.time }} minutes</time
-      >
+      {{ partial "time.html" (dict "blockData" $blockData "time" $parsedFrontMatter.time) }}
       <h3 class="c-block__byline e-heading__5">
         {{ partial "byline.html" . }}
       </h3>

--- a/layouts/partials/block-readme.html
+++ b/layouts/partials/block-readme.html
@@ -12,7 +12,7 @@
       <h3 class="c-block__byline e-heading__5">
         {{ partial "byline.html" . }}
       </h3>
-      <time class="c-block__time" datetime="P60M">60 minutes</time>
+      {{ partial "time.html" (dict "blockData" $blockData "time" "60") }}
     </header>
     <div class="c-block__content c-copy">
       {{ $response.content | base64Decode | markdownify }}

--- a/layouts/partials/time.html
+++ b/layouts/partials/time.html
@@ -1,0 +1,7 @@
+{{ $blockData := .blockData }}
+{{ $time := .time }}
+{{ if $blockData.showTime }}
+  <time class="c-block__time" datetime="P{{ $time | default 60 }}M"
+    >{{ . | default 60 }} minutes</time
+  >
+{{ end }}


### PR DESCRIPTION
we only want to show minutes on prep and dayplan layouts I think?

make a time partial and call it in some circumstances, eg on scheduling views

addresses #58

does not resolve all the block header things i have issues with