### PR TITLE
List issues via a pagination-expanding proxy

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,9 @@ tree = "https://github.com/CodeYourFuture/curriculum/tree/main/"
 edit = "https://github.com/CodeYourFuture/curriculum/edit/main/"
 root = "curriculum"
 orgapi = "https://api.github.com/repos/CodeYourFuture/"
+# We use a proxy which concatenates paginated responses, otherwise we miss results.
+# Daniel is currently hosting this code https://github.com/illicitonion/github-issue-proxy but we should work out a long-term maintainable solution to this problem.
+issuesorgapi = "https://github-issue-proxy.illicitonion.com/repos/CodeYourFuture/"
 
 [markup]
 [markup.tableOfContents]

--- a/layouts/partials/issues.html
+++ b/layouts/partials/issues.html
@@ -7,11 +7,11 @@
 {{ if ne (os.Getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN") "" }}
   {{ $headers = merge $headers (dict "Authorization" (printf "Bearer %s" (getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN"))) }}
 {{ end }}
-{{ $commitObject := getJSON $issues $headers }}
+{{ $issues := getJSON $issuesUrl $headers }}
 <!-- if no object show error -->
-{{ if ne $commitObject nil }}
+{{ if ne $issues nil }}
   <!-- range over issues list and pull out useful data -->
-  {{ range $commitObject }}
+  {{ range $issues }}
 
     {{ $showIssue := true }}
     <!-- if a filter exists, only show issues with the right label -->
@@ -62,5 +62,5 @@
     {{ end }}
   {{ end }}
 {{ else }}
-  {{ errorf "Error, fetch of %s failed: %v" $issues $commitObject }}
+  {{ errorf "Error, fetch of %s failed: %v" $issuesUrl $issues }}
 {{ end }}

--- a/layouts/partials/issues.html
+++ b/layouts/partials/issues.html
@@ -1,5 +1,5 @@
 {{ $repo := .Params.backlog }}
-{{ $issues := print .Site.Params.orgapi $repo "/issues?per_page=100&state=open&direction=asc&type=issue" }}
+{{ $issuesUrl := print .Site.Params.issuesorgapi $repo "/issues?per_page=100&state=open&direction=asc&type=issue" }}
 {{ $filter := .Params.backlog_filter }}
 {{ $currentPath := .Page.RelPermalink }}
 <!-- api call -->

--- a/layouts/shortcodes/contributors.html
+++ b/layouts/shortcodes/contributors.html
@@ -1,5 +1,9 @@
 {{ $repo := .Get 0 }}
-{{ $contributors := getJSON (printf "https://api.github.com/repos/CodeYourFuture/%s/contributors" $repo) }}
+{{ $headers := (dict) }}
+{{ if ne (os.Getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN") "" }}
+  {{ $headers = merge $headers (dict "Authorization" (printf "Bearer %s" (getenv "CYF_CURRICULUM_GITHUB_BEARER_TOKEN"))) }}
+{{ end }}
+{{ $contributors := getJSON (printf "https://api.github.com/repos/CodeYourFuture/%s/contributors" $repo) $headers }}
 
 
 <ol class="c-contributors">


### PR DESCRIPTION
Previously we were just missing any issues that didn't happen to
paginate on the first page.

For JS3, this was quite a few issues.