### PR TITLE
add day plans for JS2

### DIFF
--- a/content/js2/_index.md
+++ b/content/js2/_index.md
@@ -1,6 +1,6 @@
 +++
 title = 'JS2'
-description = 'The plan for JS2 is in progress'
+description = 'Organise and structure data; Build interactive user interfaces; Break problems down into sub-problems; Interpret acceptance criteria to form test cases'
 layout = 'module'
 emoji= '📚'
 menu = ['syllabus']

--- a/content/js2/blocks/check-in/index.md
+++ b/content/js2/blocks/check-in/index.md
@@ -1,18 +1,26 @@
 +++
 title="✏️ Check your progress"
 headless="true"
-time= 30
+time=60
 vocabulary="Backlog"
 [objectives]
     1="Check your progress so far"
 +++
 
-This week you should have been
-Use this time to check your progress.
+This week you should have been **building an app in pairs**.
+Use this time to check your progress and complete any tasks.
 
 ### 🔑 Key questions
+
+You can use the questions below to reflect on your code quality.
 
 - Which acceptance criteria have you completed for your app?
 - Have you deployed your app? Do you have a link to the deployed version that you can share with others?
 - Is your code formatted properly?
 - Is your code readable? E.g. do you have clear function names, variable names etc.
+
+If you're unsure of any of the questions above, use this time to
+
+- finish off acceptance criteria
+- get your app deployed
+- check your code formatting and quality

--- a/content/js2/blocks/check-in/index.md
+++ b/content/js2/blocks/check-in/index.md
@@ -1,0 +1,18 @@
++++
+title="✏️ Check your progress"
+headless="true"
+time= 30
+vocabulary="Backlog"
+[objectives]
+    1="Check your progress so far"
++++
+
+This week you should have been
+Use this time to check your progress.
+
+### 🔑 Key questions
+
+- Which acceptance criteria have you completed for your app?
+- Have you deployed your app? Do you have a link to the deployed version that you can share with others?
+- Is your code formatted properly?
+- Is your code readable? E.g. do you have clear function names, variable names etc.

--- a/content/js2/blocks/check-in/index.md
+++ b/content/js2/blocks/check-in/index.md
@@ -1,26 +1,24 @@
 +++
 title="✏️ Check your progress"
 headless="true"
-time=60
+time=30
 vocabulary="Backlog"
 [objectives]
-    1="Check your progress so far"
+    1="Identify outstanding pieces of work"
 +++
 
 This week you should have been **building an app in pairs**.
-Use this time to check your progress and complete any tasks.
+Use this time to check your progress and identify areas/tasks you need to complete.
 
 ### 🔑 Key questions
 
-You can use the questions below to reflect on your code quality.
+You can use the questions below to reflect on your progress this week.
 
 - Which acceptance criteria have you completed for your app?
 - Have you deployed your app? Do you have a link to the deployed version that you can share with others?
 - Is your code formatted properly?
 - Is your code readable? E.g. do you have clear function names, variable names etc.
 
-If you're unsure of any of the questions above, use this time to
+### 📝 User feedback
 
-- finish off acceptance criteria
-- get your app deployed
-- check your code formatting and quality
+If you have time, get some user feedback on your deployed application. Share your deploy link with volunteers or trainees.

--- a/content/js2/blocks/demo/index.md
+++ b/content/js2/blocks/demo/index.md
@@ -11,6 +11,13 @@ Take this time to demo the application you've been building this week to the res
 
 You can talk about the following:
 
-- Demo the app. Talk through the functionality of your application
+- Demo the app and talk through its functionality
 - Your problem solving strategy
 - Any challenges you faced in developing the app
+
+{{<note type="tip" title="Tips">}}
+
+1. Keep your demonstration brief - under 10 mins!
+2. Have both people in the pair talk about the work
+
+{{</note>}}

--- a/content/js2/blocks/demo/index.md
+++ b/content/js2/blocks/demo/index.md
@@ -1,0 +1,16 @@
++++
+title="▶️ Demo"
+headless="true"
+time= 60
+vocabulary="Backlog"
+[objectives]
+    1="Demonstrate your application in front of the group"
++++
+
+Take this time to demo the application you've been building this week to the rest of the group (your application doesn't need to be finished!)
+
+You can talk about the following:
+
+- Demo the app. Talk through the functionality of your application
+- Your problem solving strategy
+- Any challenges you faced in developing the app

--- a/content/js2/blocks/pair-up/index.md
+++ b/content/js2/blocks/pair-up/index.md
@@ -1,5 +1,5 @@
 +++
-title = '🎵 Pair up'
+title = '🫱🏿‍🫲🏾 Pair up'
 headless = true
 time = 30
 facilitation = false
@@ -8,25 +8,29 @@ emoji= '🧩'
 1="Prepare for next week's project"
 +++
 
-You'll need to take this time to prepare for next week.
+For the final week of the JS2 module, you will need to **work in pairs** to **build an application from scratch**.
+
+Use this time to setup and plan your work together for next week.
 
 ## 🧰 Setup
 
-1. You'll need to split up into pairs with someone you've not worked with before.
+1. You'll need to split up into pairs with someone you can work with over the final week of the JS2 module. Double check you will have availability to work together during the week.
 
 2. Together in your pairs, you'll have 2 options:
 
 ### Option 1
 
-Continue to finish off your DOM issues from the Week 3 backlog together.
+Choose an app from the Week 3 backlog that you can work on together _from scratch_. E.g. `alarmclock` app.
 
 ### Option 2
 
-Choose a project brief from the from the [dom-app projects section](https://github.com/CodeYourFuture/Module-JS2/tree/main/dom-apps).
+Choose a project brief from the from the [dom-app projects section](https://github.com/CodeYourFuture/Module-JS2/tree/main/dom-apps)
+and
 
-## Objectives
+1. Read the project brief carefully
 
-Once you're in pair and you've chosen one of the options from above. You'll need to do the following:
+2. Create a user story for the chosen project brief and sketch out one acceptance criterion based on the description in the project brief
 
-- [ ] Choose someone's fork of Module-JS2 to work from
-- [ ]
+## ⏲️ Availability
+
+In your pairs, discuss your availability and then agree on times to meet up during next week to work on your app together.

--- a/content/js2/blocks/pair-up/index.md
+++ b/content/js2/blocks/pair-up/index.md
@@ -13,4 +13,20 @@ You'll need to take this time to prepare for next week.
 ## 🧰 Setup
 
 1. You'll need to split up into pairs with someone you've not worked with before.
-2. Together in your pairs, you'll need to choose a project from the `mini-dom` section of the Module-JS2 repo. Together you'll need to coordinate how you can meet up during the week to work on this project together. Check your availability.
+
+2. Together in your pairs, you'll have 2 options:
+
+### Option 1
+
+Continue to finish off your DOM issues from the Week 3 backlog together.
+
+### Option 2
+
+Choose a project brief from the from the [dom-app projects section](https://github.com/CodeYourFuture/Module-JS2/tree/main/dom-apps).
+
+## Objectives
+
+Once you're in pair and you've chosen one of the options from above. You'll need to do the following:
+
+- [ ] Choose someone's fork of Module-JS2 to work from
+- [ ]

--- a/content/js2/blocks/pair-up/index.md
+++ b/content/js2/blocks/pair-up/index.md
@@ -1,0 +1,16 @@
++++
+title = '🎵 Pair up'
+headless = true
+time = 30
+facilitation = false
+emoji= '🧩'
+[objectives]
+1="Prepare for next week's project"
++++
+
+You'll need to take this time to prepare for next week.
+
+## 🧰 Setup
+
+1. You'll need to split up into pairs with someone you've not worked with before.
+2. Together in your pairs, you'll need to choose a project from the `mini-dom` section of the Module-JS2 repo. Together you'll need to coordinate how you can meet up during the week to work on this project together. Check your availability.

--- a/content/js2/blocks/pair-up/index.md
+++ b/content/js2/blocks/pair-up/index.md
@@ -29,7 +29,7 @@ and
 
 1. Read the project brief carefully
 
-2. Create a user story for the chosen project brief and sketch out one acceptance criterion based on the description in the project brief
+2. Create a user story for the chosen project brief and sketch out one acceptance criterion based on the description in the project brief. [This workshop](https://github.com/CodeYourFuture/CYF-Workshops/tree/main/breakdown) will guide you on coming up with user stories and acceptance criteria.
 
 ## ⏲️ Availability
 

--- a/content/js2/blocks/pick-an-app/index.md
+++ b/content/js2/blocks/pick-an-app/index.md
@@ -12,7 +12,8 @@ This week you're building small UI components using DOM manipulation.
 
 ## 🧰 Setup
 
-1. You'll need to get into pairs
+1. You'll need to get into groups of no more than three
 2. Choose one of the "Build a ..." issues from your [JS2 Week 3 backlog](https://curriculum.codeyourfuture.io/js2/sprints/3/backlog/)
+   It can be an app that one of you have already started or one that you'd all like to tackle together.
 3. Get into groups and have one person share their screen.
 4. As a group, you'll have to discuss your strategy and implementation for the acceptance criteria on these issues

--- a/content/js2/blocks/pick-an-app/index.md
+++ b/content/js2/blocks/pick-an-app/index.md
@@ -1,22 +1,22 @@
 +++
-title = '🪀 Pick an app'
+title = '🪀 Discuss an app'
 headless = true
-time = 90
+time = 85
 facilitation = false
 emoji= '🧩'
 [objectives]
-1='Come together as a group and problem solve'
+1='Discuss problem solving strategies in groups'
+2='Check required functionality against acceptance criteria'
 +++
 
-This week you're building small UI components using DOM manipulation.
+This week you're building small UI components/apps using DOM manipulation. The aim of this session is to get together in groups and discuss strategy and implementation for the week's backlog issues.
 
 ## 🧰 Setup
 
 1. You'll need to get into groups of no more than three
 
-2. Choose one of the "Build a ..." issues from your [JS2 Week 3 backlog](https://curriculum.codeyourfuture.io/js2/sprints/3/backlog/)
-   It can be an app that one of you have already started or one that you'd all like to tackle together.
+2. Choose one of the "Build a ..." issues e.g. "Build a slideshow app" from your [JS2 Week 3 backlog](https://curriculum.codeyourfuture.io/js2/sprints/3/backlog/). It can be an app that one of you have already started or one that you'd all like to tackle together during this session.
 
-3. Get into groups and have one person share their screen.
+3. Have one person in your group share their screen.
 
-4. As a group, you'll have to discuss your strategy and implementation for the acceptance criteria on these issues
+4. As a group, you'll have to discuss your strategy and implementation for your chosen issue. Remember to use the acceptance criteria to check your progress.

--- a/content/js2/blocks/pick-an-app/index.md
+++ b/content/js2/blocks/pick-an-app/index.md
@@ -13,7 +13,10 @@ This week you're building small UI components using DOM manipulation.
 ## 🧰 Setup
 
 1. You'll need to get into groups of no more than three
+
 2. Choose one of the "Build a ..." issues from your [JS2 Week 3 backlog](https://curriculum.codeyourfuture.io/js2/sprints/3/backlog/)
    It can be an app that one of you have already started or one that you'd all like to tackle together.
+
 3. Get into groups and have one person share their screen.
+
 4. As a group, you'll have to discuss your strategy and implementation for the acceptance criteria on these issues

--- a/content/js2/blocks/pick-an-app/index.md
+++ b/content/js2/blocks/pick-an-app/index.md
@@ -1,0 +1,18 @@
++++
+title = '🪀 Pick an app'
+headless = true
+time = 90
+facilitation = false
+emoji= '🧩'
+[objectives]
+1='Come together as a group and problem solve'
++++
+
+This week you're building small UI components using DOM manipulation.
+
+## 🧰 Setup
+
+1. You'll need to get into pairs
+2. Choose one of the "Build a ..." issues from your [JS2 Week 3 backlog](https://curriculum.codeyourfuture.io/js2/sprints/3/backlog/)
+3. Get into groups and have one person share their screen.
+4. As a group, you'll have to discuss your strategy and implementation for the acceptance criteria on these issues

--- a/content/js2/sprints/1/day-plan/index.md
+++ b/content/js2/sprints/1/day-plan/index.md
@@ -7,8 +7,41 @@ weight = 3
 backlog= 'Module-JS2'
 backlog_filter= 'Week 1'
 [[blocks]]
+name="Energiser"
+src="blocks/energiser"
+[[blocks]]
 name="Failing Fast"
 src="https://cyf-pd.netlify.app/blocks/failing-fast/readme/"
+[[blocks]]
+src="blocks/morning-break"
+name="Morning break"
+[[blocks]]
+name="Playing computer"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/asking-questions"
+time=85
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
+[[blocks]]
+name="Study Group"
+src="blocks/study-group"
+time=80
+[[blocks]]
+name="Code Review"
+src="https://github.com/CodeYourFuture/Module-JS2/pulls"
+time="0"
+[[blocks]]
+name="Afternoon break"
+src="blocks/afternoon-break"
+[[blocks]]
+name="Study Group"
+src="blocks/study-group"
+time=50
+[[blocks]]
+name="Code Review"
+src="https://github.com/CodeYourFuture/Module-JS2/pulls"
+time="0"
+[[blocks]]
+name="Retro"
+src="blocks/retro"
 +++
-
-

--- a/content/js2/sprints/1/day-plan/index.md
+++ b/content/js2/sprints/1/day-plan/index.md
@@ -16,7 +16,7 @@ src="https://cyf-pd.netlify.app/blocks/failing-fast/readme/"
 src="blocks/morning-break"
 name="Morning break"
 [[blocks]]
-name="Arrays review"
+name="🔍 Explore arrays"
 src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/arrays"
 time=85
 [[blocks]]

--- a/content/js2/sprints/1/day-plan/index.md
+++ b/content/js2/sprints/1/day-plan/index.md
@@ -16,8 +16,8 @@ src="https://cyf-pd.netlify.app/blocks/failing-fast/readme/"
 src="blocks/morning-break"
 name="Morning break"
 [[blocks]]
-name="Playing computer"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/asking-questions"
+name="Arrays review"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/arrays"
 time=85
 [[blocks]]
 name="Lunch"

--- a/content/js2/sprints/2/day-plan/index.md
+++ b/content/js2/sprints/2/day-plan/index.md
@@ -4,11 +4,44 @@ layout = 'day-plan'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 3
+backlog= 'Module-JS2'
+backlog_filter= 'Week 2'
+[[blocks]]
+name="Energiser"
+src="blocks/energiser"
 [[blocks]]
 name="Conflict Resolution"
 src="https://cyf-pd.netlify.app/blocks/conflict-resolution/readme/"
-backlog= 'Module-JS2'
-backlog_filter= 'Week 2'
+[[blocks]]
+src="blocks/morning-break"
+name="Morning break"
+[[blocks]]
+name="Playing computer"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/asking-questions"
+time=85
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
+[[blocks]]
+name="Study Group"
+src="blocks/study-group"
+time=80
+[[blocks]]
+name="Code Review"
+src="https://github.com/CodeYourFuture/Module-JS2/pulls"
+time="0"
+[[blocks]]
+name="Afternoon break"
+src="blocks/afternoon-break"
+[[blocks]]
+name="Study Group"
+src="blocks/study-group"
+time=50
+[[blocks]]
+name="Code Review"
+src="https://github.com/CodeYourFuture/Module-JS2/pulls"
+time="0"
+[[blocks]]
+name="Retro"
+src="blocks/retro"
 +++
-
-

--- a/content/js2/sprints/2/day-plan/index.md
+++ b/content/js2/sprints/2/day-plan/index.md
@@ -16,8 +16,8 @@ src="https://cyf-pd.netlify.app/blocks/conflict-resolution/readme/"
 src="blocks/morning-break"
 name="Morning break"
 [[blocks]]
-name="Playing computer"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/asking-questions"
+name="🔍 Explore objects"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/objects"
 time=85
 [[blocks]]
 name="Lunch"

--- a/content/js2/sprints/3/day-plan/index.md
+++ b/content/js2/sprints/3/day-plan/index.md
@@ -17,6 +17,7 @@ name="Importance of helping each other"
 src="https://cyf-pd.netlify.app/blocks/importance-of-helping-each-other/readme/"
 [[blocks]]
 src="js2/blocks/pick-an-app"
+name="Pick an app"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"

--- a/content/js2/sprints/3/day-plan/index.md
+++ b/content/js2/sprints/3/day-plan/index.md
@@ -30,12 +30,8 @@ name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
 name="Study Group"
-src="blocks/study-group"
+src="js2/blocks/pair-up"
 time=50
-[[blocks]]
-name="Code Review"
-src="https://github.com/CodeYourFuture/Module-JS2/pulls"
-time="0"
 [[blocks]]
 name="Retro"
 src="blocks/retro"

--- a/content/js2/sprints/3/day-plan/index.md
+++ b/content/js2/sprints/3/day-plan/index.md
@@ -6,6 +6,37 @@ menu_level = ['sprint']
 weight = 3
 backlog= 'Module-JS2'
 backlog_filter= 'Week 3'
+[[blocks]]
+name="Energiser"
+src="blocks/energiser"
+[[blocks]]
+src="blocks/morning-break"
+name="Morning break"
+[[blocks]]
+src="js2/blocks/pick-an-app"
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
+[[blocks]]
+name="Study Group"
+src="blocks/study-group"
+time=80
+[[blocks]]
+name="Code Review"
+src="https://github.com/CodeYourFuture/Module-JS2/pulls"
+time="0"
+[[blocks]]
+name="Afternoon break"
+src="blocks/afternoon-break"
+[[blocks]]
+name="Study Group"
+src="blocks/study-group"
+time=50
+[[blocks]]
+name="Code Review"
+src="https://github.com/CodeYourFuture/Module-JS2/pulls"
+time="0"
+[[blocks]]
+name="Retro"
+src="blocks/retro"
 +++
-
-

--- a/content/js2/sprints/3/day-plan/index.md
+++ b/content/js2/sprints/3/day-plan/index.md
@@ -33,7 +33,7 @@ time="0"
 name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
-name="Study Group"
+name="🫱🏿‍🫲🏾 Pair up"
 src="js2/blocks/pair-up"
 time=50
 [[blocks]]

--- a/content/js2/sprints/3/prep/index.md
+++ b/content/js2/sprints/3/prep/index.md
@@ -6,4 +6,42 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS2'
 backlog_filter= 'Week 3'
+[[blocks]]
+name="Energiser"
+src="blocks/energiser"
+[[blocks]]
+name="Conflict Resolution"
+src="https://cyf-pd.netlify.app/blocks/conflict-resolution/readme/"
+[[blocks]]
+src="blocks/morning-break"
+name="Morning break"
+[[blocks]]
+name="Playing computer"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/asking-questions"
+time=85
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
+[[blocks]]
+name="Study Group"
+src="blocks/study-group"
+time=80
+[[blocks]]
+name="Code Review"
+src="https://github.com/CodeYourFuture/Module-JS2/pulls"
+time="0"
+[[blocks]]
+name="Afternoon break"
+src="blocks/afternoon-break"
+[[blocks]]
+name="Study Group"
+src="blocks/study-group"
+time=50
+[[blocks]]
+name="Code Review"
+src="https://github.com/CodeYourFuture/Module-JS2/pulls"
+time="0"
+[[blocks]]
+name="Retro"
+src="blocks/retro"
 +++

--- a/content/js2/sprints/4/day-plan/index.md
+++ b/content/js2/sprints/4/day-plan/index.md
@@ -16,16 +16,24 @@ src="https://cyf-pd.netlify.app/blocks/ball-point-game/readme/"
 name="Public Speaking and Circles Of Influence"
 src="https://cyf-pd.netlify.app/blocks/public-speaking-circles-of-influence/readme/"
 [[blocks]]
-name="Create Groups For JS3"
-src="https://cyf-pd.netlify.app/blocks/create-groups-for-js3/readme/"
-[[blocks]]
 src="blocks/morning-break"
 name="Morning break"
 [[blocks]]
-name="Playing computer"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/asking-questions"
-time=85
+name="Create Groups For JS3"
+src="https://cyf-pd.netlify.app/blocks/create-groups-for-js3/readme/"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"
+[[blocks]]
+src="js2/blocks/check-in"
+name="Check in"
+[[blocks]]
+src="blocks/afternoon-break"
+name="Afternoon break"
+[[blocks]]
+src="js2/blocks/demo"
+name="Demo"
+[[blocks]]
+src="blocks/retro"
+name="Retro"
 +++

--- a/content/js2/sprints/4/day-plan/index.md
+++ b/content/js2/sprints/4/day-plan/index.md
@@ -7,6 +7,9 @@ weight = 3
 backlog= 'Module-JS2'
 backlog_filter= 'Week 4'
 [[blocks]]
+name="Energiser"
+src="blocks/energiser"
+[[blocks]]
 name="Ball Point Game"
 src="https://cyf-pd.netlify.app/blocks/ball-point-game/readme/"
 [[blocks]]
@@ -15,6 +18,14 @@ src="https://cyf-pd.netlify.app/blocks/public-speaking-circles-of-influence/read
 [[blocks]]
 name="Create Groups For JS3"
 src="https://cyf-pd.netlify.app/blocks/create-groups-for-js3/readme/"
+[[blocks]]
+src="blocks/morning-break"
+name="Morning break"
+[[blocks]]
+name="Playing computer"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/asking-questions"
+time=85
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
 +++
-
-

--- a/content/js2/sprints/4/day-plan/index.md
+++ b/content/js2/sprints/4/day-plan/index.md
@@ -30,6 +30,7 @@ name="Check in"
 [[blocks]]
 src="blocks/study-60"
 name="Study group"
+time="70"
 [[blocks]]
 src="blocks/afternoon-break"
 name="Afternoon break"

--- a/content/js2/sprints/4/day-plan/index.md
+++ b/content/js2/sprints/4/day-plan/index.md
@@ -28,6 +28,9 @@ src="blocks/lunch"
 src="js2/blocks/check-in"
 name="Check in"
 [[blocks]]
+src="blocks/study-60"
+name="Study group"
+[[blocks]]
 src="blocks/afternoon-break"
 name="Afternoon break"
 [[blocks]]


### PR DESCRIPTION
## What does this change?

Module: JS2
Week(s): 1-4

## Week 1 day plan

- [x] Links to the workshop for JS2 Week 1

## Week 2 day plan

- [x] Links to the workshop for JS2 Week 2 

## Week 3 day plan

- [x] Links to the "pick an app" block: getting trainees to work through a vanilla DOM app off the JS2 week 3 backlog
- [x] Links to the "pair up" block and getting trainees to pick a project for the coming week.

## Week 4 day plan

- [x] Has a **check progress** block
- [x] Has a **demo** block 

## Description

<!-- Add a description of what your PR changes here -->

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
