### PR TITLE
Use 🔝 not 📎 for back-to-top link

### DIFF
--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -46,7 +46,7 @@
           id="top"
           class="c-toc__top e-button e-button--icon e-heading__3"
           href="#skip-link"
-          >📎</a
+          >🔝</a
         >
         {{ if and
           (gt .Page.WordCount 400) (.Page.TableOfContents)


### PR DESCRIPTION
Fixes #48