### PR TITLE
Bug: weird escaping markdownifying inner nested shortcodes

### DIFF
--- a/content/fundamentals/prep/index.md
+++ b/content/fundamentals/prep/index.md
@@ -26,7 +26,7 @@ name="Backlog"
 +++
 
 {{<tabs name="prep">}}
-{{% tab name="Getting Started" %}}
+{{< tab name="Getting Started" >}}
 
 ## Getting Started
 
@@ -51,10 +51,10 @@ CYF recognises you may need to keep your birth name private. When we say real na
 When prospective employers are looking at your GitHub portfolio, **you need them to know who you are**: not your online identity, but the name you put on your job application. Don’t use cute handles on your GitHub, even though some mentors do. They are not applying for entry level developer roles.
 
 Watch [What is GitHub](#prep-1)
-{{% /tab %}}
+{{< /tab >}}
 
 {{<tab name="📼 Watch: What is GitHub">}}
-{{% youtube %}}https://www.youtube.com/watch?v=pBy1zgt0XPc{{% /youtube %}}
+{{< youtube >}}https://www.youtube.com/watch?v=pBy1zgt0XPc{{< /youtube >}}
 {{</tab>}}
 
 {{</tabs>}}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -24,7 +24,7 @@
         <div id="{{ $id }}" class="c-tabs__panel" role="tabpanel" aria-labelledby='tab-label-{{ $id }}'>
       {{ end }}
         {{- with .content -}}
-          {{- . -}}
+          {{- . | markdownify -}}
         {{- end -}}
       </div>
     {{- end -}}

--- a/layouts/shortcodes/youtube.html
+++ b/layouts/shortcodes/youtube.html
@@ -1,4 +1,5 @@
 {{ $src := .Inner }}
 {{ partial "block/data.html" (dict "Scratch" .Page.Scratch "src" $src  "name" "" "page" .) }}
 {{ $blockData := .Page.Scratch.Get "blockData" }}
-{{ partial "block/youtube.html" . }}
+{{ .Page.Scratch.SetInMap "blockData" "isShortcode" true }}
+{{ partial "block/youtube.html" . | safeHTML }}


### PR DESCRIPTION
1. Make tabs fully work with youtube shortcode
- 1. you have to declare the shortcode as safeHTML if you're nesting this deep but only sometimes so I've set it for all cases as this is always html
- 2. You have to actually set the boolean isShortcode to the scratch map instead of just somehow willing it with your mind

2. Store this one weird tip by [showing content change](https://github.com/CodeYourFuture/curriculum/pull/198/files#diff-e4a97e4548b6599d18a607fdde1c1fdb92273bab764dc55a2ad6ff3176a05b03)

If you use % markers in markdown in nested tabs your html will always be escaped, safeHTML or nay, so don't use those unless you want that, lesson learned