### PR TITLE
do not overwrite baseURL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,6 @@ defaultContentLanguageInSubdir = false
 
 [languages]
   [languages.en]
-    baseURL = "/"
     contentDir = 'content/en'
     languageCode = 'en-GB'
     languageName = 'English'


### PR DESCRIPTION
we don't need to redirect inside the language unless we are producing sites
so I've removed the config of baseURL inside the /en config 

so assets will work again on your local
