### PR TITLE
Feature: comments on github become hugo shortcodes

### DIFF
--- a/layouts/partials/block/data.html
+++ b/layouts/partials/block/data.html
@@ -56,6 +56,9 @@
   {{ end }}
 
   {{ .Scratch.SetInMap "blockData" "api" $newSrc }}
+
+  {{/* set a default time of 120 minutes for workshops */}}
+  {{ .Scratch.SetInMap "blockData" "time" 120 }}
 {{ end }}
 
 {{ if "cyf-pd.netlify.app" | in $src }}

--- a/layouts/partials/block/readme.html
+++ b/layouts/partials/block/readme.html
@@ -9,10 +9,10 @@
         id="{{ $blockData.name |urlize }}">
         <a href="{{ $response.html_url }}">{{ $blockData.name }} 🔗</a>
       </h2>
-      {{ partial "time.html" (dict "blockData" $blockData "time" "60") }}
+      {{ partial "time.html" $blockData }}
     </header>
     <div class="c-block__content c-copy">
-      {{ $response.content | base64Decode | markdownify }}
+      {{ $response.content | base64Decode | replaceRE "<!--" "" | replaceRE "-->" ""  | markdownify }}
     </div>
   </section>
 {{ else }}


### PR DESCRIPTION
## What does this change?
all

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

1. Bump the time to 120 minutes as default on workshops as that's how long they are being schedule for in class
2. Parse out stuff in html comments on github readme -- this can be used to use fancy hugo markup in github without making it look weird on github

I've done this in the Devtools workshop

TODO: the next thing to do would be to send over commented out front matter and transform it like we do in the pd block. I can't really get this working at the moment and I don't think it's worth holding up these changes.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
