### PR TITLE
Remove unused rendered pages section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,3 @@ Week(s):
 ## Who needs to know about this?
 
 <!-- Tag anyone who might want to be notified about this PR -->
-
-## Rendered Pages
-
-<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->


### PR DESCRIPTION
## What does this change?

The PR template

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

Removes the "Rendered Pages" section of the PR template. Pretty sure the bot referenced here has been superseded by the netlify bot.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

@CodeYourFuture/global-syllabus 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
