### PR TITLE
archetypes for all required module views

### DIFF
--- a/archetypes/backlog.md
+++ b/archetypes/backlog.md
@@ -1,0 +1,13 @@
++++
+title = 'backlog'
+layout = 'backlog'
+emoji= '🥞'
+menu_level = ['sprint']
+weight = 2
+backlog= 'Module-Template'
+backlog_filter= 'Week 1'
++++
+
+This view lists all the issues for the current sprint. It is looking for a repo in your org named `Module-<module-name>` where it expects issues to live. You can edit this of course.
+
+Organise your issues with labels, like 'Week 1' or 'Week 2' to filter them into the right sprint. Pass the label into the `backlog_filter` in the front matter to filter the issues.

--- a/archetypes/blocks/index.md
+++ b/archetypes/blocks/index.md
@@ -1,0 +1,13 @@
++++
+title = '{{ replace .Name "-" " " | title }}'
+headless = true
+time = 30
+facilitation = false
+threads = ['to-be-assigned']
+emoji= '🧩'
+[objectives]
+    1='Use the Teach Tech Together guide to construct your objectives'
+    2='Limit the objectives to 3-5 items'
+    3='Write objectives you can measure'
++++
+

--- a/archetypes/day-plan.md
+++ b/archetypes/day-plan.md
@@ -1,0 +1,45 @@
++++
+title = 'day-plan'
+layout = 'day-plan'
+emoji= '📅'
+menu_level = ['sprint']
+weight = 3
+[[blocks]]
+name="Energiser"
+src="blocks/energiser"
+[[blocks]]
+name="PD Placeholder to be replaced with PD link"
+src="blocks/pd-placeholder"
+[[blocks]]
+name="Morning break"
+src="blocks/morning-break"
+[[blocks]]
+name="Placeholder Workshop"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/template"
+time="60"
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
+[[blocks]]
+name="Study Group 2"
+src="blocks/study-group"
+time="90"
+[[blocks]]
+name="Code Review"
+src="https://github.com/CodeYourFuture/Module-Template/pulls"
+time="0"
+[[blocks]]
+name="Afternoon break"
+src="blocks/afternoon-break"
+[[blocks]]
+name="Study Group 2"
+src="blocks/study-group"
+time="60"
+[[blocks]]
+name="Retro"
+src="blocks/retro"
++++
+
+This example day plan is a template for you to use. It is a good idea to have a consistent structure for your day plans so that everyone knows _what_ to do _when_. The day plan will create a schedule from the time (in minutes) stored on each block using the `time-stamper` web component. You can override this time by adding a `time` parameter in the front matter as shown above.
+
+This view doesn't expect any content in the `.Content` section; delete these instructions. If you want to add a description of the day, add it to a `.Description` parameter in the front matter.

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,5 @@
----
-title: "{{ replace .Name "-" " " | title }}"
-date: {{ .Date }}
-draft: true
----
++++
+title = '{{ replace .Name "-" " " | title }}'
++++
 
+This is just a single. You can use this to create an uncomplicated basic page. 

--- a/archetypes/module-prep.md
+++ b/archetypes/module-prep.md
@@ -1,0 +1,32 @@
++++
+title = 'prep'
+description = 'This work must be done to prepare for this module'
+layout = 'prep'
+emoji= '🧑🏾‍💻'
+menu_level = ['module']
+weight = 1
+[[blocks]]
+name="Local"
+src="blocks/types/local"
+[[blocks]]
+name="Readme"
+src="https://github.com/CodeYourFuture/Module-Template"
+[[blocks]]
+name="Youtube video or playlist"
+src="https://www.youtube.com/watch?v=P1ww1IXRfTA"
+[[blocks]]
+name="Slide - an image with caption"
+caption="With caption please!"
+src="https://github.com/MaggieAppleton/maggieappleton.com-V2/blob/main/public/images/posts/programming-pictures/PicturesProgramming-26_vnlzye-1100.jpg"
+[[blocks]]
+name="PD syllabus website"
+src="https://cyf-pd.netlify.app/blocks/agreements/readme/"
+[[blocks]]
+name="Issue, just one"
+src="https://github.com/CodeYourFuture/Module-JS1/issues/8"
+[[blocks]]
+name="Pullreqs, list"
+src="https://github.com/CodeYourFuture/Module-JS1"
++++
+## Anything written in .Content needs an h2
+This example prep view has an example of each type of block so you can see how the blocks work. 

--- a/archetypes/module-success.md
+++ b/archetypes/module-success.md
@@ -1,0 +1,11 @@
++++
+title = 'success'
+layout = 'success'
+emoji= '✅'
+menu_level = ['module']
+weight = 4
++++
+
+This view compiles learning objectives from the day plan and prep view into a checkbox list to help trainees check in on their progress.
+
+You can initiate a module level success view as well and write in some overall outcomes or success criteria.

--- a/archetypes/module.md
+++ b/archetypes/module.md
@@ -8,7 +8,7 @@ menu = ['syllabus']
 
 ### Quickstart
 
-Generate a template module by running` module_create.sh <module-name>` in the root of your website. This script produces a complete module structure with all the necessary files and folders from the Hugo archetypes stored in the `archetypes` folder. Create any single archetype by running `hugo new --kind $ARCHETYPE_NAME $PATH_TO_NEW_FILE`.
+Generate a template module by running `./module_create.sh <module-name>` in the root of your website. This script produces a complete module structure with all the necessary files and folders from the Hugo archetypes stored in the `archetypes` folder. Create any single archetype by running `hugo new --kind $ARCHETYPE_NAME $PATH_TO_NEW_FILE`.
 
 The template module contains a prep view to express all your entry criteria and setup instructions for the module, 4 template sprints to plan the weekly work, a product folder to organise the module project, and a success view to express the exit criteria and handoff details.
 

--- a/archetypes/module.md
+++ b/archetypes/module.md
@@ -1,0 +1,17 @@
++++
+title = '{{ replace .Name "-" " " | title }}'
+description = 'The plan for {{ replace .Name "-" " " | title }}'
+layout = 'module'
+emoji= '📚'
+menu = ['syllabus']
++++
+
+### Quickstart
+
+Generate a template module by running` module_create.sh <module-name>` in the root of your website. This script produces a complete module structure with all the necessary files and folders from the Hugo archetypes stored in the `archetypes` folder. Create any single archetype by running `hugo new --kind $ARCHETYPE_NAME $PATH_TO_NEW_FILE`.
+
+The template module contains a prep view to express all your entry criteria and setup instructions for the module, 4 template sprints to plan the weekly work, a product folder to organise the module project, and a success view to express the exit criteria and handoff details.
+
+Edit this basic setup to suit your needs. The module folder is located at content/$MODULE_NAME and it creates pages matching the folder structure on your website.
+
+If you don't want this module to show up on the default menu, remove `menu = ['syllabus']` from the front matter. The pages will still be accessible via the URLs.

--- a/archetypes/prep.md
+++ b/archetypes/prep.md
@@ -1,0 +1,32 @@
++++
+title = 'prep'
+description = 'Note the general topic'
+layout = 'prep'
+emoji= '🧑🏾‍💻'
+menu_level = ['sprint']
+weight = 1
+[[blocks]]
+name="Local"
+src="blocks/types/local"
+[[blocks]]
+name="Readme"
+src="https://github.com/CodeYourFuture/Module-Template"
+[[blocks]]
+name="Youtube video or playlist"
+src="https://www.youtube.com/watch?v=P1ww1IXRfTA"
+[[blocks]]
+name="Slide - an image with caption"
+caption="With caption please!"
+src="https://github.com/MaggieAppleton/maggieappleton.com-V2/blob/main/public/images/posts/programming-pictures/PicturesProgramming-26_vnlzye-1100.jpg"
+[[blocks]]
+name="PD syllabus website"
+src="https://cyf-pd.netlify.app/blocks/agreements/readme/"
+[[blocks]]
+name="Issue, just one"
+src="https://github.com/CodeYourFuture/Module-JS1/issues/8"
+[[blocks]]
+name="Pullreqs, list"
+src="https://github.com/CodeYourFuture/Module-JS1"
++++
+## Anything written in .Content needs an h2
+This example prep view has an example of each type of block so you can see how the blocks work. 

--- a/archetypes/product-backlog.md
+++ b/archetypes/product-backlog.md
@@ -1,0 +1,10 @@
++++
+title = 'backlog'
+layout = 'backlog'
+emoji= '🥞'
+menu_level = ['product']
+weight = 2
+backlog= 'React-Module-Project'
++++
+
+This view lists all the issues for the project. It is looking for a repo in your org named `React-Module-Project` where it expects issues to live. Wire in your actual project repo.

--- a/archetypes/product-prep.md
+++ b/archetypes/product-prep.md
@@ -1,0 +1,20 @@
++++
+title = 'prep'
+description = 'Wire in your repo docs, example given'
+layout = 'prep'
+emoji= '🧑🏾‍💻'
+menu_level = ['product']
+weight = 1
+[[blocks]]
+name="Planning and organising your team"
+src="https://github.com/CodeYourFuture/React-Module-Project/tree/main/docs/plan/"
+[[blocks]]
+name="Building your product"
+src="https://github.com/CodeYourFuture/React-Module-Project/tree/main/docs/build/"
+[[blocks]]
+name="Test driven development"
+src="https://github.com/CodeYourFuture/React-Module-Project/tree/main/docs/test/"
+[[blocks]]
+name="Shipping your product"
+src="https://github.com/CodeYourFuture/React-Module-Project/tree/main/docs/ship/"
++++

--- a/archetypes/product.md
+++ b/archetypes/product.md
@@ -1,0 +1,11 @@
++++
+title = 'Product'
+description = 'The module project for {{ replace .Name "-" " " | title }}'
+layout = 'product'
+emoji= '🎁'
+menu_level = ['module']
++++
+
+Each module should have a module-length project that produces a tangible product. These products form a starting point for trainee portfolios, and are mandatory for progression. 
+
+The actual instructions are generally pulled from the project repo. 

--- a/archetypes/sprint.md
+++ b/archetypes/sprint.md
@@ -1,0 +1,9 @@
++++
+title = 'Sprint {{ replace .Name "-" " " | title }}'
+layout = 'sprint'
+emoji= '🎽'
+menu_level = ['module']
+weight = 2
++++
+
+This is an index to organise the views for a sprint block. If you want to remove this sprint from the menu, remove the `menu_level` parameter from the front matter. We don't use Hugo menus as Hugo doesn't like having duplicate items, but we want all our modules and sprints to have consistent, repeated (predictable) names. 

--- a/archetypes/success.md
+++ b/archetypes/success.md
@@ -1,0 +1,11 @@
++++
+title = 'success'
+layout = 'success'
+emoji= '✅'
+menu_level = ['sprint']
+weight = 4
++++
+
+This view compiles learning objectives from the day plan and prep view into a checkbox list to help trainees check in on their progress.
+
+You can initiate a module level success view as well and write in some overall outcomes or success criteria.

--- a/create_module.sh
+++ b/create_module.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-
-if [ -z "$1" ]
-  then
+# You need to name the module
+if [ -z "$1" ]; then
     echo "No module name supplied. Usage: ./create_module.sh <module_name>"
     exit 1
 fi
@@ -9,120 +8,38 @@ fi
 MODULE_NAME=$1
 MODULE_DIR="content/$MODULE_NAME"
 SPRINT_DIR="$MODULE_DIR/sprints"
-BLOCKS_DIR="$MODULE_DIR/blocks"
 PRODUCT_DIR="$MODULE_DIR/product"
 
-mkdir -p $MODULE_DIR
-mkdir -p $SPRINT_DIR
-mkdir -p $BLOCKS_DIR
-mkdir -p $PRODUCT_DIR
+# Main module index
+hugo new --kind module "$MODULE_DIR/_index.md"
 
-echo "+++
-title = '$MODULE_NAME'
-description = 'The plan for $MODULE_NAME'
-layout = 'module'
-emoji= '📚'
-menu = ['syllabus']
-+++
+# Module has at top level: prep/ sprints/ product/ success/. 
+# Sprints and Product are dirs containing further dirs
 
-" > $MODULE_DIR/_index.md
-
-FILES=("prep" "backlog" "success")
-MENU_ORDER=1
+FILES=("prep" "success")
 for file in "${FILES[@]}"; do
-  mkdir -p $MODULE_DIR/$file
-  echo "+++
-title = '$file'
-description = '$file description'
-layout = '$file'
-emoji= '📝'
-menu_level = ['module']
-weight = $MENU_ORDER
-backlog= 'Module-$MODULE_NAME'
-backlog_filter= '$MODULE_NAME'
-+++
-
-" > $MODULE_DIR/$file/index.md
-  MENU_ORDER=$((MENU_ORDER + 5))
+    FILE_PATH="$MODULE_DIR/$file/index.md"
+    hugo new --kind "module-$file" "$FILE_PATH"
 done
+
+# Make sprint folders. Sprints have prep backlog day-plan success
 
 for i in {1..4}; do
-  SPRINT_NAME="$i"
-  SPRINT_PATH="$SPRINT_DIR/$SPRINT_NAME"
-  mkdir -p $SPRINT_PATH
-  echo "+++
-title = 'Sprint $i'
-description = 'The plan for the week'
-layout = 'sprint'
-emoji= '⏱️'
-menu_level = ['module']
-weight = $((i + 1))
-+++
+    SPRINT_NAME="$i"
+    SPRINT_PATH="$SPRINT_DIR/$SPRINT_NAME"
 
-" > $SPRINT_PATH/_index.md
-
-  SPRINT_FILES=("prep" "backlog" "day-plan" "success")
-  MENU_ORDER=1
-
-  for file in "${SPRINT_FILES[@]}"; do
-    mkdir -p $SPRINT_PATH/$file
-    echo "+++
-title = '$file'
-layout = '$file'
-emoji= '📝'
-menu_level = ['sprint']
-weight = $MENU_ORDER
-backlog= 'Module-$MODULE_NAME'
-backlog_filter= 'Week $i'
-+++
-
-" > $SPRINT_PATH/$file/index.md
-MENU_ORDER=$((MENU_ORDER + 1))
-  done
+    SPRINT_FILES=("prep" "backlog" "day-plan" "success")
+    for file in "${SPRINT_FILES[@]}"; do
+        FILE_PATH="$SPRINT_PATH/$file/index.md"
+        hugo new --kind "$file" "$FILE_PATH"
+    done
 done
 
-BLOCKS=("block1" "block2" "block3")
+# Make product dir. Product has prep backlog success
+hugo new --kind product "$PRODUCT_DIR/_index.md"
 
-for block in "${BLOCKS[@]}"; do
-  mkdir -p $BLOCKS_DIR/$block
-  echo "+++
-title = '$block'
-headless = true
-time = 30
-facilitation = false
-emoji= '🧩'
-[objectives]
-    1='Use the Teach Tech Together guide to construct your objectives'
-    2='Limit the objectives to 3-5 items'
-    3='Write objectives you can measure'
-+++
-
-" > $BLOCKS_DIR/$block/index.md
-done
-
-PRODUCT_FILES=("plan" "build" "test" "ship")
-echo "+++
-title = 'Product'
-description = 'Product description'
-layout = 'product'
-emoji= '🎁'
-menu_level = ['module']
-+++
-
-" > $PRODUCT_DIR/_index.md
-
-MENU_ORDER=1
-for product_file in "${PRODUCT_FILES[@]}"; do
-  mkdir -p $PRODUCT_DIR/$product_file
-  echo "+++
-title = '$product_file'
-description = '$product_file description'
-layout = '$product_file'
-menu_level = ['product']
-emoji= '🎁'
-weight = $MENU_ORDER
-+++
-
-" > $PRODUCT_DIR/$product_file/index.md
-  MENU_ORDER=$((MENU_ORDER + 1))
+PRODUCT_FILES=("prep" "backlog" "success")
+for file in "${PRODUCT_FILES[@]}"; do
+    FILE_PATH="$PRODUCT_DIR/$file/index.md"
+    hugo new --kind "product-$file" "$FILE_PATH"
 done


### PR DESCRIPTION
This moves page creation into Hugo archetypes. You can still run a create_module.sh to produce a module all at once, it will just do it by calling archetypes. You can also generate any individual view from an archetype, and generate a block, with hugo new --kind

https://gohugo.io/content-management/archetypes/

This is necessary for the modularisation change upcoming. #421 
