### PR TITLE
fix readme timestamp on day-plan schedule

### DIFF
--- a/layouts/partials/block/local.html
+++ b/layouts/partials/block/local.html
@@ -8,7 +8,7 @@
     <h2 class="c-block__title e-heading__2" id="{{ $blockData.name |urlize }}">
       {{ $block.Title }}
     </h2>
-    {{ partial "time.html" (dict "blockData" $blockData "time" $block.Params.time) }}
+    {{ partial "time.html" (merge $blockData (dict "time" $block.Params.time)) }}
   </header>
   {{ with $block.Params.Objectives }}
     <details>

--- a/layouts/partials/block/pd.html
+++ b/layouts/partials/block/pd.html
@@ -22,7 +22,8 @@
       <h2 class="c-block__title e-heading__2" id="{{ $blockData |urlize }}">
         <a href="{{ $response.html_url }}">{{ $parsedFrontMatter.title }} 🔗</a>
       </h2>
-      {{ partial "time.html" (dict "blockData" $blockData "time" $parsedFrontMatter.time) }}
+      {{ partial "time.html" (merge $blockData (dict "time" $parsedFrontMatter.time)) }}
+
     </header>
 
     <section class="c-copy">{{ $markdownContent | markdownify }}</section>

--- a/layouts/partials/block/readme.html
+++ b/layouts/partials/block/readme.html
@@ -9,7 +9,7 @@
         id="{{ $blockData.name |urlize }}">
         <a href="{{ $response.html_url }}">{{ $blockData.name }} 🔗</a>
       </h2>
-      {{ partial "time.html" $blockData }}
+      {{ partial "time.html" (dict "blockData" $blockData "time" $blockData.time) }}
     </header>
     <div class="c-block__content c-copy">
       {{ $response.content | base64Decode | replaceRE "<!--" "" | replaceRE "-->" ""  | markdownify }}

--- a/layouts/partials/block/readme.html
+++ b/layouts/partials/block/readme.html
@@ -9,7 +9,7 @@
         id="{{ $blockData.name |urlize }}">
         <a href="{{ $response.html_url }}">{{ $blockData.name }} 🔗</a>
       </h2>
-      {{ partial "time.html" (dict "blockData" $blockData "time" $blockData.time) }}
+      {{ partial "time.html" (merge $blockData (dict "time" $blockData.time)) }}
     </header>
     <div class="c-block__content c-copy">
       {{ $response.content | base64Decode | replaceRE "<!--" "" | replaceRE "-->" ""  | markdownify }}

--- a/layouts/partials/time.html
+++ b/layouts/partials/time.html
@@ -1,7 +1,7 @@
-{{ $blockData := .blockData }}
-{{ $time := .time }}
+{{ $blockData := . }}
+{{ $time := $blockData.time }}
 {{ if $blockData.showTime }}
   <time class="c-block__time" datetime="P{{ $time | default 60 }}M"
-    >{{ .time | default 60 }} minutes</time
+    >{{ $time | default 60 }} minutes</time
   >
 {{ end }}


### PR DESCRIPTION
## What does this change?

Currently the time render properly for workshops on the day plan.
Just tweaked the data passed to the time partial so it shows up properly.

### Currently, the day-plan looks like this in production:
<img width="1077" alt="image" src="https://github.com/CodeYourFuture/curriculum/assets/25401570/ef8724af-e832-4dab-a939-291f3180b933">
Note: no time for the git workshop section.

### Now checkout the same page on the deploy preview:
https://deploy-preview-221--cyf-curriculum.netlify.app/induction/sprints/1/day-plan/#git-workshop
<img width="1174" alt="image" src="https://github.com/CodeYourFuture/curriculum/assets/25401570/da80cbb9-bf7b-4eb6-86b1-3c290b3e3874">
It should have the correct time and it should have a duration of 2 hours.



## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
