### PR TITLE
Bugfix: Images in Tabs

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,7 +1,6 @@
 {{ $src := .Destination }}
 {{ $alt := .PlainText | safeHTML }}
 {{ $caption := "" }}
-
 {{ with .Title }}
   {{ $caption = . | safeHTML }}
 {{ end }}
@@ -21,16 +20,19 @@
 
 {{/* If it's not an external link, look for the image in Page resources */}}
 {{ if not $isExternal }}
-  {{ with .Page.Resources.GetMatch (printf "%s" $src) }}
+  {{/* Check if the image is a resource */}}
+  {{ with $.Page.Resources.GetMatch (printf "%s" $src) }}
     {{ $image = . }}
     {{ $isResource = true }}
   {{ end }}
 {{ end }}
 
-{{/* If the image is still not found, use the path directly (assuming the image is in the /pictures directory) */}}
+{{/* If the image is still not found, try to get it from the assets directory */}}
 {{- if and (not $image) (not $isExternal) -}}
-  {{ $path := (path.Join "/pictures" $src) }}
-  {{ $image = (dict "RelPermalink" $path "Width" 0 "Height" 0) }}
+  {{ $path := (path.Join "pictures" $src) }}
+  {{ with resources.Get $path }}
+    {{ $image = . }}
+  {{ end }}
 {{- end -}}
 
 {{/* Handle external images directly */}}
@@ -73,5 +75,7 @@
     {{ end }}
   </figure>
 {{ else }}
-  <div style="font-size: 48px; text-align: center;">🖼️</div>
+  <div title="broken image link" style="font-size: 48px; text-align: center;">
+    🖼️
+  </div>
 {{ end }}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -24,7 +24,7 @@
         <div id="{{ $id }}" class="c-tabs__panel" role="tabpanel" aria-labelledby='tab-label-{{ $id }}'>
       {{ end }}
         {{- with .content -}}
-          {{- . | markdownify -}}
+          {{- . | $.Page.RenderString -}}
         {{- end -}}
       </div>
     {{- end -}}


### PR DESCRIPTION
## What does this change?

Module: all
Week(s): all

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

So, once deeply nested inside tabs, image links coming from headless leaf bundles were broken. This is because at the point of render, markdownify didn't know where the hell it was.

I've used https://gohugo.io/functions/renderstring/ to control the site of the render, in tabs.html on line 27

and then accessed the global page object inside the image hook to find the resource on render_image line 24

I also updated the fall back to global check on 32, 33 to use the same get resources method and assume we put everything global in the assets dir . It's empty at the moment but obv I did stuff some images in there to check.

Note, this doesn't address the larger image handling changes we want to make, it just fixes the display problem thrown up in JS1-1

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
