### PR TITLE
add first attempt js3 step-through-prep workshops

### DIFF
--- a/content/en/js3/sprints/1/prep/index.md
+++ b/content/en/js3/sprints/1/prep/index.md
@@ -10,6 +10,9 @@ backlog_filter= 'Week 1'
 name="data to ui"
 src="js3/blocks/data-ui"
 [[blocks]]
+name="Step-through-prep workshop"
+src="https://www.youtube.com/watch?v=HgbzMhJgdbU"
+[[blocks]]
 name="now-showing"
 src="js3/blocks/now-showing"
 [[blocks]]

--- a/content/en/js3/sprints/2/prep/index.md
+++ b/content/en/js3/sprints/2/prep/index.md
@@ -11,6 +11,9 @@ backlog_filter= 'Week 2'
 name="Reacting"
 src="js3/blocks/reacting"
 [[blocks]]
+name="Step-through-prep workshop"
+src="https://www.youtube.com/watch?v=j2Iz8ZNm3n8"
+[[blocks]]
 name="Decomposition"
 src="js3/blocks/break-down"
 [[blocks]]


### PR DESCRIPTION
## What does this change?

Module: JS3
Week(s): 1 & 2

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

Add first attempts at walking-through prep for JS3 Weeks 1 & 2

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
