### PR TITLE
Pull requests open in new tab

### DIFF
--- a/layouts/partials/block/pullreq.html
+++ b/layouts/partials/block/pullreq.html
@@ -7,27 +7,40 @@
     {{ if ne $response nil }}
       <h3 class="e-heading__2">
         🛎️ Code waiting for review
-        <a class="c-issue__link" href="{{ $blockData.sot }}">🔗</a>
+        <a class="c-issue__link" target="_blank" href="{{ $blockData.sot }}"
+          >🔗</a
+        >
         <time class="c-block__time is-invisible" datetime="P10M"></time>
       </h3>
-      <p>Below are trainee coursework Pull Requests that need to be reviewed by volunteers.</p>
+      <p>
+        Below are trainee coursework Pull Requests that need to be reviewed by
+        volunteers.
+      </p>
       {{/* <!-- range over PRs list and pull out useful data --> */}}
       {{ range $response }}
         <details class="c-issue c-issue--pr">
           <summary class="c-issue__title e-heading__3">
             {{ .title }}
-            <a class="c-issue__link" href="{{ .html_url }}">🔗</a>
+            <a class="c-issue__link" target="_blank" href="{{ .html_url }}"
+              >🔗</a
+            >
           </summary>
           <div class="c-issue__body">
             {{ .body | markdownify }}
-            <a class="e-button c-issue__button" href="{{ .html_url }}/files"
+            <a
+              class="e-button c-issue__button"
+              target="_blank"
+              href="{{ .html_url }}/files"
               >Start a review</a
             >
           </div>
         </details>
       {{ end }}
     {{ end }}
-    <a href="{{ $blockData.sot }}" class="e-button c-issue__button"
+    <a
+      href="{{ $blockData.sot }}"
+      target="_blank"
+      class="e-button c-issue__button"
       >See more pull requests</a
     >
   </section>


### PR DESCRIPTION
## What does this change?
When clicking on a pull request I lose the ability to easily return back to the curriculum, this change opens them in a new tab by default

Module: JS1
Week(s): 1

## Checklist

- [X] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [X] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [X] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [X] I have run my code to check it works
- [X] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

I have modified the `<a>` tags in `layouts/partials/block/pullreq.html` to include `target="_blank"` so that pull requests open in a new tab/window.


## Who needs to know about this?

@SallyMcGrath @Dedekind561 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
