### PR TITLE
temporary fix for GFM task lists

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -41,3 +41,16 @@ const editableCodeBlocks = document.querySelectorAll("code[data-lang]");
 editableCodeBlocks.forEach((block) => {
   block.setAttribute("contenteditable", true);
 });
+
+// Fix for GFM task lists
+// https://github.com/github/cmark-gfm/issues/299
+window.addEventListener("DOMContentLoaded", (event) => {
+  const taskListItems = document.querySelectorAll(
+    "ul > li > input[type=checkbox]"
+  );
+  taskListItems.forEach((item) => {
+    item.removeAttribute("disabled");
+    const parent = item.parentNode;
+    parent.innerHTML = `<label>${parent.innerHTML}</label>`;
+  });
+});


### PR DESCRIPTION
I was loath to do this and I have built in a way to mark up task lists as objectives (to feed them to other views) but I guess actually we also want task lists that are not objectives so here we are - I have just fixed it post hoc with a link in the code to the issue -- when GFM fix this we can remove our js.

https://github.com/github/cmark-gfm/issues/299