### PR TITLE
TEMPORARY FIX for missing scripts

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,24 +1,15 @@
 {{/* global */}}
 {{ $scripts := resources.Get "scripts/app.js" | resources.Minify }}
-<script src="{{ $scripts.Permalink }}" defer></script>
-
-{{/* components
-  set the page store to true in the partial and then load your resources here
+{{/* temporarily load scripts until we track down this page store problem
+  https://discourse.gohugo.io/t/page-store-is-sometimes-empty-for-unclear-reasons/44950
 */}}
-{{ if .Page.Store.Get "hasMermaid" }}
-  <script
-    type="module"
-    src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs"></script>
-{{ end }}
-{{ if .Page.Store.Get "hasYoutube" }}
-  {{ $player := resources.Get "scripts/youtube-player.js" | resources.Minify }}
-  <script src="{{ $player.Permalink }}" defer></script>
-{{ end }}
-{{ if .Page.Store.Get "hasCodeMirror" }}
-  {{ $codemirror := resources.Get "scripts/cm6.ts" | js.Build | resources.Minify }}
-  <script src="{{ $codemirror.Permalink }}" defer></script>
-{{ end }}
-{{ if .Page.Store.Get "hasTabs" }}
-  {{ $tabs := resources.Get "scripts/tab-panels.js" | resources.Minify }}
-  <script src="{{ $tabs.Permalink }}" type="module" defer></script>
-{{ end }}
+<script src="{{ $scripts.Permalink }}" defer></script>
+{{ $player := resources.Get "scripts/youtube-player.js" | resources.Minify }}
+<script src="{{ $player.Permalink }}" defer></script>
+{{ $codemirror := resources.Get "scripts/cm6.ts" | js.Build | resources.Minify }}
+<script src="{{ $codemirror.Permalink }}" defer></script>
+{{ $tabs := resources.Get "scripts/tab-panels.js" | resources.Minify }}
+<script src="{{ $tabs.Permalink }}" type="module" defer></script>
+<script
+  type="module"
+  src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs"></script>


### PR DESCRIPTION
temporarily load scripts until we track down this page store problem
  https://discourse.gohugo.io/t/page-store-is-sometimes-empty-for-unclear-reasons/44950

I will revert this ASAP because we never want to load all scripts on every page, except obviously in this case we must get something working for tomorrow

Addresses #143 and #145 