### PR TITLE
Fix build issues where backlogs were pointing at wrong repo

### DIFF
--- a/content/en/the-launch/prep/index.md
+++ b/content/en/the-launch/prep/index.md
@@ -5,10 +5,8 @@ layout = 'prep'
 emoji= '📝'
 menu_level = ['module']
 weight = 1
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 [[blocks]]
 name="Prep for Launch"
 src="https://cyf-pd.netlify.app/blocks/launch-prep/readme/"
 +++
-
-

--- a/content/en/the-launch/sprints/1/backlog/index.md
+++ b/content/en/the-launch/sprints/1/backlog/index.md
@@ -4,8 +4,6 @@ layout = 'backlog'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 2
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 1'
 +++
-
-

--- a/content/en/the-launch/sprints/1/day-plan/index.md
+++ b/content/en/the-launch/sprints/1/day-plan/index.md
@@ -4,8 +4,6 @@ layout = 'day-plan'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 3
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 1'
 +++
-
-

--- a/content/en/the-launch/sprints/1/prep/index.md
+++ b/content/en/the-launch/sprints/1/prep/index.md
@@ -4,8 +4,6 @@ layout = 'prep'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 1
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 1'
 +++
-
-

--- a/content/en/the-launch/sprints/1/success/index.md
+++ b/content/en/the-launch/sprints/1/success/index.md
@@ -4,8 +4,6 @@ layout = 'success'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 4
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 1'
 +++
-
-

--- a/content/en/the-launch/sprints/2/backlog/index.md
+++ b/content/en/the-launch/sprints/2/backlog/index.md
@@ -4,8 +4,6 @@ layout = 'backlog'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 2
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 2'
 +++
-
-

--- a/content/en/the-launch/sprints/2/day-plan/index.md
+++ b/content/en/the-launch/sprints/2/day-plan/index.md
@@ -4,8 +4,6 @@ layout = 'day-plan'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 3
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 2'
 +++
-
-

--- a/content/en/the-launch/sprints/2/prep/index.md
+++ b/content/en/the-launch/sprints/2/prep/index.md
@@ -4,8 +4,6 @@ layout = 'prep'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 1
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 2'
 +++
-
-

--- a/content/en/the-launch/sprints/2/success/index.md
+++ b/content/en/the-launch/sprints/2/success/index.md
@@ -4,8 +4,6 @@ layout = 'success'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 4
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 2'
 +++
-
-

--- a/content/en/the-launch/sprints/3/backlog/index.md
+++ b/content/en/the-launch/sprints/3/backlog/index.md
@@ -4,8 +4,6 @@ layout = 'backlog'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 2
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 3'
 +++
-
-

--- a/content/en/the-launch/sprints/3/day-plan/index.md
+++ b/content/en/the-launch/sprints/3/day-plan/index.md
@@ -4,8 +4,6 @@ layout = 'day-plan'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 3
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 3'
 +++
-
-

--- a/content/en/the-launch/sprints/3/prep/index.md
+++ b/content/en/the-launch/sprints/3/prep/index.md
@@ -4,8 +4,6 @@ layout = 'prep'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 1
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 3'
 +++
-
-

--- a/content/en/the-launch/sprints/3/success/index.md
+++ b/content/en/the-launch/sprints/3/success/index.md
@@ -4,8 +4,6 @@ layout = 'success'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 4
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 3'
 +++
-
-

--- a/content/en/the-launch/sprints/4/backlog/index.md
+++ b/content/en/the-launch/sprints/4/backlog/index.md
@@ -4,8 +4,6 @@ layout = 'backlog'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 2
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 4'
 +++
-
-

--- a/content/en/the-launch/sprints/4/day-plan/index.md
+++ b/content/en/the-launch/sprints/4/day-plan/index.md
@@ -4,8 +4,6 @@ layout = 'day-plan'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 3
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 4'
 +++
-
-

--- a/content/en/the-launch/sprints/4/prep/index.md
+++ b/content/en/the-launch/sprints/4/prep/index.md
@@ -4,8 +4,6 @@ layout = 'prep'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 1
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 4'
 +++
-
-

--- a/content/en/the-launch/sprints/4/success/index.md
+++ b/content/en/the-launch/sprints/4/success/index.md
@@ -4,8 +4,6 @@ layout = 'success'
 emoji= '📝'
 menu_level = ['sprint']
 weight = 4
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 backlog_filter= 'Week 4'
 +++
-
-

--- a/content/en/the-launch/success/index.md
+++ b/content/en/the-launch/success/index.md
@@ -5,7 +5,5 @@ layout = 'success'
 emoji= '📝'
 menu_level = ['module']
 weight = 11
-backlog= 'Module-Final-Projects'
+backlog= 'Module-The-Launch'
 +++
-
-


### PR DESCRIPTION
## What does this change?

Module: The Launch
Week(s): All

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

We've recently removed the Module-Final-Projects in favour Module-The-Launch, so the urls used for the backlog need to be updated.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

@CodeYourFuture/global-syllabus 
