### PR TITLE
restore js3 prep workshops

### DIFF
--- a/org-cyf/content/js3/sprints/1/prep/index.md
+++ b/org-cyf/content/js3/sprints/1/prep/index.md
@@ -13,6 +13,9 @@ src="module/js3/data-ui"
 name="now-showing"
 src="module/js3/now-showing"
 [[blocks]]
+name="Step-through-prep workshop"
+src="https://www.youtube.com/watch?v=HgbzMhJgdbU"
+[[blocks]]
 name="single-datum"
 src="module/js3/single-datum"
 [[blocks]]

--- a/org-cyf/content/js3/sprints/2/prep/index.md
+++ b/org-cyf/content/js3/sprints/2/prep/index.md
@@ -11,6 +11,9 @@ backlog_filter= 'Week 2'
 name="Reacting"
 src="module/js3/reacting"
 [[blocks]]
+name="Step-through-prep workshop"
+src="https://www.youtube.com/watch?v=j2Iz8ZNm3n8"
+[[blocks]]
 name="Decomposition"
 src="module/js3/break-down"
 [[blocks]]


### PR DESCRIPTION
## What does this change?

Module: JS3
Week(s): Sprint 1 & 2

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

Restores prep workshops to JS3 Sprint 1 & 2

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
