### PR TITLE
add major change warning, see below

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+# WARNING MAJOR STRUCTURAL CHANGE IN PROGRESS 12 JAN 2024
+
+Hello contributor! In between you opening this PR and you merging it, you may find a large conflict appears. This is because this site will be broken down into Hugo modules in the same way CodeYourFuture/curriculum-labs is currently structured. The platform (features) will move into the common-theme module and the content (text) will move into the common-content module. The pages will move into the organisation directory. (org-cyf for CYF and org-mcb for MigraCode) You will need to find the new location of your content and move it there. If you are unsure, please ask in the comment thread of this ticket.
+
 ## What does this change?
 
 Module:


### PR DESCRIPTION
# WARNING MAJOR STRUCTURAL CHANGE IN PROGRESS 12 JAN 2024

Hello contributor! In between you opening this PR and you merging it, you may find a large conflict appears. This is because this site will be broken down into Hugo modules in the same way CodeYourFuture/curriculum-labs is currently structured. The platform (features) will move into the common-theme module and the content (text) will move into the common-content module. The pages will move into the organisation directory. (org-cyf for CYF and org-mcb for MigraCode) You will need to find the new location of your content and move it there. If you are unsure, please ask in the comment thread of this ticket.

## What does this change?

Module:
Week(s):

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
