### PR TITLE
Feature: add jsDelivr to get round CORS

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -8,6 +8,11 @@
 
 {{/* Check if the source is an external link */}}
 {{ $isExternal := or (strings.HasPrefix $src "http://") (strings.HasPrefix $src "https://") }}
+{{/* If this image is served from GitHub, swap to jSDelivr */}}
+{{ if "github" | in $src }}
+  {{ $src = replace $src "https://github.com/" "https://cdn.jsdelivr.net/gh/" }}
+  {{ $src = replace $src "/blob/" "@" }}
+{{ end }}
 
 {{/* Define an image variable and a flag to indicate if it's a resource */}}
 {{ $image := "" }}


### PR DESCRIPTION
## What does this change?

Module: all
Week(s):

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

I want to hotlink github images and it's blocking me so I'm going round it with jsDelivr. Take that, CORS.

Longer term, I'd prefer we had a regular action to go get these images and process them with Hugo Pipes. Please write one!

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
