### PR TITLE
Feature: Module Success

### DIFF
--- a/content/html-css/success/index.md
+++ b/content/html-css/success/index.md
@@ -1,11 +1,17 @@
 +++
 title = 'success'
-description = 'success description'
+description = 'How do we know if we have completed this module?'
 layout = 'success'
 emoji= '📝'
 menu_level = ['module']
 weight = 11
 backlog= 'Module-HTML-CSS'
+[[objectives]]
+1="Every trainee has received and responded to at least one code review"
+2="Every trainee has opened at least 3 PRs to the module repo"
+3="70% of cohort is at or beyond milestones"
 +++
 
+Every module, you must review your progress to understand if your cohort can progress to the next stage. The conditions for success are listed below. If your cohort has met all of these conditions, you can progress to the next module. If you have not met them yet, what actions will you take to meet them?
 
+Discuss your plan in your class channel.

--- a/layouts/_default/success.html
+++ b/layouts/_default/success.html
@@ -9,54 +9,58 @@
     {{ end }}
     <confetti-checkboxes>
       {{/* print any objectives from the success page front matter */}}
-      {{ if .Params.Objectives }}
+      {{ with .Params.Objectives }}
         <section class="c-objectives">
-          <h3 class="c-objectives__title e-heading__4">Overall Objectives</h3>
-          {{ partial "objectives-block.html" .Params.Objectives }}
+          <h3 class="c-objectives__title is-invisible">Overall Objectives</h3>
+          {{ range . }}{{ partial "objectives/block.html" . }}{{ end }}
         </section>
-        <hr />
       {{ end }}
-      <section class="c-objectives">
-        <h2 class="e-heading__4 c-objectives__title is-invisible">
-          Compiled Learning Objectives
-        </h2>
-        {{/* get the path to the pages that are the siblings of this page */}}
-        {{ $prep := .Site.GetPage (printf "%sprep/index.md"
-          .CurrentSection.RelPermalink)
-        }}
-        {{ $dayplan := .Site.GetPage (printf "%sday-plan/index.md"
-          .CurrentSection.RelPermalink)
-        }}
-        {{ $blocks := slice }}
-        {{/* append non-nil blocks */}}
-        {{ range $prep.Params.blocks }}
-          {{ if . }}{{ $blocks = $blocks | append . }}{{ end }}
-        {{ end }}
-        {{ range $dayplan.Params.blocks }}
-          {{ if . }}{{ $blocks = $blocks | append . }}{{ end }}
-        {{ end }}
-        {{/* Deduplicate blocks */}}
-        {{ $blocks = $blocks | uniq }}
-        {{/* now we need to extract objectives from blocks, some not stored in this repo,
-          so we will use the block-data scratch function to get the block data
-        */}}
-        {{ range $blocks }}
-          {{ $name := .name }}
-          {{ $src := .src }}
-          {{/* Call our scratch function */}}
-          {{ partial "block/data.html" (dict "Scratch" $.Page.Scratch "src" $src  "name" $name "page" .) }}
-          {{/* Retrieve the blockData from Scratch */}}
-          {{ $blockData := $.Page.Scratch.Get "blockData" }}
-          {{/* Depending on the type of block, call the appropriate partial */}}
-          {{ if or (eq $blockData.type "readme") (eq $blockData.type "pd") }}
-            {{ partial "objectives/parsed" (dict "blockData" $blockData "pageContext" $pageContext) }}
-          {{ end }}
-          {{ if or (eq $blockData.type "local_module") (eq $blockData.type "local_course") }}
-            {{ partial "objectives/lookup.html" (dict "blockData" $blockData "pageContext" $pageContext) }}
-          {{ end }}
 
-        {{ end }}
-      </section>
+      {{ if in .Params.menu_level "module" }}
+        {{/* At the module level, we just want the overall criteria for progressing to the next module */}}
+      {{ else }}
+        <section class="c-objectives">
+          <h2 class="e-heading__4 c-objectives__title is-invisible">
+            Compiled Learning Objectives
+          </h2>
+          {{/* get the path to the pages that are the siblings of this page */}}
+          {{ $prep := .Site.GetPage (printf "%sprep/index.md"
+            .CurrentSection.RelPermalink)
+          }}
+          {{ $dayplan := .Site.GetPage (printf "%sday-plan/index.md"
+            .CurrentSection.RelPermalink)
+          }}
+          {{ $blocks := slice }}
+          {{/* append non-nil blocks */}}
+          {{ range $prep.Params.blocks }}
+            {{ if . }}{{ $blocks = $blocks | append . }}{{ end }}
+          {{ end }}
+          {{ range $dayplan.Params.blocks }}
+            {{ if . }}{{ $blocks = $blocks | append . }}{{ end }}
+          {{ end }}
+          {{/* Deduplicate blocks */}}
+          {{ $blocks = $blocks | uniq }}
+          {{/* now we need to extract objectives from blocks, some not stored in this repo,
+            so we will use the block-data scratch function to get the block data
+          */}}
+          {{ range $blocks }}
+            {{ $name := .name }}
+            {{ $src := .src }}
+            {{/* Call our scratch function */}}
+            {{ partial "block/data.html" (dict "Scratch" $.Page.Scratch "src" $src  "name" $name "page" .) }}
+            {{/* Retrieve the blockData from Scratch */}}
+            {{ $blockData := $.Page.Scratch.Get "blockData" }}
+            {{/* Depending on the type of block, call the appropriate partial */}}
+            {{ if or (eq $blockData.type "readme") (eq $blockData.type "pd") }}
+              {{ partial "objectives/parsed" (dict "blockData" $blockData "pageContext" $pageContext) }}
+            {{ end }}
+            {{ if or (eq $blockData.type "local_module") (eq $blockData.type "local_course") }}
+              {{ partial "objectives/lookup.html" (dict "blockData" $blockData "pageContext" $pageContext) }}
+            {{ end }}
+
+          {{ end }}
+        </section>
+      {{ end }}
     </confetti-checkboxes>
   </article>
 


### PR DESCRIPTION
## What does this change?

Module: each, but example is in HTML-CSS
Week(s): all /4

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

Creates a different success view for the module level

This view expects objectives to be directly set in the md 

Addresses #266

## Who needs to know about this?



## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
