### PR TITLE
remove default time of 120 for workshops

### DIFF
--- a/layouts/partials/block/data.html
+++ b/layouts/partials/block/data.html
@@ -60,8 +60,7 @@
   {{ end }}
 
   {{ .Scratch.SetInMap "blockData" "api" $newSrc }}
-  {{/* set a default time of 120 minutes for workshops TODO pull this from commented out front matter in Github readmes */}}
-  {{ .Scratch.SetInMap "blockData" "time" 120 }}
+  {{/* TODO pull time from commented out front matter in Github readmes */}}
 {{ end }}
 
 {{ if "cyf-pd.netlify.app" | in $src }}


### PR DESCRIPTION
## What does this change?

Module:
Week(s):

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
