### PR TITLE
revise success page

### DIFF
--- a/layouts/_default/success.html
+++ b/layouts/_default/success.html
@@ -17,7 +17,7 @@
         <hr />
       {{ end }}
       <section class="c-objectives">
-        <h2 class="e-heading__4 c-objectives__title">
+        <h2 class="e-heading__4 c-objectives__title is-invisible">
           Compiled Learning Objectives
         </h2>
         {{/* get the path to the pages that are the siblings of this page */}}
@@ -49,11 +49,6 @@
           {{ $blockData := $.Page.Scratch.Get "blockData" }}
           {{/* Depending on the type of block, call the appropriate partial */}}
           {{ if or (eq $blockData.type "readme") (eq $blockData.type "pd") }}
-            <h5>
-              <a href="{{ $blockData.sot }}" class="c-objectives__link">
-                {{ $blockData.name }} 🔗
-              </a>
-            </h5>
             {{ partial "objectives/parsed" (dict "blockData" $blockData "pageContext" $pageContext) }}
           {{ end }}
           {{ if or (eq $blockData.type "local_module") (eq $blockData.type "local_course") }}

--- a/layouts/partials/objectives/lookup.html
+++ b/layouts/partials/objectives/lookup.html
@@ -1,7 +1,10 @@
 {{ $scope := . }}
 {{ $pageContext := .pageContext }}
 {{ $localBlock := $pageContext.GetPage $scope.blockData.api }}
-{{ with $localBlock.Params.Objectives }}
+{{ if (eq $scope.blockData.type "local_module") }}
+  {{ $localBlock = $pageContext.GetPage (replace $scope.blockData.api "%!s(<nil>)" .pageContext.Section) }}
+{{ end }}
+{{ with $localBlock.Page.Params.Objectives }}
   <h5>{{ $scope.blockData.name }}</h5>
   {{ partial "objectives/block.html" . }}
 {{ end }}

--- a/layouts/partials/objectives/parsed.html
+++ b/layouts/partials/objectives/parsed.html
@@ -1,5 +1,7 @@
 {{ $response := getJSON .blockData.api }}
 {{ $type := .blockData.type }}
+{{ $sot := .blockData.sot }}
+{{ $name := .blockData.name }}
 {{ $decodedContent := $response.content | base64Decode }}
 {{/* Find fenced objectives in text */}}
 {{ $regexFence := "```objectives\\s*([^`]*?)\\s*```" }}
@@ -32,6 +34,9 @@
 
 {{/* Output list */}}
 {{ if gt (len $blocks) 0 }}
+  <h5>
+    <a href="{{ $sot }}" class="c-objectives__link"> {{ $name }} 🔗 </a>
+  </h5>
   {{ with $blocks }}
     {{ partial "objectives/block.html" . }}
   {{ end }}


### PR DESCRIPTION
1. make heading invisible as per feedback
2. get local module objectives:  the section was empty
3. only show headings if objectives exist: PD was printing empty blocks

fixes #73 

I feel like we could do a lot more with this page but let's just put it out there and see what users do first