### PR TITLE
add new slide block type

### DIFF
--- a/assets/styles/03-elements/images.scss
+++ b/assets/styles/03-elements/images.scss
@@ -18,6 +18,7 @@ picture {
 figure {
   width: fit-content;
   box-shadow: var(--theme-box-shadow);
+  margin: 0 auto var(--theme-spacing--gutter) 0;
 }
 
 figure img {

--- a/content/en/react/prep/index.md
+++ b/content/en/react/prep/index.md
@@ -6,6 +6,12 @@ emoji= '📝'
 menu_level = ['module']
 weight = 1
 backlog= 'Module-React'
+[[blocks]]
+name="the usual heading, and you could hide this"
+src="https://github.com/MaggieAppleton/react-metaphors-slides/blob/master/PNGs/MetaphorsofReact_2.0.017.png"
+caption="figcaption and any attr"
+[[blocks]]
+name="another heading"
+src="https://github.com/MaggieAppleton/react-metaphors-slides/blob/master/PNGs/MetaphorsofReact_2.0.039.png"
+caption="Maggie Appleton picture"
 +++
-
-

--- a/content/en/react/prep/index.md
+++ b/content/en/react/prep/index.md
@@ -6,12 +6,4 @@ emoji= '📝'
 menu_level = ['module']
 weight = 1
 backlog= 'Module-React'
-[[blocks]]
-name="the usual heading, and you could hide this"
-src="https://github.com/MaggieAppleton/react-metaphors-slides/blob/master/PNGs/MetaphorsofReact_2.0.017.png"
-caption="figcaption and any attr"
-[[blocks]]
-name="another heading"
-src="https://github.com/MaggieAppleton/react-metaphors-slides/blob/master/PNGs/MetaphorsofReact_2.0.039.png"
-caption="Maggie Appleton picture"
 +++

--- a/layouts/partials/block/block.html
+++ b/layouts/partials/block/block.html
@@ -1,5 +1,5 @@
 {{/* Call our scratch function */}}
-{{ partial "block/data.html" (dict "Scratch" .Page.Scratch "src" .block.src  "name" .block.name "time" .block.time "page" .) }}
+{{ partial "block/data.html" (dict "Scratch" .Page.Scratch "src" .block.src  "name" .block.name "time" .block.time "caption" .block.caption "page" .) }}
 {{/* Retrieve the blockData from Scratch */}}
 {{ $blockData := .Page.Scratch.Get "blockData" }}
 
@@ -16,6 +16,8 @@
   {{ partial "block/pd.html" . }}
 {{ else if eq $blockData.type "local" }}
   {{ partial "block/local.html" . }}
+{{ else if eq $blockData.type "slide" }}
+  {{ partial "block/slide.html" . }}
 {{ else }}
   <p>Error: {{ $blockData.type }} Unrecognized block type</p>
 {{ end }}

--- a/layouts/partials/block/data.html
+++ b/layouts/partials/block/data.html
@@ -26,6 +26,7 @@
 {{ .Scratch.SetInMap "blockData" "sot" $src }}
 {{ .Scratch.SetInMap "blockData" "api" $src }}
 {{ .Scratch.SetInMap "blockData" "isShortcode" false }}
+{{ .Scratch.SetInMap "blockData" "caption" .caption | default "" }}
 {{/* Override any block time */}}
 {{ .Scratch.SetInMap "blockData" "time" .time | default "" }}
 
@@ -41,37 +42,44 @@
   ======================
 */}}
 
-{{ if "github" | in $src }}
-  {{/* Change base URL to api.github.com */}}
-  {{ $newSrc := replace $src "https://github.com/CodeYourFuture/" "https://api.github.com/repos/CodeYourFuture/" }}
+{{ if or "png" "webp" "jpg" "jpeg" "gif" | in $src }}
+  {{ .Scratch.SetInMap "blockData" "type" "slide" }}
+  {{ .Scratch.SetInMap "blockData" "api" $src }}
+{{ else }}
 
-  {{ if (in $src "issues") }}
-    {{ .Scratch.SetInMap "blockData" "type" "issue" }}
-  {{ else if (in $src "pulls") }}
-    {{ $newSrc = print $newSrc "?per_page=5&state=open" }}
-    {{ .Scratch.SetInMap "blockData" "type" "pullreq" }}
-  {{ else }}
-    {{/* For repositories and individual README files, use readme API endpoint
-      https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-a-repository-readme-for-a-directory
-    */}}
-    {{ $newSrc = replace $newSrc "/tree/main" "/readme" }}
-    {{ $newSrc = replace $newSrc "/blob/main/README.md" "/readme" }}
-    {{ .Scratch.SetInMap "blockData" "type" "readme" }}
+  {{ if "github" | in $src }}
+    {{/* Change base URL to api.github.com */}}
+    {{ $newSrc := replace $src "https://github.com/CodeYourFuture/" "https://api.github.com/repos/CodeYourFuture/" }}
+
+    {{ if (in $src "issues") }}
+      {{ .Scratch.SetInMap "blockData" "type" "issue" }}
+    {{ else if (in $src "pulls") }}
+      {{ $newSrc = print $newSrc "?per_page=5&state=open" }}
+      {{ .Scratch.SetInMap "blockData" "type" "pullreq" }}
+    {{ else }}
+      {{/* For repositories and individual README files, use readme API endpoint
+        https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-a-repository-readme-for-a-directory
+      */}}
+      {{ $newSrc = replace $newSrc "/tree/main" "/readme" }}
+      {{ $newSrc = replace $newSrc "/blob/main/README.md" "/readme" }}
+      {{ .Scratch.SetInMap "blockData" "type" "readme" }}
+    {{ end }}
+
+    {{ .Scratch.SetInMap "blockData" "api" $newSrc }}
+    {{/* TODO pull time from commented out front matter in Github readmes */}}
   {{ end }}
 
-  {{ .Scratch.SetInMap "blockData" "api" $newSrc }}
-  {{/* TODO pull time from commented out front matter in Github readmes */}}
-{{ end }}
+  {{ if "cyf-pd.netlify.app" | in $src }}
+    {{ .Scratch.SetInMap "blockData" "type" "pd" }}
+    {{ $blockPath := replace $src "https://cyf-pd.netlify.app/blocks/" "" }}
+    {{ $blockPath := replace $blockPath "/readme/" "" }}
+    {{ $newSrc := printf "https://api.github.com/repos/CodeYourFuture/CYF-PD/readme/content/blocks/%s/" $blockPath }}
+    {{ .Scratch.SetInMap "blockData" "api" $newSrc }}
+  {{ end }}
 
-{{ if "cyf-pd.netlify.app" | in $src }}
-  {{ .Scratch.SetInMap "blockData" "type" "pd" }}
-  {{ $blockPath := replace $src "https://cyf-pd.netlify.app/blocks/" "" }}
-  {{ $blockPath := replace $blockPath "/readme/" "" }}
-  {{ $newSrc := printf "https://api.github.com/repos/CodeYourFuture/CYF-PD/readme/content/blocks/%s/" $blockPath }}
-  {{ .Scratch.SetInMap "blockData" "api" $newSrc }}
-{{ end }}
+  {{ if "youtu" | in $src }}
+    {{ .Scratch.SetInMap "blockData" "type" "youtube" }}
+    {{ .Scratch.SetInMap "blockData" "api" $src }}
+  {{ end }}
 
-{{ if "youtu" | in $src }}
-  {{ .Scratch.SetInMap "blockData" "type" "youtube" }}
-  {{ .Scratch.SetInMap "blockData" "api" $src }}
 {{ end }}

--- a/layouts/partials/block/slide.html
+++ b/layouts/partials/block/slide.html
@@ -1,0 +1,12 @@
+{{ $blockData := .Page.Scratch.Get "blockData" }}
+<section class="c-block c-block--{{ $blockData.type }}">
+  {{ if not $blockData.isShortcode }}
+    <h2 class="c-block__title e-heading__2" id="{{ $blockData.name |urlize }}">
+      <a href="{{ $blockData.sot }}">{{ $blockData.name }} 🔗</a>
+    </h2>
+  {{ end }}
+  <div class="c-block__content">
+    {{ $image := $blockData.caption | printf "![%s](%s '%s')" $blockData.name $blockData.api }}
+    {{ $image |markdownify }}
+  </div>
+</section>


### PR DESCRIPTION
## What does this change?

Module: all
Week(s): all

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description


I made a slide block. You can use it to set up slide decks with solo view or just intersperse hero images. At the moment it's just assuming you're linking a single image - though obviously you could expand this.

I made it purely because I want to put some good pictures I found in the React module, but I don't want them on the page with text. I want them solo. I could just make a local content block for each and include this single image, but it felt sufficiently distinguished to become a block.  

In this case I reconstruct the markdown for a figure and send it to the existing render hook for images. 

It expects
```
name="the usual heading, and you could hide this"
src="https://github.com/MaggieAppleton/react-metaphors-slides/blob/master/PNGs/MetaphorsofReact_2.0.017.png"
caption="figcaption and any attr"
```

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
