### PR TITLE
586 Launch content isn't showing on Curriculum

### DIFF
--- a/org-cyf/content/the-launch/_index.md
+++ b/org-cyf/content/the-launch/_index.md
@@ -1,6 +1,6 @@
 +++
 title = 'The Launch'
-description = 'The Launch is in development.'
+description = 'Work together in a cross functional Agile team to design, develop, and deliver a unique full stack web application'
 layout = 'module'
 emoji= '🚀'
 menu = ['syllabus']

--- a/org-cyf/content/the-launch/prep/index.md
+++ b/org-cyf/content/the-launch/prep/index.md
@@ -1,8 +1,8 @@
 +++
 title = 'prep'
-description = 'prep description'
+description = 'Getting ready to launch'
 layout = 'prep'
-emoji= '🧑🏿‍'
+emoji= '🧑🏾‍💻'
 menu_level = ['module']
 weight = 1
 backlog= 'Module-The-Launch'

--- a/org-cyf/content/the-launch/sprints/1/day-plan/index.md
+++ b/org-cyf/content/the-launch/sprints/1/day-plan/index.md
@@ -6,4 +6,34 @@ menu_level = ['sprint']
 weight = 3
 backlog= 'Module-The-Launch'
 backlog_filter= 'Week 1'
+[[blocks]]
+name="Energiser"
+src="https://cyf-pd.netlify.app/blocks/employability-energiser/readme/"
+[[blocks]]
+name="Launch overview"
+src="https://cyf-pd.netlify.app/blocks/what-is-the-launch-module/readme/"
+[[blocks]]
+name="Morning Break"
+src="blocks/morning-break"
+[[blocks]]
+name="Prep your product"
+src="https://cyf-pd.netlify.app/blocks/prep-and-plan-your-product/readme/"
+[[blocks]]
+name="Design your product"
+src="https://cyf-pd.netlify.app/blocks/design-your-product/readme/"
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
+[[blocks]]
+name="Writing user stories"
+src="https://cyf-pd.netlify.app/blocks/writing-user-stories/readme/"
+[[blocks]]
+name="Sprint planning"
+src="https://cyf-pd.netlify.app/blocks/sprint-planning/readme/"
+[[blocks]]
+name="Afternoon Break"
+src="blocks/afternoon-break"
+[[blocks]]
+name="Project Work"
+src="module/portfolio/project"
 +++

--- a/org-cyf/content/the-launch/sprints/1/prep/index.md
+++ b/org-cyf/content/the-launch/sprints/1/prep/index.md
@@ -1,9 +1,13 @@
 +++
 title = 'prep'
 layout = 'prep'
-emoji= '🧑🏿‍'
+description='Launching your Agile team'
+emoji= '🧑🏾‍💻'
 menu_level = ['sprint']
 weight = 1
 backlog= 'Module-The-Launch'
 backlog_filter= 'Week 1'
+[[blocks]]
+name="Prep for Launch"
+src="https://cyf-pd.netlify.app/blocks/launch-prep/readme/"
 +++

--- a/org-cyf/content/the-launch/sprints/2/day-plan/index.md
+++ b/org-cyf/content/the-launch/sprints/2/day-plan/index.md
@@ -1,9 +1,34 @@
 +++
 title = 'day-plan'
+description='Your CI/CD codebase is ready for features'
 layout = 'day-plan'
 emoji= '🧑🏽‍🤝‍🧑🏽'
 menu_level = ['sprint']
 weight = 3
 backlog= 'Module-The-Launch'
 backlog_filter= 'Week 2'
+[[blocks]]
+name="Energiser"
+src="https://cyf-pd.netlify.app/blocks/employability-energiser/readme/"
+[[blocks]]
+name="Demo Time"
+src="https://cyf-pd.netlify.app/blocks/demo-time/readme/"
+[[blocks]]
+name="Morning Break"
+src="blocks/morning-break"
+[[blocks]]
+name="Retrospective"
+src="https://cyf-pd.netlify.app/blocks/retrospective/readme/"
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
+[[blocks]]
+name="Sprint Planning"
+src="https://cyf-pd.netlify.app/blocks/sprint-planning/readme/"
+[[blocks]]
+name="Afternoon Break"
+src="blocks/afternoon-break"
+[[blocks]]
+name="Project work"
+src="module/portfolio/project"
 +++

--- a/org-cyf/content/the-launch/sprints/2/prep/index.md
+++ b/org-cyf/content/the-launch/sprints/2/prep/index.md
@@ -1,9 +1,16 @@
 +++
 title = 'prep'
+description='Your product is deployed, but it has no features!'
 layout = 'prep'
-emoji= '🧑🏿‍'
+emoji= '🧑🏾‍💻'
 menu_level = ['sprint']
 weight = 1
 backlog= 'Module-The-Launch'
 backlog_filter= 'Week 2'
+[[blocks]]
+name="Prep your Demo"
+src="https://cyf-pd.netlify.app/blocks/prep-launch-week-2/readme/"
+[[blocks]]
+name="User research"
+src="https://cyf-pd.netlify.app/blocks/user-research/readme/"
 +++

--- a/org-cyf/content/the-launch/sprints/3/day-plan/index.md
+++ b/org-cyf/content/the-launch/sprints/3/day-plan/index.md
@@ -1,9 +1,34 @@
 +++
 title = 'day-plan'
+description = 'Features features features'
 layout = 'day-plan'
 emoji= '🧑🏽‍🤝‍🧑🏽'
 menu_level = ['sprint']
 weight = 3
 backlog= 'Module-The-Launch'
 backlog_filter= 'Week 3'
+[[blocks]]
+name="Energiser"
+src="https://cyf-pd.netlify.app/blocks/employability-energiser/readme/"
+[[blocks]]
+name="Demo Time"
+src="https://cyf-pd.netlify.app/blocks/demo-time/readme/"
+[[blocks]]
+name="Morning Break"
+src="blocks/morning-break"
+[[blocks]]
+name="Retrospective"
+src="https://cyf-pd.netlify.app/blocks/retrospective/readme/"
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
+[[blocks]]
+name="Sprint Planning"
+src="https://cyf-pd.netlify.app/blocks/sprint-planning/readme/"
+[[blocks]]
+name="Afternoon Break"
+src="blocks/afternoon-break"
+[[blocks]]
+name="Project work"
+src="module/portfolio/project"
 +++

--- a/org-cyf/content/the-launch/sprints/3/prep/index.md
+++ b/org-cyf/content/the-launch/sprints/3/prep/index.md
@@ -1,9 +1,16 @@
 +++
 title = 'prep'
+description='Building features and reviewing PRs'
 layout = 'prep'
-emoji= '🧑🏿‍'
+emoji= '🧑🏾‍💻'
 menu_level = ['sprint']
 weight = 1
 backlog= 'Module-The-Launch'
 backlog_filter= 'Week 3'
+[[blocks]]
+name="Prep your Demo"
+src="https://cyf-pd.netlify.app/blocks/prep-launch-week-2/readme/"
+[[blocks]]
+name="User research"
+src="https://cyf-pd.netlify.app/blocks/user-research/readme/"
 +++

--- a/org-cyf/content/the-launch/sprints/4/day-plan/index.md
+++ b/org-cyf/content/the-launch/sprints/4/day-plan/index.md
@@ -6,4 +6,28 @@ menu_level = ['sprint']
 weight = 3
 backlog= 'Module-The-Launch'
 backlog_filter= 'Week 4'
+[[blocks]]
+name="Energiser"
+src="https://cyf-pd.netlify.app/blocks/employability-energiser/readme/"
+[[blocks]]
+name="Demo Time"
+src="https://cyf-pd.netlify.app/blocks/demo-time/readme/"
+[[blocks]]
+name="Morning Break"
+src="blocks/morning-break"
+[[blocks]]
+name="Retrospective"
+src="https://cyf-pd.netlify.app/blocks/retrospective/readme/"
+[[blocks]]
+name="Lunch"
+src="blocks/lunch"
+[[blocks]]
+name="Sprint Planning"
+src="https://cyf-pd.netlify.app/blocks/sprint-planning/readme/"
+[[blocks]]
+name="Afternoon Break"
+src="blocks/afternoon-break"
+[[blocks]]
+name="Project work"
+src="module/portfolio/project"
 +++

--- a/org-cyf/content/the-launch/sprints/4/prep/index.md
+++ b/org-cyf/content/the-launch/sprints/4/prep/index.md
@@ -1,9 +1,16 @@
 +++
 title = 'prep'
 layout = 'prep'
-emoji= '🧑🏿‍'
+description='Your product is viable and the team is ready to launch'
+emoji= '🧑🏾‍💻'
 menu_level = ['sprint']
 weight = 1
 backlog= 'Module-The-Launch'
 backlog_filter= 'Week 4'
+[[blocks]]
+name="Prep your Demo"
+src="https://cyf-pd.netlify.app/blocks/prep-launch-week-2/readme/"
+[[blocks]]
+name="User research"
+src="https://cyf-pd.netlify.app/blocks/user-research/readme/"
 +++


### PR DESCRIPTION
1. Restore the Launch links which got overwritten when we did the mega merge.  This is because these PRs were merged in during the changeover - bad timing. Fixes #586 

2. Also restored the old emoji as the staring girl alarmed me. 

3. Added short descriptions which can be edited

4. I'm not keen on these mega tabs. Can we perhaps use issues here? Or local blocks? The tabbed view as the only view seems hard to read. We can add specific issues to the prep view and use those tabs.

5. It seems like entry criteria should go in module/prep and exit criteria in module/success now we have those things