### PR TITLE
Update README to point users to use dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,17 @@ The "Repository access" you need is "Public repositories (read-only)", and you d
 ![screenshot of required permissions](./readme_repository_access.png)
 </details>
 
+#### Set up `.env`
+
+Copy the `.env.example` file over and name it `.env`. Edit the file and then change the line that says `CYF_CURRICULUM_GITHUB_BEARER_TOKEN` to contain the token that you have generated earlier.
+
 #### Run this command
 
 Run this command in a terminal, substituting in the github API token you generated above:
 
 ```bash
 npm i
-CYF_CURRICULUM_GITHUB_BEARER_TOKEN=your_github_api_token hugo server
+dotenv hugo server
 ```
 
 ### To create a new module

--- a/assets/styles/04-components/tooltip.scss
+++ b/assets/styles/04-components/tooltip.scss
@@ -16,8 +16,6 @@ tool-tip-container {
 }
 
 tool-tip {
-  pointer-events: none;
-  user-select: none;
   opacity: 0;
   transition: opacity 0.2s ease;
   position: absolute;


### PR DESCRIPTION
## What does this change?

Minor change to update the README to point people to use dotenv instead supplying secret values on the command line. The `dotenv` command while non standard is included in the `package.json` so is installed using `npm i` 