### PR TITLE
Add explanatory text to PR block

### DIFF
--- a/layouts/partials/block/pullreq.html
+++ b/layouts/partials/block/pullreq.html
@@ -10,6 +10,7 @@
         <a class="c-issue__link" href="{{ $blockData.sot }}">🔗</a>
         <time class="c-block__time is-invisible" datetime="P10M"></time>
       </h3>
+      <p>Below are trainee coursework Pull Requests that need to be reviewed by volunteers.</p>
       {{/* <!-- range over PRs list and pull out useful data --> */}}
       {{ range $response }}
         <details class="c-issue c-issue--pr">


### PR DESCRIPTION
This should hopefully prevent trainees from thinking that they need to review the PRs

## What does this change?

Module: N/A
Week(s): N/A

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

Add some text to the PR block to explain that the PRs are to be reviewed by volunteers, not trainees.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

@CodeYourFuture/global-syllabus 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
