### PR TITLE
remove text transform off e-heading_4 class

### DIFF
--- a/assets/styles/03-elements/headings.scss
+++ b/assets/styles/03-elements/headings.scss
@@ -15,7 +15,6 @@ $heading__levels: 1, 2, 3, 4, 5, 6;
 
 h4,
 .e-heading__4 {
-  text-transform: uppercase;
   font-weight: 500;
   color: var(--theme-color--pop);
 }


### PR DESCRIPTION
## What does this change?

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

Removes upper case off the h4 class. Personal preference here unless someone else thinks it should be capitalised?

## Who needs to know about this?


## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
