### PR TITLE
Bugfix: blank views on prep pages

### DIFF
--- a/assets/scripts/solo-view.js
+++ b/assets/scripts/solo-view.js
@@ -34,7 +34,9 @@ class SoloView extends HTMLElement {
 
   // Cache DOM elements
   cacheDOM() {
-    this.state.blocks = [...this.querySelectorAll('[slot="blocks"] .c-block')];
+    this.state.blocks = [
+      ...this.querySelectorAll('[slot="blocks"] > .c-block'),
+    ];
     this.state.tocLinks = [
       ...this.querySelectorAll('[slot="header"] .c-toc li a'),
     ];
@@ -75,9 +77,18 @@ class SoloView extends HTMLElement {
     this.addEventListener("keydown", this.handleKeydown);
   }
 
+  // Get derived tocItemIds
+  getTocItemIds() {
+    return this.state.tocLinks.map((link) =>
+      link.getAttribute("href").substring(1)
+    );
+  }
+
   // Update current block index
   updateCurrentBlockIndex(index) {
+    console.log(`Updating current block index to: ${index}`);
     this.state.currentBlockIndex = index;
+    console.log(`currenBlockIndex is: ${this.state.currentBlockIndex}`);
     this.updateView();
   }
 
@@ -121,11 +132,10 @@ class SoloView extends HTMLElement {
   // look for a fragment in the URL and navigate to it if one exists so we can link directly to a view
   handleFragment = () => {
     const fragment = window.location.hash.substring(1);
+    const tocItemIds = this.getTocItemIds(); // Get derived tocItemIds
 
-    if (fragment === "toc") {
-      this.state.currentBlockIndex = 0;
-      this.updateView();
-    } else if (fragment) {
+    // Check if the hash matches any TOC item
+    if (tocItemIds.includes(fragment)) {
       const matchingLinkIndex = this.state.tocLinks.findIndex(
         (link) => link.getAttribute("href").substring(1) === fragment
       );
@@ -138,7 +148,12 @@ class SoloView extends HTMLElement {
 
   // Update view
   updateView() {
+    console.log(this.state.blocks);
     this.state.blocks.forEach((block, index) => {
+      console.log(`Updating view: ${index}`);
+      console.log(
+        `Current block index in updateView is: ${this.state.currentBlockIndex}`
+      );
       block.hidden = index !== this.state.currentBlockIndex;
     });
 

--- a/assets/scripts/solo-view.js
+++ b/assets/scripts/solo-view.js
@@ -77,13 +77,6 @@ class SoloView extends HTMLElement {
     this.addEventListener("keydown", this.handleKeydown);
   }
 
-  // Get derived tocItemIds
-  getTocItemIds() {
-    return this.state.tocLinks.map((link) =>
-      link.getAttribute("href").substring(1)
-    );
-  }
-
   // Update current block index
   updateCurrentBlockIndex(index) {
     this.state.currentBlockIndex = index;
@@ -130,10 +123,7 @@ class SoloView extends HTMLElement {
   // look for a fragment in the URL and navigate to it if one exists so we can link directly to a view
   handleFragment = () => {
     const fragment = window.location.hash.substring(1);
-    const tocItemIds = this.getTocItemIds(); // Get derived tocItemIds
-
-    // Check if the hash matches any TOC item
-    if (tocItemIds.includes(fragment)) {
+    if (fragment) {
       const matchingLinkIndex = this.state.tocLinks.findIndex(
         (link) => link.getAttribute("href").substring(1) === fragment
       );

--- a/assets/scripts/solo-view.js
+++ b/assets/scripts/solo-view.js
@@ -86,9 +86,7 @@ class SoloView extends HTMLElement {
 
   // Update current block index
   updateCurrentBlockIndex(index) {
-    console.log(`Updating current block index to: ${index}`);
     this.state.currentBlockIndex = index;
-    console.log(`currenBlockIndex is: ${this.state.currentBlockIndex}`);
     this.updateView();
   }
 
@@ -148,12 +146,7 @@ class SoloView extends HTMLElement {
 
   // Update view
   updateView() {
-    console.log(this.state.blocks);
     this.state.blocks.forEach((block, index) => {
-      console.log(`Updating view: ${index}`);
-      console.log(
-        `Current block index in updateView is: ${this.state.currentBlockIndex}`
-      );
       block.hidden = index !== this.state.currentBlockIndex;
     });
 

--- a/content/en/html-css/sprints/1/prep/index.md
+++ b/content/en/html-css/sprints/1/prep/index.md
@@ -35,6 +35,8 @@ name="backlog"
 src="blocks/backlog"
 +++
 
+## Recap HTML and CSS
+
 {{<tabs name="HTML and CSS basics">}}
 {{<tab name="1. Intro to HTML">}}
 {{<youtube>}}https://www.youtube.com/watch?v=PqYud9dGW5s{{</youtube>}}

--- a/layouts/_default/prep.html
+++ b/layouts/_default/prep.html
@@ -9,14 +9,12 @@
       {{ with .Content }}
         <section class="l-page__main c-block c-copy">{{ . }}</section>
       {{ end }}
-      <div class="c-block__list">
-        <!-- Blocks will appear here in order listed in the blocks list in the sprint front matter -->
-        {{ range .Params.blocks }}
-          {{ partial "block/block.html" (dict "block" . "Page"
-            $.Page)
-          }}
-        {{ end }}
-      </div>
+      <!-- Blocks will appear here in order listed in the blocks list in the sprint front matter -->
+      {{ range .Params.blocks }}
+        {{ partial "block/block.html" (dict "block" . "Page"
+          $.Page)
+        }}
+      {{ end }}
     </div>
     {{ if gt .Params.blocks 1 }}
       <nav slot="nav">


### PR DESCRIPTION
## What does this change?

Module: HTML
Week(s): 1, 2, 3

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

The solo view was selecting blocks inside blocks and this meant the block index and the block array were mismatched

I have updated the component to limit the selector to the scope we actually want

In the course of tracking down this bug, I made a bunch of improvements to this and a few other web components, but I will open those as a new PR

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
