### PR TITLE
add feedback button

### DIFF
--- a/common-theme/assets/styles/04-components/block.scss
+++ b/common-theme/assets/styles/04-components/block.scss
@@ -26,6 +26,10 @@
     scroll-margin-top: var(--theme-spacing--scrollmargin);
   }
 
+  &__feedback {
+    margin: auto 0 auto auto;
+  }
+
   &--youtube {
     text-align: center;
     padding: var(--theme-spacing--4) 0;

--- a/common-theme/assets/styles/04-components/block.scss
+++ b/common-theme/assets/styles/04-components/block.scss
@@ -12,6 +12,7 @@
     justify-content: space-between;
     align-items: center;
     margin: var(--theme-spacing--1) 0 var(--theme-spacing--gutter) 0;
+    gap: var(--theme-spacing--gutter);
   }
 
   &__series {

--- a/common-theme/hugo.toml
+++ b/common-theme/hugo.toml
@@ -34,6 +34,7 @@ org = "https://github.com/YOUR_ORG_HERE"
 repo = "https://github.com/YOUR_ORG_HERE/YOUR_REPO/"
 root = "YOUR_REPO_I_THINK"
 orgapi = "https://api.github.com/repos/YOUR_ORG_HERE/"
+pdrepo = "PD-curriculum-repo"
 # We use a proxy which concatenates paginated responses, otherwise we miss results.
 # Daniel is currently hosting this code https://github.com/illicitonion/github-issue-proxy but we should work out a long-term maintainable solution to this problem.
 issuesorgapi = "https://github-issue-proxy.illicitonion.com/repos/CodeYourFuture/"

--- a/common-theme/layouts/_default/day-plan.html
+++ b/common-theme/layouts/_default/day-plan.html
@@ -9,7 +9,7 @@
       <div class="c-block__series c-block__series--timeline">
         {{ range $index, $block := .Params.blocks }}
 
-          {{ partial "block/block.html" (dict "block" $block "Page" $.Page) }}
+          {{ partial "block/block.html" (dict "block" $block "Page" $.Page "Site" $.Site) }}
 
         {{ end }}
       </div>

--- a/common-theme/layouts/_default/prep.html
+++ b/common-theme/layouts/_default/prep.html
@@ -11,8 +11,7 @@
       <!-- Blocks will appear here in order listed in the blocks list in the sprint front matter -->
       {{ range .Params.blocks }}
         {{ partial "block/block.html" (dict "block" . "Page"
-          $.Page)
-        }}
+          $.Page "Site" $.Site ) }}
       {{ end }}
     </div>
     {{ if gt .Params.blocks 1 }}

--- a/common-theme/layouts/_default/single.html
+++ b/common-theme/layouts/_default/single.html
@@ -6,7 +6,7 @@
       <!-- Blocks will appear here in order listed in the blocks list in the sprint front matter -->
       {{ range .Params.blocks }}
         {{ partial "block/block.html" (dict "block" . "Page"
-          $.Page)
+          $.Page "Site" $.Site)
         }}
       {{ end }}
     </div>

--- a/common-theme/layouts/partials/block/pd.html
+++ b/common-theme/layouts/partials/block/pd.html
@@ -3,6 +3,7 @@
 {{ $block := $blockData }}
 {{ $tab_set_id := $blockData.name | anchorize}}
 {{ if $response }}
+{{ $issueForm := print .Site.Params.org "/" .Site.Params.pdrepo "/issues/new?assignees=&labels=Feedback&template=feedback_template.yml&title=Feedback+on+" ($blockData.name | urlize)}}
 {{/*  Here we are decoding the content from the base64 readme API
   and turning it back into a Hugo doc with front matter
 An improvement on this would likely be to 
@@ -33,6 +34,7 @@ Have a crack!  */}}
         id="{{ $blockData.name |urlize }}">
         <a href="{{ $response.html_url }}">{{ $block.title }} 🔗</a>
       </h2>
+      <a href="{{$issueForm}}" class="c-block__feedback e-button">🤙🏽 Feedback</a>
       {{ partial "time.html" . }}
 
     </header>

--- a/common-theme/layouts/partials/block/pd.html
+++ b/common-theme/layouts/partials/block/pd.html
@@ -3,7 +3,7 @@
 {{ $block := $blockData }}
 {{ $tab_set_id := $blockData.name | anchorize}}
 {{ if $response }}
-{{ $issueForm := print .Site.Params.org "/" .Site.Params.pdrepo "/issues/new?assignees=&labels=Feedback&template=feedback_template.yml&title=Feedback+on+" ($blockData.name | urlize)}}
+{{ $issueForm := print $.Site.Params.org "/" $.Site.Params.pdrepo "/issues/new?assignees=&labels=Feedback&template=feedback_template.yml&title=Feedback+on+" ($blockData.name | urlize)}}
 {{/*  Here we are decoding the content from the base64 readme API
   and turning it back into a Hugo doc with front matter
 An improvement on this would likely be to 

--- a/common-theme/layouts/partials/module-tabs.html
+++ b/common-theme/layouts/partials/module-tabs.html
@@ -39,7 +39,7 @@
       <!-- Blocks will appear here in order listed in the blocks list in the front matter -->
       {{ range .Params.blocks }}
         {{ partial "block/block.html" (dict "block" . "Page"
-          $.Page)
+          $.Page "Site" $.Site)
         }}
       {{ end }}
     </div>

--- a/org-cyf/hugo.toml
+++ b/org-cyf/hugo.toml
@@ -30,6 +30,7 @@ main_website = "https://codeyourfuture.io/"
 main_org_name = "Code Your Future"
 org = "https://github.com/CodeYourFuture"
 repo = "https://github.com/CodeYourFuture/curriculum/"
+pdrepo = "CYF-PD"
 root = "curriculum"
 orgapi = "https://api.github.com/repos/CodeYourFuture/"
 # We use a proxy which concatenates paginated responses, otherwise we miss results.


### PR DESCRIPTION
## What does this change?

### Common Theme?

Issue number: #597 

This is a button that links to the PD feedback form. The values are nil right now  - checking into why it isn't pulling from hugo.toml as expected 

UPDATE fixed - was not passing site context through

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Description

adds a button to link to pd form

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
