### PR TITLE
add step-through-prep workshops

### DIFF
--- a/content/en/js1/sprints/4/prep/index.md
+++ b/content/en/js1/sprints/4/prep/index.md
@@ -10,6 +10,9 @@ backlog_filter= 'Week 4'
 src="js1/blocks/ordinal"
 name="ordinal"
 [[blocks]]
+name="Step-through-prep workshop"
+src="https://www.youtube.com/watch?v=2k_EtdVbb4c"
+[[blocks]]
 src="js1/blocks/framework"
 name="framework"
 [[blocks]]

--- a/content/en/js2/sprints/1/prep/index.md
+++ b/content/en/js2/sprints/1/prep/index.md
@@ -10,6 +10,9 @@ backlog_filter= 'Week 1'
 name="grouping-data"
 src="js2/blocks/grouping-data"
 [[blocks]]
+name="Step-through-prep workshop"
+src="https://www.youtube.com/watch?v=Hds02_3fQ58"
+[[blocks]]
 name="arrays"
 src="js2/blocks/arrays"
 [[blocks]]


### PR DESCRIPTION
## What does this change?

Module: JS1 Week 4, JS2 Week 1

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

Add step-through-prep workshops ( recordings of sessions with WM5 trainees on the prep view )
[JS2 Week 1 prep view](https://deploy-preview-514--cyf-curriculum.netlify.app/js2/sprints/1/prep/)
[JS1 Week 4 prep view](https://deploy-preview-514--cyf-curriculum.netlify.app/js1/sprints/4/prep/)


## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
