### PR TITLE
Bugfix : suppress spellcheckers

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -40,6 +40,10 @@ darkModeToggle.addEventListener("click", () => {
 const editableCodeBlocks = document.querySelectorAll("code[data-lang]");
 editableCodeBlocks.forEach((block) => {
   block.setAttribute("contenteditable", true);
+  block.setAttribute("spellcheck", false);
+  block.setAttribute("data-gramm", false);
+  block.setAttribute("autocorrect", "off");
+  block.setAttribute("autocapitalize", "off");
 });
 
 // Fix for GFM task lists

--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -41,7 +41,6 @@ const editableCodeBlocks = document.querySelectorAll("code[data-lang]");
 editableCodeBlocks.forEach((block) => {
   block.setAttribute("contenteditable", true);
   block.setAttribute("spellcheck", false);
-  block.setAttribute("data-gramm", false);
   block.setAttribute("autocorrect", "off");
   block.setAttribute("autocapitalize", "off");
 });


### PR DESCRIPTION
## What does this change?

Module: all
Week(s): all
 
## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

fixing #201

Given we turn on 
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable

We should then suppress
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck

and https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize

etc. 

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
