### PR TITLE
Feature: Runkit -- I want executable runkits for Node

### DIFF
--- a/assets/styles/03-elements/table.scss
+++ b/assets/styles/03-elements/table.scss
@@ -8,6 +8,10 @@ table {
   border-image: var(--theme-border-image);
 }
 
+.highlight table {
+  width: 100%;
+}
+
 thead th {
   font: var(--theme-font--system);
   background-color: var(--theme-color--block);

--- a/layouts/_default/_markup/render-codeblock-runkit.html
+++ b/layouts/_default/_markup/render-codeblock-runkit.html
@@ -1,0 +1,3 @@
+{{ $id := print "runkit-" (substr (md5 .Inner) 0 16) }}
+<script src="https://embed.runkit.com" data-element-id="{{ $id }}"></script>
+<div id="{{ $id }}">{{ .Inner | safeHTML }}</div>

--- a/layouts/_default/_markup/render-codeblock-runkit.html
+++ b/layouts/_default/_markup/render-codeblock-runkit.html
@@ -1,3 +1,7 @@
 {{ $id := print "runkit-" (substr (md5 .Inner) 0 16) }}
 <script src="https://embed.runkit.com" data-element-id="{{ $id }}"></script>
-<div id="{{ $id }}">{{ .Inner | safeHTML }}</div>
+<div class="highlight">
+  <div style="background:var(--theme-color--paper);">
+    <div id="{{ $id }}" style="font-size:0;">{{ .Inner | safeHTML }}</div>
+  </div>
+</div>


### PR DESCRIPTION
## What does this change?

Module: Node + all
Week(s): all

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

The Express docs use this and it's pretty easy to create notebooks directly from a render hook.

https://runkit.com/home

It's not themeable, really, so far as I can see. Sadface. But you can do this:

- all documents on RunKit are public, you can make them searchable by publishing.
- all of npm's 1,000,000+ packages are already pre-installed, just require() them
- use arrow functions, classes, template strings, and most of ES6. See everything we support here.
- await any promise instead of using callbacks (example)
- store secrets in environment variables
- export an endpoint function to turn any notebook into an API (endpoint docs)


# Usage - creates the runkit directly from the code block

```runkit
//Load the 'express' library to easily handle HTTP conversations:
const express = require("express");

const app = express();

//Register some handlers for different routes.
app.get("/", function (request, response) {
    response.send("Hello CYF");
});
app.get("/two", function (request, response) {
    response.send("Another route");
});
app.get("/numbers", function(request, response) {
  const someData = [1, 2, 3];
  response.json(someData);
});
//Tell the server to start listening for requests.
app.listen(3000);
```

## Who needs to know about this?

