### PR TITLE
Fix environment setup in new structure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Allow accessing a GitHub bearer token to avoid rate limits when doing HTTP fetches to the GitHub API.
 # This can be generated at https://github.com/settings/tokens?type=beta and needs read-only access to all public CYF GitHub repos.
-CYF_CURRICULUM_GITHUB_BEARER_TOKEN=""
+HUGO_CURRICULUM_GITHUB_BEARER_TOKEN=""
 # Client ID and secret for the GitHub OAuth app used to authenticate users.
 GITHUB_CLIENT_ID="clientid"
 GITHUB_CLIENT_SECRET="clientsecret"

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ For each module you import, add a `replace` directive to your `go.mod` file - if
 
 ## To locally develop your site
 
-`cd` into the site you wish to develop, and run `hugo server` to get a live preview.
+Check [org-cyf/README.md](/org-cyf/README.md) on how to set up your local environment. Once that is done you can `cd` into the site you wish to develop, and run `npm run start:dev` to get a live preview.

--- a/org-cyf/README.md
+++ b/org-cyf/README.md
@@ -38,7 +38,7 @@ The "Repository access" you need is "Public repositories (read-only)", and you d
 
 #### Set up `.env`
 
-Copy the `.env.example` file over and name it `.env`. Edit the file and then change the line that says `CYF_CURRICULUM_GITHUB_BEARER_TOKEN` to contain the token that you have generated earlier.
+Copy the `.env.example` file over and name it `.env`. Edit the file and then change the line that says `HUGO_CURRICULUM_GITHUB_BEARER_TOKEN` to contain the token that you have generated earlier.
 
 #### Run this command
 

--- a/org-cyf/package.json
+++ b/org-cyf/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start:dev": "dotenv -- hugo server -p 3000 -D"
+    "start:dev": "dotenv -e ../.env -- hugo server --environment issues-are-cached-and-incomplete",
+    "build:dev": "dotenv -e ../.env  -- hugo --environment issues-are-cached-and-incomplete"
   },
   "keywords": [],
   "author": "",

--- a/org-mcb/package.json
+++ b/org-mcb/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start:dev": "dotenv -- hugo server --environment issues-are-cached-and-incomplete",
-    "build:dev": "dotenv -- hugo --environment issues-are-cached-and-incomplete"
+    "start:dev": "dotenv -e ../.env -- hugo server --environment issues-are-cached-and-incomplete",
+    "build:dev": "dotenv -e ../.env  -- hugo --environment issues-are-cached-and-incomplete"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The GITHUB TOKEN's environment name has changed recently but this was not reflected in the readme and the .env configs. This change also makes sure that the .env file values are proeprly picked up, and that the README is updated to help new users be able to set up their local dev environment quicker
