### PR TITLE
markdownify is sometimes weird

### DIFF
--- a/assets/styles/04-components/copy.scss
+++ b/assets/styles/04-components/copy.scss
@@ -3,7 +3,8 @@
 .c-copy {
   & p,
   & ol,
-  & ul {
+  & ul,
+  &__node {
     max-width: var(--theme-spacing--linelength);
   }
   margin-bottom: var(--theme-spacing--gutter);

--- a/layouts/partials/block/pd.html
+++ b/layouts/partials/block/pd.html
@@ -39,13 +39,13 @@
     {{ with $parsedFrontMatter.prep }}
       <section class="c-copy">
         <h3>Preparation</h3>
-        {{ . | markdownify }}
+        <div class="c-copy__node">{{ . | markdownify }}</div>
       </section>
     {{ end }}
     {{ with $parsedFrontMatter.introduction }}
       <section class="c-copy">
         <h3>Introduction</h3>
-        {{ . | markdownify }}
+        <div class="c-copy__node">{{ . | markdownify }}</div>
       </section>
     {{ end }}
     {{ with $parsedFrontMatter.exercises }}


### PR DESCRIPTION
https://github.com/gohugoio/hugo/issues/7372

If the text is just one line, markdownify doesn't give us paragraphs, or a way to tell if this is the case. In the PD blocks we quite often get this.

I am constraining phrasing blocks to a readable line length, so this choice has some text spooling out across the page

Therefore I have begrudgingly wrapped these risk areas in a div and constrained that.

But I don't like it