### PR TITLE
filter api call to only look at issues

### DIFF
--- a/layouts/partials/issues.html
+++ b/layouts/partials/issues.html
@@ -1,5 +1,5 @@
 {{ $repo := .Params.backlog }}
-{{ $issues := print .Site.Params.orgapi $repo "/issues?per_page=100" }}
+{{ $issues := print .Site.Params.orgapi $repo "/issues?per_page=100&state=open&direction=asc&type=issue" }}
 {{ $filter := .Params.backlog_filter }}
 {{ $currentPath := .Page.RelPermalink }}
 <!-- api call -->
@@ -12,54 +12,52 @@
 {{ if ne $commitObject nil }}
   <!-- range over issues list and pull out useful data -->
   {{ range $commitObject }}
-    <!-- only show open issues -->
-    {{ if eq .state "open" }}
-      {{ $showIssue := true }}
-      <!-- if a filter exists, only show issues with the right label -->
-      {{ if $filter }}
-        {{ $showIssue = false }}
-        {{ range .labels }}
-          {{ if in .name
-            $filter
-          }}
-            {{ $showIssue = true }}
-          {{ end }}
+
+    {{ $showIssue := true }}
+    <!-- if a filter exists, only show issues with the right label -->
+    {{ if $filter }}
+      {{ $showIssue = false }}
+      {{ range .labels }}
+        {{ if in .name
+          $filter
+        }}
+          {{ $showIssue = true }}
         {{ end }}
       {{ end }}
-      <!-- now show the issue -->
-      {{ if $showIssue }}
-        {{ if strings.Contains .body "_No response_" }}
-          {{ errorf "Issue %s contains _No response_ - please edit the issue to remove it." .html_url }}
-        {{ end }}
-        <div class="c-alert" role="alert" hidden>
-          <span class="alert__message"></span>
-          <button aria-label="Close" class="clean-btn close" type="button">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <details class="c-issue">
-          <summary class="c-issue__title e-heading__3">
-            {{ .title }} <a class="c-issue__link" href="{{ .html_url }}">🔗</a>
-            <a
-              href="/api/clone?state={{ dict "issue" .number "module" $repo "sprint" $filter "prevPath" $currentPath | jsonify }}"
-              class="e-button"
-              data-props="{{ $currentPath }}">
-              Clone
-            </a>
-          </summary>
-          <div class="c-issue__body">{{ .body | markdownify }}</div>
-        </details>
-        {{ with .labels }}
-          <ul class="c-issue__labels">
-            {{ range . }}
-              <li class="c-issue__label" style="--github:#{{ .color }}4d">
-                <span class="c-issue__label-name" title="{{ .description }}">
-                  {{ .name }}
-                </span>
-              </li>
-            {{ end }}
-          </ul>
-        {{ end }}
+    {{ end }}
+    <!-- now show the issue -->
+    {{ if $showIssue }}
+      {{ if strings.Contains .body "_No response_" }}
+        {{ errorf "Issue %s contains _No response_ - please edit the issue to remove it." .html_url }}
+      {{ end }}
+      <div class="c-alert" role="alert" hidden>
+        <span class="alert__message"></span>
+        <button aria-label="Close" class="clean-btn close" type="button">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <details class="c-issue">
+        <summary class="c-issue__title e-heading__3">
+          {{ .title }} <a class="c-issue__link" href="{{ .html_url }}">🔗</a>
+          <a
+            href="/api/clone?state={{ dict "issue" .number "module" $repo "sprint" $filter "prevPath" $currentPath | jsonify }}"
+            class="e-button"
+            data-props="{{ $currentPath }}">
+            Clone
+          </a>
+        </summary>
+        <div class="c-issue__body">{{ .body | markdownify }}</div>
+      </details>
+      {{ with .labels }}
+        <ul class="c-issue__labels">
+          {{ range . }}
+            <li class="c-issue__label" style="--github:#{{ .color }}4d">
+              <span class="c-issue__label-name" title="{{ .description }}">
+                {{ .name }}
+              </span>
+            </li>
+          {{ end }}
+        </ul>
       {{ end }}
     {{ end }}
   {{ end }}


### PR DESCRIPTION
addresses #333

1. improve api call to only pull open issues not all issues and PRs
2. rm template check on state as it's available as an argument

I've kept the partial match on labels as I just don't remotely trust us to be disciplined with labelling as we are many part time humans not one hive mind

## test

compare https://deploy-preview-334--cyf-curriculum.netlify.app/html-css/sprints/1/backlog/ to  https://github.com/orgs/CodeYourFuture/projects/87/views/4
