### PR TITLE
Add overview page

### DIFF
--- a/content/en/blocks/backlog/index.md
+++ b/content/en/blocks/backlog/index.md
@@ -3,6 +3,7 @@ title="Backlog"
 headless="true"
 time= 30
 vocabulary="Backlog"
+hide_from_overview=true
 [objectives]
     1="Find the backlog"
     2="Copy your tickets to your own backlog"

--- a/content/en/blocks/spaced-repetition/index.md
+++ b/content/en/blocks/spaced-repetition/index.md
@@ -2,6 +2,7 @@
 title="Spaced Repetition"
 headless="true"
 time= 10
+hide_from_overview=true
 +++
 
 {{<tabs name="Scheduled check-ins">}}

--- a/content/en/fundamentals/blocks/code-dot-org/index.md
+++ b/content/en/fundamentals/blocks/code-dot-org/index.md
@@ -1,5 +1,5 @@
 +++
-title = 'code dot org'
+title = 'Code.org'
 headless = true
 time = 20
 facilitation = false

--- a/content/en/js1/blocks/installing/index.md
+++ b/content/en/js1/blocks/installing/index.md
@@ -1,5 +1,5 @@
 +++
-title = '🃏 Installing Jest' 
+title = '🃏 Installing Jest'
 headless = true
 time = 20
 facilitation = false

--- a/content/en/js1/sprints/1/prep/index.md
+++ b/content/en/js1/sprints/1/prep/index.md
@@ -7,6 +7,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS1'
 backlog_filter= 'Week 1'
+theme = 'Programming fundamentals'
 [[blocks]]
 name="Interface"
 src="js1/blocks/interface"

--- a/content/en/js1/sprints/2/prep/index.md
+++ b/content/en/js1/sprints/2/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS1'
 backlog_filter= 'Week 2'
+theme = "Breaking down problems with functions"
 [[blocks]]
 name="Percentages"
 src="js1/blocks/percentages"

--- a/content/en/js1/sprints/3/prep/index.md
+++ b/content/en/js1/sprints/3/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS1'
 backlog_filter= 'Week 3'
+theme = "Breaking down problems and testing"
 [[blocks]]
 src="js1/blocks/clocks"
 name="Clocks"

--- a/content/en/js1/sprints/4/prep/index.md
+++ b/content/en/js1/sprints/4/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS1'
 backlog_filter= 'Week 4'
+theme = "Using packages including Jest"
 [[blocks]]
 src="js1/blocks/ordinal"
 name="ordinal"

--- a/content/en/js2/blocks/arrays/index.md
+++ b/content/en/js2/blocks/arrays/index.md
@@ -1,5 +1,5 @@
 +++
-title = '📜 grouping data'
+title = '📜 Grouping data'
 headless = true
 time = 10
 facilitation = false

--- a/content/en/js2/blocks/iteration/index.md
+++ b/content/en/js2/blocks/iteration/index.md
@@ -1,5 +1,5 @@
 +++
-title = '🔁 iterating'
+title = '🔁 Iterating'
 headless = true
 time = 20
 facilitation = false

--- a/content/en/js2/blocks/mutation/index.md
+++ b/content/en/js2/blocks/mutation/index.md
@@ -1,5 +1,5 @@
 +++
-title = ' mutation'
+title = '🔀 Mutation'
 headless = true
 time = 25
 facilitation = false

--- a/content/en/js2/blocks/querying/index.md
+++ b/content/en/js2/blocks/querying/index.md
@@ -1,5 +1,5 @@
 +++
-title = 'Querying the DOM'
+title = '🔎 Querying the DOM'
 headless = true
 time = 30
 facilitation = false

--- a/content/en/js2/sprints/1/prep/index.md
+++ b/content/en/js2/sprints/1/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS2'
 backlog_filter= 'Week 1'
+theme = "Arrays, iteration, and side-effects"
 [[blocks]]
 name="grouping-data"
 src="js2/blocks/grouping-data"

--- a/content/en/js2/sprints/2/prep/index.md
+++ b/content/en/js2/sprints/2/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS2'
 backlog_filter= 'Week 2'
+theme = "Objects, and generalising problems"
 [[blocks]]
 src="js2/blocks/ordered-data"
 name="Ordered data"

--- a/content/en/js2/sprints/3/prep/index.md
+++ b/content/en/js2/sprints/3/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS2'
 backlog_filter= 'Week 3'
+theme = "Event handlers and the DOM"
 [[blocks]]
 src="js2/blocks/browser"
 name="browser"

--- a/content/en/js3/blocks/identifying-state/index.md
+++ b/content/en/js3/blocks/identifying-state/index.md
@@ -1,5 +1,5 @@
 +++
-title = 'Identifying state'
+title = '🔎 Identifying state'
 headless = true
 time = 15
 facilitation = false

--- a/content/en/js3/sprints/1/prep/index.md
+++ b/content/en/js3/sprints/1/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS3'
 backlog_filter= 'Week 1'
+theme = "Rendering components"
 [[blocks]]
 name="data to ui"
 src="js3/blocks/data-ui"

--- a/content/en/js3/sprints/2/prep/index.md
+++ b/content/en/js3/sprints/2/prep/index.md
@@ -7,6 +7,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS3'
 backlog_filter= 'Week 2'
+theme = "State"
 [[blocks]]
 name="Reacting"
 src="js3/blocks/reacting"

--- a/content/en/js3/sprints/3/prep/index.md
+++ b/content/en/js3/sprints/3/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS3'
 backlog_filter= 'Week 3'
+theme = "Fetch"
 [[blocks]]
 name="Fetching data"
 src="js3/blocks/fetching-data"

--- a/content/en/js3/sprints/4/prep/index.md
+++ b/content/en/js3/sprints/4/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 backlog= 'Module-JS3'
 backlog_filter= 'Week 4'
+theme = "Promises, async/await"
 [[blocks]]
 name="Promises"
 src="js3/blocks/promises"

--- a/content/en/overview/_index.md
+++ b/content/en/overview/_index.md
@@ -1,0 +1,6 @@
++++
+title = 'Course overview'
+description = 'An overview of all of the modules'
+layout = 'overview'
+menu = ['main']
++++

--- a/content/en/portfolio/sprints/1/prep/index.md
+++ b/content/en/portfolio/sprints/1/prep/index.md
@@ -12,4 +12,5 @@ src="https://cyf-pd.netlify.app/blocks/goal-setting-and-planning/readme/"
 [[blocks]]
 name="Ground rules"
 src="portfolio/blocks/ground-rules"
+hide_from_overview=true
 +++

--- a/layouts/_default/overview.html
+++ b/layouts/_default/overview.html
@@ -1,0 +1,51 @@
+{{ define "main" }}
+
+  {{ $site := .Site }}
+  {{ $lang := .Site.Language.Lang }}
+  {{ $scratch := .Page.Scratch }}
+
+  {{ partial "page-header.html" . }}
+
+  {{- range site.Menus.syllabus }}
+  {{ $moduleURL := .URL }}
+  {{ $moduleTitle := .Title }}
+  <!-- We use hasShown variables to avoid printing headings for things which have no contents -->
+  {{ $scratch.Set "hasShownModuleTitle" false }}
+    {{ range sort (where .Page.Site.Pages "Section" .Page.Section) "Path" }}
+      {{ if not (and (eq .Layout "prep") (strings.Contains .Path "/sprints/")) }}
+        {{ continue }}
+      {{ end }}
+
+      <!-- This is a pretty sketchy way to make this link - I'm not sure why .URL doesn't work here... -->
+      {{ $weekURL := printf "/%s" (path.Dir .Path) }}
+      {{ $weekTheme := .Params.theme }}
+      {{ $allBlocks := .Params.blocks }}
+      {{ $scratch.Set "hasShownBlockTitle" false }}
+      {{ range $allBlocks }}
+
+        {{ if or .hide_from_overview (strings.Contains .src "https:") }}
+          {{ continue }}
+        {{ end }}
+
+        {{ $page := $site.GetPage .src }}
+        {{ if $page.Param "hide_from_overview" }}
+          {{ continue }}
+        {{ end }}
+
+        {{ if not ($scratch.Get "hasShownBlockTitle") }}
+          {{ if not ($scratch.Get "hasShownModuleTitle") }}
+            <h4><a href="{{ $moduleURL }}">{{ $moduleTitle }}</a></h4>
+            {{ $scratch.Set "hasShownModuleTitle" true }}
+          {{ end }}
+          <h5><a href="{{ $weekURL }}">{{ $weekTheme }}</a></h5>
+          <ol style="list-style-type: none;">
+          {{ $scratch.Set "hasShownBlockTitle" true }}
+        {{ end }}
+            <li>{{ $page.Title }}</li>
+        {{ end }}
+        {{ if $scratch.Get "hasShownBlockTitle" }}
+        </ol>
+      {{ end }}
+    {{ end }}
+  {{- end }}
+{{ end }}


### PR DESCRIPTION
It can be hard to tell at a glance what we teach when.

This adds a new page which collates each of the titles of each of the prep blocks.

I have some improvements I'm planning to make, but I think this is a stand-alone useful piece on its own.