### PR TITLE
Error instead of warning on `_No response_`

### DIFF
--- a/layouts/partials/issues.html
+++ b/layouts/partials/issues.html
@@ -28,7 +28,7 @@
       <!-- now show the issue -->
       {{ if $showIssue }}
         {{ if strings.Contains .body "_No response_" }}
-          {{ warnf "Issue %s contains _No response_ - please edit the issue to remove it." .html_url }}
+          {{ errorf "Issue %s contains _No response_ - please edit the issue to remove it." .html_url }}
         {{ end }}
         <details class="c-issue">
           <summary class="c-issue__title e-heading__3">


### PR DESCRIPTION
I have edited all the issues.

We will now rely on notifications of build/deploy failures to detect these problems in the future.

We should probably work out who gets those notifications.

Fixes #59