### PR TITLE
Content: React workshops on day plans plus simplified orientation block

### DIFF
--- a/common-content/en/blocks/morning-orientation/index.md
+++ b/common-content/en/blocks/morning-orientation/index.md
@@ -9,33 +9,45 @@ time=15
 +++
 
 {{<note title="Planning during the week" type="info">}}
-🧭 Step 1 and step 6 can be done earlier in the week. Create a post on Slack and get some people to take on the roles of **timekeeper** and **facilitator**. Nominate people who've not done it before.
+🧭 During the week, create a post on Slack and get some people to take on the roles of **facilitator** and **timekeeper**. Nominate new people each time.
 {{</note>}}
 
 # 👣 Steps
 
-0. Assemble the entire group (all volunteers & all trainees) in a circle
-1. Choose someone (volunteer or trainee) to be a **facilitator** for this morning orientation block
-2. The **facilitator** should briefly welcome everyone with an announcement. Here is an example announcement to read aloud:
+If you haven't done so already, choose someone (volunteer or trainee) to be the **facilitator** for this morning orientation block. Choose another to be the **timekeeper**.
 
-> 💬 "Morning everyone, Welcome to CYF {REGION}, this week we are working on {MODULE HERE} {SPRINT NUMBER HERE} and we're currently working on {SUMMARISE THE TOPICS OF THE WEEK}"
+<details>
+<summary>
 
-3. Check if there are any new volunteers or if there are some attendees who haven't met before. Ask any newcomers to introduce themselves to the group/relevant people
+### 🎙️ The Facilitator will:
 
-4. Check if it is the _start of a new module_. In other words, are you working on sprint 1? If so then ask someone to read out the success criteria for the new module you have started.
+</summary>
 
-5. Go through the _morning day plan only_ (typically on the curriculum website) - check the following things:
+1. Assemble the entire group (all volunteers & all trainees) in a circle
+1. Briefly welcome everyone with an announcement, like this:
+   > 💬 "Morning everyone, Welcome to CYF {REGION}, this week we are working on {MODULE} {SPRINT} and we're currently working on {SUMMARISE THE TOPICS OF THE WEEK}"
+1. Ask any newcomers to introduce themselves to the group, and welcome them.
+1. Now check: is it the _start of a new module_? Is it sprint 1? If so, read out the success criteria for the new module.
+1. Next go through the _morning day plan only_ (typically on the curriculum website) - and check the following things:
 
-- Check the number of Tech-Ed / PD volunteers you have for the morning
-- Double-check check someone is leading a given session
-- For any new activities ( like workshops or anything unfamiliar) - describe how this block works for the group. If there are any new volunteers, then briefly describe how that block works
-- Decide how best to allocate trainees and volunteers for a given block - some blocks will make this clear
+#### Facilitator Checklist
 
-6. Nominate a timekeeper (volunteer or trainee) from the group - aim for someone who hasn't done it before.
+- [ ] Check the number of volunteers you have for the morning
+- [ ] Check someone is leading each session
+- [ ] Describe how any new activities works for the group
+- [ ] Decide how best to allocate trainees and volunteers for a given block - most blocks will make this clear
 
-⏱️ Timekeepers will need to:
+</details>
 
-- Announce the start of an activity and how long it will take (check everyone is listening)
-- Manage any whole class timers that are used in an activity
-- Give people a 10-minute wrap-up warning before the end of an activity
-- Announce the end of an activity and what happens next
+<details>
+<summary>
+
+### ⏰ The Timekeeper will:
+
+</summary>
+
+- [ ] Announce the start of an activity and how long it will take (check everyone is listening)
+- [ ] Manage any whole class timers that are used in an activity
+- [ ] Give people a 10-minute wrap-up warning before the end of an activity
+- [ ] Announce the end of an activity and what happens next
+</details>

--- a/common-theme/assets/styles/03-elements/misc-phrasing.scss
+++ b/common-theme/assets/styles/03-elements/misc-phrasing.scss
@@ -57,7 +57,6 @@ summary {
 }
 summary > * {
   display: inline-block;
-  vertical-align: text-bottom;
   margin: 0;
 }
 summary::marker {

--- a/org-cyf/content/react/sprints/1/day-plan/index.md
+++ b/org-cyf/content/react/sprints/1/day-plan/index.md
@@ -7,8 +7,13 @@ weight = 3
 backlog= 'Module-React'
 backlog_filter= 'Week 1'
 [[blocks]]
+name="Orientation"
+src="morning-orientation"
+time=15
+[[blocks]]
 name="Energiser"
 src="blocks/energiser"
+time=10
 [[blocks]]
 name="Resilience"
 src="https://cyf-pd.netlify.app/blocks/resilience/readme/"
@@ -16,16 +21,16 @@ src="https://cyf-pd.netlify.app/blocks/resilience/readme/"
 name="Morning break"
 src="blocks/morning-break"
 [[blocks]]
-name="Placeholder Workshop"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/template"
-time="60"
+name="Pokedex Workshop"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/react-pokedex/pokedex-1"
+time="90"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"
 [[blocks]]
 name="React Hotel: Working in teams"
 src="module/react/team-project"
-time="90"
+time="60"
 [[blocks]]
 name="Code Review"
 src="https://github.com/CodeYourFuture/Module-React/pulls"
@@ -34,9 +39,9 @@ time="0"
 name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
-name="Study Group 2"
+name="Study Group"
 src="blocks/study-group"
-time="60"
+time="70"
 [[blocks]]
 name="Code Review"
 src="https://github.com/CodeYourFuture/React-Module-Project/pulls"

--- a/org-cyf/content/react/sprints/2/day-plan/index.md
+++ b/org-cyf/content/react/sprints/2/day-plan/index.md
@@ -7,8 +7,13 @@ weight = 3
 backlog= 'Module-React'
 backlog_filter= 'Week 2'
 [[blocks]]
+name="Orientation"
+src="morning-orientation"
+time=10
+[[blocks]]
 name="Energiser"
 src="blocks/energiser"
+time=10
 [[blocks]]
 name="Problem Solving"
 src="https://cyf-pd.netlify.app/blocks/problem-solving/readme/"
@@ -16,9 +21,9 @@ src="https://cyf-pd.netlify.app/blocks/problem-solving/readme/"
 name="Morning break"
 src="blocks/morning-break"
 [[blocks]]
-name="Placeholder Workshop"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/template"
-time="60"
+name="Pokedex Workshop"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/react-pokedex/pokedex-2"
+time="70"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"
@@ -33,9 +38,9 @@ time="0"
 name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
-name="Study Group 2"
-src="blocks/study-group"
-time="60"
+name="React Hotel: Working in teams"
+src="module/react/team-project"
+time="80"
 [[blocks]]
 name="Code Review"
 src="https://github.com/CodeYourFuture/React-Module-Project/pulls"

--- a/org-cyf/content/react/sprints/3/day-plan/index.md
+++ b/org-cyf/content/react/sprints/3/day-plan/index.md
@@ -7,8 +7,9 @@ weight = 3
 backlog= 'Module-React'
 backlog_filter= 'Week 3'
 [[blocks]]
-name="Energiser"
-src="blocks/energiser"
+name="Orientation"
+src="morning-orientation"
+time=20
 [[blocks]]
 name="WIP And Feedback"
 src="https://cyf-pd.netlify.app/blocks/wip-and-feedback/readme/"
@@ -16,9 +17,9 @@ src="https://cyf-pd.netlify.app/blocks/wip-and-feedback/readme/"
 name="Morning break"
 src="blocks/morning-break"
 [[blocks]]
-name="Placeholder Workshop"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/template"
-time="60"
+name="Pokedex Workshop"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/react-pokedex/pokedex-3"
+time="90"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"
@@ -33,13 +34,9 @@ time="0"
 name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
-name="Study Group 2"
-src="blocks/study-group"
-time="60"
-[[blocks]]
-name="Code Review"
-src="https://github.com/CodeYourFuture/React-Module-Project/pulls"
-time="0"
+name="React Hotel: Working in teams"
+src="module/react/team-project"
+time="75"
 [[blocks]]
 name="Retro"
 src="blocks/retro"

--- a/org-cyf/content/react/sprints/4/day-plan/index.md
+++ b/org-cyf/content/react/sprints/4/day-plan/index.md
@@ -7,8 +7,13 @@ weight = 3
 backlog= 'Module-React'
 backlog_filter= 'Week 4'
 [[blocks]]
+name="Orientation"
+src="morning-orientation"
+time=10
+[[blocks]]
 name="Energiser"
 src="blocks/energiser"
+time=10
 [[blocks]]
 name="Diversity and Inclusion"
 src="https://cyf-pd.netlify.app/blocks/diversity-and-inclusion/readme/"
@@ -16,9 +21,9 @@ src="https://cyf-pd.netlify.app/blocks/diversity-and-inclusion/readme/"
 name="Morning break"
 src="blocks/morning-break"
 [[blocks]]
-name="Placeholder Workshop"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/template"
-time="60"
+name="Pokedex Workshop"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/react-pokedex/pokedex-4"
+time="45"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"
@@ -34,8 +39,8 @@ time="0"
 name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
-name="Study Group 2"
-src="blocks/study-group"
+name="React Hotel: Working in teams"
+src="module/react/team-project"
 time="60"
 [[blocks]]
 name="Code Review"


### PR DESCRIPTION

## What does this change?

Module: React day plans
Week(s): 1 2 3 4 

Also morning-orientation block, which I have added to every week on this day plan and therefore looked at more and simplified it -- it was a bit baggy.

Nobody reviewed the React workshops and they languished for 6 weeks. WM5 is approaching so I have merged them. They are just the pokedex workshops from the old syllabus, so not new material. However, if anyone has edits please open prs to cyf-workshops!

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

<!-- Add a description of what your PR changes here -->

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
