### PR TITLE
Feature : nestable Youtube shortcode, in new tabs

### DIFF
--- a/layouts/partials/block/data.html
+++ b/layouts/partials/block/data.html
@@ -10,6 +10,8 @@
   3. block name
   4. source of truth (sot)
   5. headers and auth for the api call
+  6. showTime, a boolean to show the time in the block
+  7. isShortcode, a boolean to indicate if the block is being called from a shortcode
 */}}
 {{ $name := .name | default "warning: name is empty" }}
 {{ $src := .src | default "warning: src is empty" }}
@@ -30,6 +32,9 @@
 {{ if or (eq $p.Page.Layout "day-plan") (eq $p.Page.Layout "prep") }}
   {{ .Scratch.SetInMap "blockData" "showTime" true }}
 {{ end }}
+
+{{/* It's only the Youtube partial that cares about being a shortcode */}}
+{{ .Scratch.SetInMap "blockData" "isShortcode" false }}
 
 {{/* Default block */}}
 {{ .Scratch.SetInMap "blockData" "type" "local_course" }}

--- a/layouts/partials/block/youtube.html
+++ b/layouts/partials/block/youtube.html
@@ -1,7 +1,6 @@
 {{ $blockData := .Page.Scratch.Get "blockData" }}
-{{ $isShortcode := .Page.Scratch.Get "isShortcode" }}
 <section class="c-block c-block--youtube">
-  {{ if not $isShortcode }}
+  {{ if not $blockData.isShortcode }}
     <h2
       class="c-block__title e-heading__2 is-invisible"
       id="{{ $blockData.name |urlize }}">

--- a/layouts/partials/block/youtube.html
+++ b/layouts/partials/block/youtube.html
@@ -1,7 +1,7 @@
 {{ $blockData := .Page.Scratch.Get "blockData" }}
-{{- .Page.Store.Set "hasYoutube" true -}}
+{{ $isShortcode := .Page.Scratch.Get "isShortcode" }}
 <section class="c-block c-block--youtube">
-  {{ if $blockData }}
+  {{ if not $isShortcode }}
     <h2
       class="c-block__title e-heading__2 is-invisible"
       id="{{ $blockData.name |urlize }}">

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,19 +1,11 @@
 {{ if .Parent }}
   {{ $name := trim (.Get "name") " " }}
-  {{ $include := trim (.Get "include") " " }}
-  {{ $codelang := .Get "codelang" }}
   {{ if not (.Parent.Scratch.Get "tabs") }}
     {{ .Parent.Scratch.Set "tabs" slice }}
   {{ end }}
   {{ with .Inner }}
-    {{ if $codelang }}
-      {{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" (highlight . $codelang "") ) }}
-    {{ else }}
-      {{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" . ) }}
-    {{ end }}
+    {{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" . ) }}
   {{ else }}
-    {{ $.Parent.Scratch.Add "tabs" (dict "name" $name "include" $include "codelang" $codelang) }}
+    {{- errorf "[%s] %q: tab shortcode missing its parent" site.Language.Lang .Page.Path -}}
   {{ end }}
-{{ else }}
-  {{- errorf "[%s] %q: tab shortcode missing its parent" site.Language.Lang .Page.Path -}}
 {{ end }}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -25,26 +25,6 @@
       {{ end }}
         {{- with .content -}}
           {{- . -}}
-        {{- else -}}
-          {{- if eq $.Page.BundleType "leaf" -}}
-            {{- /* find the file somewhere inside the bundle. Note the use of double asterisk */ -}}
-            {{- with $.Page.Resources.GetMatch (printf "**%s*" .include) -}}
-              {{- if ne .ResourceType "page" -}}
-                {{- /* Assume it is a file that needs code highlighting. */ -}}
-                {{- highlight .Content -}}
-              {{- else -}}
-                {{- .Content | markdownify -}}
-              {{- end -}}
-            {{- end -}}
-          {{- else -}}
-            {{- $path := path.Join $.Page.File.Dir .include -}}
-            {{- $page := site.GetPage "page" $path -}}
-            {{- with $page -}}
-              {{- .Content -}}
-            {{- else -}}
-              {{- errorf "[%s] tabs include not found for path %q" site.Language.Lang $path -}}
-            {{- end -}}
-          {{- end -}}
         {{- end -}}
       </div>
     {{- end -}}

--- a/layouts/shortcodes/youtube.html
+++ b/layouts/shortcodes/youtube.html
@@ -1,4 +1,5 @@
 {{ $src := .Inner }}
 {{ partial "block/data.html" (dict "Scratch" .Page.Scratch "src" $src  "name" "" "page" .) }}
 {{ $blockData := .Page.Scratch.Get "blockData" }}
+{{ $isShortcode := .Page.Scratch.Set "isShortcode" true }}
 {{ partial "block/youtube.html" . }}

--- a/layouts/shortcodes/youtube.html
+++ b/layouts/shortcodes/youtube.html
@@ -1,5 +1,4 @@
 {{ $src := .Inner }}
 {{ partial "block/data.html" (dict "Scratch" .Page.Scratch "src" $src  "name" "" "page" .) }}
 {{ $blockData := .Page.Scratch.Get "blockData" }}
-{{ $isShortcode := .Page.Scratch.Set "isShortcode" true }}
 {{ partial "block/youtube.html" . }}


### PR DESCRIPTION
## What does this change?

This is a bugfix but also a feature change tbh as it takes out a bunch of (unused) functionality 

I know we've all pointed it out, I can't find the issue for it!

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
-[x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

I have made these changes:

In the youtube shortcode partial, 

which is a pass-through that calls the youtube block, I have also passed along the context that this is a shortcode by adding it to the blockData. I didn't add it to the page scratch as I thought it might get messy with multiple versions of this block on the page, some shortcode some not.

You can test this on fundamentals/prep/ which has a video in a tab up top and then an inline video down the page. The inline video has a (visually hidden) heading and the tab video does not.

I then stripped out all the page bundle logic from the tabs. We aren't using it, we don't really understand it, so let's take it out until we want it.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
