### PR TITLE
Fix previewing instructions in Fundamentals 2 Ship It

### DIFF
--- a/content/fundamentals/blocks/ship-it-iteration/index.md
+++ b/content/fundamentals/blocks/ship-it-iteration/index.md
@@ -29,14 +29,16 @@ First you'll integrate the code you made in CYF Blocks into your website locally
 
 1. Open up VSCode (which you should already have installed).
 1. In VSCode, open up the folder where your website is saved (**File > Open Folder** and choose the unzipped folder).
-1. Now your IDE shows your code just like Codepen did. Take a look. You can also view the rendered view right in your browser. Take a look!
+1. Now your IDE shows your code just like Codepen did. Take a look.
+1. By default, VSCode doesn't show you how the code renders (i.e. what the page looks like), only the HTML iteslf. But VSCode has extensions which can help with this! [Install the Live Preview extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server). After it's installed, right-click on your code and click the "Show Preview" menu item. Now you can also view the rendered view right in your browser. Take a look! In the future you will find more VSCode extensions which are useful too - feel free to experiment with them!
+1. Try changing your HTML in some way. Make sure you see the change reflected in the preview.
 1. If one doesn't already exist, create a new file called `script.js` (**File > New File**) in the same directory as your `index.html`.
 1. From CYF Blocks, click the "Generated Code" tab to see the JavaScript you created by putting together your blocks. Copy it all, and paste in in your new `script.js` file, and save the file.
 1. In your `index.html` page, add the following HTML, just before your the end of your body tag (before the `</body>`):
    ```html
    <script src="script.js" type="text/javascript"></script>
    ```
-1. If the code your wrote needs elements from your CYF Blocks page, in CYF Blocks switch back to the "Static HTML" tab and copy that into your `index.html` wherever it makes sense. (You may not need to do this if you were already using elements and IDs that were already in your page).
+1. If the code you wrote needs elements from your CYF Blocks page, in CYF Blocks switch back to the "Static HTML" tab and copy that into your `index.html` wherever it makes sense. (You may not need to do this if you were already using elements and IDs that were already in your page).
 1. Test it out! Use your website locally and make sure it works as you expect. Fix anything that doesn't work.
 
 #### Step Two : GitHub


### PR DESCRIPTION
## What does this change?

Module: Fundamentals
Week(s): 1

## Description

VSCode doesn't show previews by default (as was expected from https://syllabus.codeyourfuture.io/fundamentals/week-2/session#step-by-step
- though maybe we used to have trainees install extensions earlier or something? I couldn't find where, if so...)

So instead have the trainees explicitly install an extension.

Follow up from #116 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
