### PR TITLE
Feature: Youtube Playlists

### DIFF
--- a/assets/scripts/youtube-player.js
+++ b/assets/scripts/youtube-player.js
@@ -1,7 +1,15 @@
 class YouTubePlayer extends HTMLElement {
   constructor() {
     super();
-    this.videoId = this.getAttribute("data-video-id");
+    this.src = this.getAttribute("data-src");
+    // Extract video ID, playlist ID, and start index from the passed in src
+    const url = new URL(this.src);
+    this.videoId =
+      url.hostname === "youtu.be"
+        ? url.pathname.slice(1)
+        : new URLSearchParams(url.search).get("v");
+    this.playlistId = new URLSearchParams(url.search).get("list");
+    this.startAt = new URLSearchParams(url.search).get("index");
     this.attachShadow({ mode: "open" });
   }
 
@@ -70,10 +78,11 @@ class YouTubePlayer extends HTMLElement {
       .querySelector(".play-button")
       .addEventListener("click", () => {
         const iframe = document.createElement("iframe");
-        iframe.setAttribute(
-          "src",
-          `https://www.youtube.com/embed/${this.videoId}?autoplay=1`
-        );
+        const iframeSrc =
+          `https://www.youtube.com/embed/${this.videoId}?autoplay=1` +
+          (this.playlistId ? `&list=${this.playlistId}` : "") +
+          (this.startAt ? `&index=${this.startAt}` : "");
+        iframe.setAttribute("src", iframeSrc);
         iframe.setAttribute("title", "Youtube Video");
         iframe.setAttribute("frameborder", "0");
         iframe.setAttribute("allowfullscreen", "");

--- a/layouts/partials/block/data.html
+++ b/layouts/partials/block/data.html
@@ -67,9 +67,8 @@
 {{ end }}
 
 {{ if "youtu" | in $src }}
-  {{ $newSrc := cond (in $src "youtu.be") (last 1 (split $src "/")) (last 1 (split $src "?v=")) }}
   {{ .Scratch.SetInMap "blockData" "type" "youtube" }}
-  {{ .Scratch.SetInMap "blockData" "api" (delimit $newSrc "" "") }}
+  {{ .Scratch.SetInMap "blockData" "api" $src }}
 {{ end }}
 
 {{/* Now let's do our headers */}}

--- a/layouts/partials/block/youtube.html
+++ b/layouts/partials/block/youtube.html
@@ -9,6 +9,6 @@
     </h2>
   {{ end }}
   <div class="c-block__content">
-    <youtube-player data-video-id="{{ $blockData.api }}"></youtube-player>
+    <youtube-player data-src="{{ $blockData.api }}"></youtube-player>
   </div>
 </section>


### PR DESCRIPTION
## What does this change?

Module: all
Week(s):

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

I wanted to link to a specific video in a playlist, but then let the playlist roll. So I've extended the youtube component to do this.

While I was there, I moved all the string manipulation into the web component as it seems like it belongs to the youtube component. The string isn't used anywhere else.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
