### PR TITLE
fix get forms time html css sprint 3

### DIFF
--- a/content/html-css/sprints/3/day-plan/index.md
+++ b/content/html-css/sprints/3/day-plan/index.md
@@ -23,6 +23,7 @@ src="blocks/lunch"
 [[blocks]]
 name="Get Forms Workshop"
 src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/get-forms"
+time="120"
 [[blocks]]
 name="Afternoon break"
 src="blocks/afternoon-break"


### PR DESCRIPTION
## What does this change?

Module: HTML CSS
Week(s): 3

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->
add correct time to get forms workshop
## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
