### PR TITLE
Feature: basic tooltip

### DIFF
--- a/assets/styles/04-components/tooltip.scss
+++ b/assets/styles/04-components/tooltip.scss
@@ -1,7 +1,7 @@
 tool-tip-container {
   position: relative;
   display: inline-block;
-  cursor: pointer;
+  cursor: help;
 }
 
 .tooltip {

--- a/assets/styles/04-components/tooltip.scss
+++ b/assets/styles/04-components/tooltip.scss
@@ -1,0 +1,45 @@
+tool-tip-container {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.tooltip {
+  &__title {
+    display: block;
+    margin-bottom: var(--theme-spacing--gutter);
+  }
+  &__content {
+    font-size: var(--theme-type-size--3);
+  }
+}
+
+tool-tip {
+  pointer-events: none;
+  user-select: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  position: absolute;
+  z-index: 1;
+  max-width: 45ch;
+  min-width: 30ch;
+  padding: var(--theme-spacing--2);
+  border-radius: var(--theme-border-radius);
+  box-shadow: var(--theme-box-shadow);
+  background-image: linear-gradient(
+    -45deg,
+    var(--theme-color--block),
+    var(--theme-color--paper)
+  );
+  color: var(--theme-color--ink);
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+:has(> tool-tip):hover > tool-tip,
+:has(> tool-tip):focus-visible > tool-tip,
+:has(> tool-tip):active > tool-tip {
+  opacity: 1;
+  transition-delay: 200ms;
+}

--- a/assets/styles/04-components/tooltip.scss
+++ b/assets/styles/04-components/tooltip.scss
@@ -10,7 +10,7 @@ tool-tip-container {
     margin-bottom: var(--theme-spacing--gutter);
   }
   &__content {
-    font-size: var(--theme-type-size--3);
+    font-size: var(--theme-type-size--5);
   }
 }
 
@@ -24,8 +24,9 @@ tool-tip {
   max-width: 45ch;
   min-width: 30ch;
   padding: var(--theme-spacing--2);
+  border: 1px solid var(--theme-color--pop);
   border-radius: var(--theme-border-radius);
-  box-shadow: var(--theme-box-shadow);
+  box-shadow: var(--theme-box-shadow--slim);
   background-image: linear-gradient(
     -45deg,
     var(--theme-color--block),
@@ -39,6 +40,7 @@ tool-tip {
 
 :has(> tool-tip):hover > tool-tip,
 :has(> tool-tip):focus-visible > tool-tip,
+:has(> tool-tip):focus-within > tool-tip,
 :has(> tool-tip):active > tool-tip {
   opacity: 1;
   transition-delay: 200ms;

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -3,7 +3,7 @@
 
 
 <tool-tip-container>
-  <strong class="tooltip__trigger" id="trigger__{{ $title }}">
+  <strong class="tooltip__trigger" id="trigger__{{ $title }}" tabindex="0">
     {{ $title }}
   </strong>
   <span class="tooltip__emoji">{{ $emoji }}</span>

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -1,14 +1,14 @@
 {{ $title := .Get "title" | default "tooltip" }}
-{{ $emoji := .Get "emoji" | default "🙋🏽" }}
-
-
-<tool-tip-container>
-  <strong class="tooltip__trigger" id="trigger__{{ $title }}" tabindex="0">
+{{ $emoji := .Get "emoji" | default "🧶" }}
+<tool-tip-container tabindex="0">
+  <strong class="tooltip__trigger" id="trigger__{{ $title }}">
     {{ $title }}
   </strong>
   <span class="tooltip__emoji">{{ $emoji }}</span>
   <tool-tip role="tooltip" aria-labelledby="{{ $title }}">
-    <span class="tooltip__title e-heading__2">{{ $title }}</span>
+    <span class="tooltip__title e-heading__2"
+      ><span class="tooltip__emoji">{{ $emoji }}</span> {{ $title }}</span
+    >
     <span class="tooltip__content">
       {{ .Inner | markdownify }}
     </span>

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -1,7 +1,7 @@
 {{ $title := .Get "title" | default "tooltip" }}
 {{ $emoji := .Get "emoji" | default "🧶" }}
 <tool-tip-container tabindex="0">
-  <strong class="tooltip__trigger" id="trigger__{{ $title }}">
+  <strong class="tooltip__trigger" id="trigger__{{- $title -}}">
     {{ $title }}
   </strong>
   <span class="tooltip__emoji">{{ $emoji }}</span>

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -1,0 +1,16 @@
+{{ $title := .Get "title" | default "tooltip" }}
+{{ $emoji := .Get "emoji" | default "🙋🏽" }}
+
+
+<tool-tip-container>
+  <strong class="tooltip__trigger" id="trigger__{{ $title }}">
+    {{ $title }}
+  </strong>
+  <span class="tooltip__emoji">{{ $emoji }}</span>
+  <tool-tip role="tooltip" aria-labelledby="{{ $title }}">
+    <span class="tooltip__title e-heading__2">{{ $title }}</span>
+    <span class="tooltip__content">
+      {{ .Inner | markdownify }}
+    </span>
+  </tool-tip>
+</tool-tip-container>


### PR DESCRIPTION
## What does this change?

feature

## Description

There are lots of definitions making the prep views very long. Should some of them be tooltips? 

PS footnotes already exist in this flavour of markdown

https://github.blog/changelog/2021-09-30-footnotes-now-supported-in-markdown-fields/

I've actually lost preview as my user id has been temporarily rate limited on github. But this should roughly work?

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
