### PR TITLE
add step -> prep workshops for JS2 & JS3

### DIFF
--- a/content/en/js2/sprints/2/prep/index.md
+++ b/content/en/js2/sprints/2/prep/index.md
@@ -19,6 +19,9 @@ name="Access"
 src="js2/blocks/query-string"
 name="Query string"
 [[blocks]]
+name="Step-through-prep workshop"
+src="https://www.youtube.com/watch?v=GeKL1Mer4x8"
+[[blocks]]
 src="js2/blocks/no-params"
 name="No params"
 [[blocks]]

--- a/content/en/js2/sprints/3/prep/index.md
+++ b/content/en/js2/sprints/3/prep/index.md
@@ -13,6 +13,9 @@ name="browser"
 src="js2/blocks/character-limit"
 name="character-limit"
 [[blocks]]
+name="Step-through-prep workshop"
+src="https://www.youtube.com/watch?v=0tI34jHLpkY"
+[[blocks]]
 src="js2/blocks/plan"
 name="strategy"
 [[blocks]]

--- a/content/en/js3/sprints/3/prep/index.md
+++ b/content/en/js3/sprints/3/prep/index.md
@@ -10,6 +10,9 @@ backlog_filter= 'Week 3'
 name="Fetching data"
 src="js3/blocks/fetching-data"
 [[blocks]]
+name="Step-through-prep workshop"
+src="https://www.youtube.com/watch?v=J-0XkB54yp8"
+[[blocks]]
 name="Latency"
 src="js3/blocks/latency"
 [[blocks]]


### PR DESCRIPTION
# WARNING MAJOR STRUCTURAL CHANGE IN PROGRESS 12 JAN 2024

Hello contributor! In between you opening this PR and you merging it, you may find a large conflict appears. This is because this site will be broken down into Hugo modules in the same way CodeYourFuture/curriculum-labs is currently structured. The platform (features) will move into the common-theme module and the content (text) will move into the common-content module. The pages will move into the organisation directory. (org-cyf for CYF and org-mcb for MigraCode) You will need to find the new location of your content and move it there. If you are unsure, please ask in the comment thread of this ticket.

## What does this change?

Module: JS2 Week 2, Week 3 & JS3 Week 3

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

Add step through prep workshops for JS2 Week 2, JS2 Week 3, JS3 Week 3. Each of the prep views below should have a step -> prep block:

[JS3 Sprint 3 prep view](https://deploy-preview-533--cyf-curriculum.netlify.app/js3/sprints/3/prep/#step-through-prep-workshopl)
[JS2 Sprint 2 prep view](https://deploy-preview-533--cyf-curriculum.netlify.app/js2/sprints/2/prep/#step-through-prep-workshopl)
[JS2 Sprint 3 prep view](https://deploy-preview-533--cyf-curriculum.netlify.app/js2/sprints/3/prep/#step-through-prep-workshopl)

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
