### PR TITLE
Feature: turn on taxonomies

### DIFF
--- a/org-cyf/hugo.toml
+++ b/org-cyf/hugo.toml
@@ -1,5 +1,11 @@
 title = "CYF Curriculum"
 
+
+[taxonomies]
+  category = 'categories' # Content types are blocks, definitions, guides
+  tag = 'themes'
+
+
 [module]
   [[module.imports]]
     path = "github.com/CodeYourFuture/curriculum/common-theme" 
@@ -59,7 +65,6 @@ guessSyntax = true
 # Enable HTML codeblocks, e.g. for <details> blocks
 unsafe = true
 hardWraps = true
-disableKinds = ["taxonomy", "term"]
 footnote= true
 
 


### PR DESCRIPTION
## What does this change?


### Org Content?

hugo.toml -- config

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

I'm turning on taxonomies. 

I'll go through and update common content with some categories. Here's my general concept:

categories= ['block', 'guide', 'term'] // the category of content
themes = ['state', 'side-effects'] // the learning theme 

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
