### PR TITLE
Mermaid fix: prevent loading until intersection

### DIFF
--- a/common-theme/assets/scripts/mermaid-observer.js
+++ b/common-theme/assets/scripts/mermaid-observer.js
@@ -1,0 +1,32 @@
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs";
+
+mermaid.initialize({ startOnLoad: false });
+// Prevent automatic loading so that mermaid only renders on intersection
+// this is because mermaid regularly loses race conditions
+// and fails to size itself correctly when loaded inside hidden elements that have no dimensions in the DOM
+// like eg tabs, accordions, etc.
+// adapted from https://github.com/mermaid-js/mermaid/issues/311#issuecomment-332557344
+
+const initializeMermaid = (container) => {
+  mermaid.init(undefined, container);
+};
+
+const observeMermaidContainer = () => {
+  const observer = new IntersectionObserver(
+    (entries, observer) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          initializeMermaid(entry.target);
+          observer.unobserve(entry.target); // Stop observing after initialization
+        }
+      });
+    },
+    { threshold: 0.1 }
+  );
+
+  document.querySelectorAll(".mermaid").forEach((container) => {
+    observer.observe(container);
+  });
+};
+
+document.addEventListener("DOMContentLoaded", observeMermaidContainer);

--- a/common-theme/layouts/_default/_markup/render-codeblock-mermaid.html.html
+++ b/common-theme/layouts/_default/_markup/render-codeblock-mermaid.html.html
@@ -4,9 +4,14 @@
   }
   .mermaid {
     margin-bottom: var(--theme-spacing--gutter);
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+  }
+  .mermaid[data-processed] {
+    opacity: 1;
   }
 </style>
-<pre class="mermaid">{{- .Inner | safeHTML }}</pre>
-<script
-  type="module"
-  src="https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs"></script>
+<!-- Placeholder for Mermaid diagrams -->
+<div class="mermaid">{{- .Inner | safeHTML }}</div>
+{{ $mermaid := resources.Get "scripts/mermaid-observer.js" | resources.Minify }}
+<script type="module" src="{{ $mermaid.Permalink }}" defer></script>

--- a/common-theme/layouts/_default/_markup/render-codeblock-mermaid.html.html
+++ b/common-theme/layouts/_default/_markup/render-codeblock-mermaid.html.html
@@ -11,7 +11,6 @@
     opacity: 1;
   }
 </style>
-<!-- Placeholder for Mermaid diagrams -->
 <div class="mermaid">{{- .Inner | safeHTML }}</div>
 {{ $mermaid := resources.Get "scripts/mermaid-observer.js" | resources.Minify }}
 <script type="module" src="{{ $mermaid.Permalink }}" defer></script>


### PR DESCRIPTION
1. prevent render
2. initialise on intersection

Fixes #411

An interaction between solo view and mermaid triggered a race mermaid reliably lost. My best guess is that the node the diagram was nested within was removed from the DOM before mermaid had completed its render. Mermaid consequently rendered the SVG with no dimensions, as it sizes itself automagically from its parent dimensions. It was still attaching data-processed="true" though, so it was a blob mess.

I went down a blind alley trying to find out how to re-render mermaid last time I looked at this. I concluded this was a fools' errand this evening and instead wrote an intersection observer that renders mermaid whenever the parent div hoves into view. It doesn't seem to hit performance. I concealed the unsightly FOUT with a small fade on animation. 