### PR TITLE
Feature: columns shortcode (tiny)

### DIFF
--- a/assets/styles/04-components/columns.scss
+++ b/assets/styles/04-components/columns.scss
@@ -1,0 +1,7 @@
+// put anything side by side
+
+.c-columns {
+  display: grid;
+  gap: var(--theme-spacing--gutter);
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}

--- a/layouts/shortcodes/columns.html
+++ b/layouts/shortcodes/columns.html
@@ -1,0 +1,8 @@
+<div class="c-columns">
+  {{ $cols := split .Inner "<--->" }}
+  {{ range $cols }}
+    <div class="c-columns__column">
+      {{ . | safeHTML | markdownify }}
+    </div>
+  {{ end }}
+</div>


### PR DESCRIPTION
## What does this change?

Module: JS3
Week(s): 3

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

this tiny feature adds columns as a shortcode in markdow

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
