### PR TITLE
Add Using the curriculum to Fundamentals

### DIFF
--- a/content/fundamentals/blocks/code-dot-org/index.md
+++ b/content/fundamentals/blocks/code-dot-org/index.md
@@ -11,14 +11,12 @@ emoji= '🧩'
  4="Control flow with while statements"
 +++
 
-Code.org is a block based programming tool. We will use something similar to build our course project. Let's look at Code.org together now and work through the first two exercises. One person will share their screen.
+Code.org is a block based programming tool. We will use something similar to build our course project. Go to the Code.org website and work through the first two exercises
 
 {{<note type="activity" title=" Exercise">}}
 Go to [Course Three, Lesson 2: The Maze](https://studio.code.org/s/course3/lessons/2/levels/1)
 
-1. Look at the interface together
-2. Everybody open the interface on their own computer as well
-3. Complete the first exercise
-4. Complete the second exercise
+1. Inspect the interface
+2. Complete exercise one and two
 
 {{</note>}}

--- a/content/fundamentals/blocks/cyf-blocks-requirements/index.md
+++ b/content/fundamentals/blocks/cyf-blocks-requirements/index.md
@@ -18,6 +18,6 @@ For the majority of this course, we will use a custom CYF application called [CY
 
 - Inspect the interface
 - Read the introduction
-- Complete all steps of the first exercise
+- Complete all steps in the first exercise
 
 {{</note>}}

--- a/content/fundamentals/blocks/cyf-blocks-requirements/index.md
+++ b/content/fundamentals/blocks/cyf-blocks-requirements/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'CYF Blocks'
 headless = true
-time = 20
+time = 30
 facilitation = false
 emoji= '🧩'
 [objectives]
@@ -14,11 +14,10 @@ emoji= '🧩'
 
 For the majority of this course, we will use a custom CYF application called [CYF Blocks](https://blocks.codeyourfuture.io/#introduction). It uses the same visual programming editor, Block.ly, as Code.org, but you will use it to create JavaScript for real websites you can show others.
 
-Let's all look through the interface together now, and do one exercise as a group.
+{{<note title="CYF Blocks" type="activity">}}
 
-{{<note title="CYF Blocks (20 minutes)" type="activity">}}
-
-- Look at the interface together
-- Everybody open the interface on their own computer as well
+- Inspect the interface
+- Read the introduction
 - Complete all steps of the first exercise
-  {{</note>}}
+
+{{</note>}}

--- a/content/fundamentals/blocks/overcoming-blockers/index.md
+++ b/content/fundamentals/blocks/overcoming-blockers/index.md
@@ -6,8 +6,9 @@ facilitation=false
 
 {{<note type="narrative" title="Reading">}}
 
-> [Overcoming Coding Blockers](https://www.linkedin.com/pulse/how-overcome-coding-blockers-kingsley-ibe/)
-> {{</note>}}
+[Overcoming Coding Blockers](https://www.linkedin.com/pulse/how-overcome-coding-blockers-kingsley-ibe/)
+
+{{</note>}}
 
 ## Why are we doing this?
 

--- a/content/fundamentals/blocks/user-stories/index.md
+++ b/content/fundamentals/blocks/user-stories/index.md
@@ -1,12 +1,12 @@
 +++
 title = 'Understanding Requirements'
 headless = true
-time = 60
+time = 50
 facilitation = false
 vocabulary=["Requirements", "User Stories"]
 emoji= '🧩'
 [objectives]
-1='Identify described requirements'
+    1='Identify described requirements'
     2='Identify extra requirements from your own experience'
     3='Resolve trade-offs in conflicting requirements'
     4='Translate requirements into high-level design outlines' 

--- a/content/fundamentals/blocks/using-the-curriculum/index.md
+++ b/content/fundamentals/blocks/using-the-curriculum/index.md
@@ -1,0 +1,31 @@
++++
+title = '🗺️ Using the curriculum'
+headless = true
+time="50"
+facilitation = true
+emoji= '🧩'
+[objectives]
+   1="Describe CYF's mission"
+   2="Identify the key elements of CYF's educational philosophy"
+   3='Describe how a flipped classroom works'
+   4='Identify the key pages of the curriculum interface'
+   5='Explain the sequencing of work in a typical week at CYF'
++++
+
+At Code Your Future, the curriculum is maps out the content you will learn together over the course. It defines your weekly work, the preparation you must do before class and what you will do together on Saturdays. You will use this time now to go through the activities to learn how to navigate the curriculum interface.
+
+### Resources
+
+The facilitator will need to make a copy of this template presentation 👉 [Using the curriculum presentation](https://miro.com/app/board/uXjVMh2y3Ds=/?share_link_id=217111259406)
+
+### Preparation
+
+- [ ] Facilitator: Review the [Using the curriculum presentation](https://miro.com/app/board/uXjVMh2y3Ds=/?share_link_id=217111259406) before class.
+- [ ] Facilitator: Ensure everyone can access the Miro board presentation.
+- [ ] Facilitator: Split the class into groups of no more than 4.
+- [ ] Facilitator: Make sure every group has access to a laptop.
+- [ ] Facilitator: Make sure every group has access to a piece of paper and pen
+
+### Introduction
+
+The facilitator will use the Miro board presentation to guide trainees and volunteers on a discussion about how we learn together as a community.

--- a/content/fundamentals/blocks/using-the-curriculum/index.md
+++ b/content/fundamentals/blocks/using-the-curriculum/index.md
@@ -30,4 +30,4 @@ The facilitator will make a copy of this template presentation 👉
 
 ### Introduction
 
-The facilitator will use the Miro board presentation to guide trainees and volunteers on a discussion about how we use the curriculum.
+The facilitator will use the Miro board presentation to guide trainees and volunteers through a discussion about how we use the curriculum.

--- a/content/fundamentals/blocks/using-the-curriculum/index.md
+++ b/content/fundamentals/blocks/using-the-curriculum/index.md
@@ -12,15 +12,17 @@ emoji= '🧩'
    5='Explain the sequencing of work in a typical week at CYF'
 +++
 
-At Code Your Future, the curriculum is maps out the content you will learn together over the course. It defines your weekly work, the preparation you must do before class and what you will do together on Saturdays. You will use this time now to go through the activities to learn how to navigate the curriculum interface.
+At Code Your Future, the curriculum is maps out the content you will learn together over the course. It defines your weekly work, the preparation you must do before class and what you will do together on Saturdays. Use this time to go through the activities and learn how to navigate the curriculum interface.
 
 ### Resources
 
-The facilitator will need to make a copy of this template presentation 👉 [Using the curriculum presentation](https://miro.com/app/board/uXjVMh2y3Ds=/?share_link_id=217111259406)
+The facilitator will need to make a copy of this template presentation 👉
+
+<iframe title="using-the-curriculum" width="768" height="432" src="https://miro.com/app/live-embed/uXjVMh2y3Ds=/?moveToViewport=-7348,-6186,14736,7636&embedId=173973063452" frameborder="0" scrolling="no" allow="fullscreen; clipboard-read; clipboard-write" allowfullscreen></iframe>
 
 ### Preparation
 
-- [ ] Facilitator: Review the [Using the curriculum presentation](https://miro.com/app/board/uXjVMh2y3Ds=/?share_link_id=217111259406) before class.
+- [ ] Facilitator: Review the [How to use the curriculum](https://miro.com/app/board/uXjVMh2y3Ds=/?share_link_id=217111259406) presentation before class.
 - [ ] Facilitator: Ensure everyone can access the Miro board presentation.
 - [ ] Facilitator: Split the class into groups of no more than 4.
 - [ ] Facilitator: Make sure every group has access to a laptop.

--- a/content/fundamentals/blocks/using-the-curriculum/index.md
+++ b/content/fundamentals/blocks/using-the-curriculum/index.md
@@ -16,7 +16,7 @@ At Code Your Future, the curriculum maps out what you will learn together over t
 
 ### Resources
 
-The facilitator will need to make a copy of this template presentation 👉
+The facilitator will make a copy of this template presentation 👉
 
 <iframe title="using-the-curriculum" width="768" height="432" src="https://miro.com/app/live-embed/uXjVMh2y3Ds=/?moveToViewport=-7348,-6186,14736,7636&embedId=173973063452" frameborder="0" scrolling="no" allow="fullscreen; clipboard-read; clipboard-write" allowfullscreen></iframe>
 

--- a/content/fundamentals/blocks/using-the-curriculum/index.md
+++ b/content/fundamentals/blocks/using-the-curriculum/index.md
@@ -12,7 +12,7 @@ emoji= '🧩'
    5='Explain the sequencing of work in a typical week at CYF'
 +++
 
-At Code Your Future, the curriculum is maps out the content you will learn together over the course. It defines your weekly work, the preparation you must do before class and what you will do together on Saturdays. Use this time to go through the activities and learn how to navigate the curriculum interface.
+At Code Your Future, the curriculum maps out what you will learn together over the course. It defines your weekly work, the preparation you must do before class and what you will do together on Saturdays. Use this time to go through the activities and learn how to navigate the curriculum interface.
 
 ### Resources
 

--- a/content/fundamentals/blocks/using-the-curriculum/index.md
+++ b/content/fundamentals/blocks/using-the-curriculum/index.md
@@ -30,4 +30,4 @@ The facilitator will need to make a copy of this template presentation 👉
 
 ### Introduction
 
-The facilitator will use the Miro board presentation to guide trainees and volunteers on a discussion about how we learn together as a community.
+The facilitator will use the Miro board presentation to guide trainees and volunteers on a discussion about how we use the curriculum.

--- a/content/fundamentals/sprints/1/day-plan/index.md
+++ b/content/fundamentals/sprints/1/day-plan/index.md
@@ -20,11 +20,8 @@ src="https://cyf-pd.netlify.app/blocks/lets-talk-about-our-code-of-conduct/readm
 name="Morning break"
 src="blocks/morning-break"
 [[blocks]]
-name="code.org"
-src="fundamentals/blocks/code-dot-org"
-[[blocks]]
-name="CYF Blocks"
-src="fundamentals/blocks/cyf-blocks-requirements"
+name="Using the curriculum"
+src="fundamentals/blocks/using-the-curriculum"
 [[blocks]]
 name="lunch"
 src="blocks/lunch"

--- a/content/fundamentals/sprints/2/prep/index.md
+++ b/content/fundamentals/sprints/2/prep/index.md
@@ -9,10 +9,16 @@ backlog= 'Course-Fundamentals'
 backlog_filter= 'Week 2'
 [[blocks]]
 name="overcoming-blockers"
-src="module"
+src="fundamentals/blocks/overcoming-blockers"
 [[blocks]]
 name="Learn about Slack"
 src="https://cyf-pd.netlify.app/blocks/learn-about-slack/readme/"
+[[blocks]]
+name="code.org"
+src="fundamentals/blocks/code-dot-org"
+[[blocks]]
+name="CYF Blocks"
+src="fundamentals/blocks/cyf-blocks-requirements"
 [[blocks]]
 name="backlog"
 src="blocks/backlog"


### PR DESCRIPTION
## What does this change?

Module: Fundamentals
Week(s): 1 & 2

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

### Using the curriculum
This PR introduces "Using the curriculum" presentation to week 1 of Fundamentals. It is a set of activities that will invite volunteers and trainees to navigate the curriculum and make sense of how to use it at CYF.
"Using the curriculum" is the first of two workshops inviting people to make sense of the CYF curriculum. The second one occurs at the start of the SDC in Induction and is a discussion about the challenges of using the curriculum.

### Fundamentals day 2 prep
The blockly based content is now set as prep for week 2 of Fundamentals.

## Rendered Pages

[Fundamentals sprint 1 day plan](https://deploy-preview-305--cyf-curriculum.netlify.app/fundamentals/sprints/1/day-plan/)
[Fundamentals sprint 2 prep](https://deploy-preview-305--cyf-curriculum.netlify.app/fundamentals/sprints/2/prep/)
