### PR TITLE
603 Images are broken on https://curriculum.codeyourfuture.io/guides/contributing/supporters/

### DIFF
--- a/common-theme/layouts/_default/_markup/render-codeblock-mermaid.html.html
+++ b/common-theme/layouts/_default/_markup/render-codeblock-mermaid.html.html
@@ -13,4 +13,4 @@
 </style>
 <div class="mermaid">{{- .Inner | safeHTML }}</div>
 {{ $mermaid := resources.Get "scripts/mermaid-observer.js" | resources.Minify }}
-<script type="module" src="{{ $mermaid.Permalink }}" defer></script>
+<script type="module" src="{{ $mermaid.RelPermalink }}" defer></script>

--- a/common-theme/layouts/_default/day-plan.html
+++ b/common-theme/layouts/_default/day-plan.html
@@ -16,5 +16,5 @@
     </time-stamper>
   </article>
   {{ $timestamper := resources.Get "scripts/time-stamper.js" | resources.Minify }}
-  <script src="{{ $timestamper.Permalink }}" type="module" defer></script>
+  <script src="{{ $timestamper.RelPermalink }}" type="module" defer></script>
 {{ end }}

--- a/common-theme/layouts/_default/list.html
+++ b/common-theme/layouts/_default/list.html
@@ -5,7 +5,7 @@
   <ol class="c-timeline">
     {{ range .Pages }}
       <li class="c-timeline__entry">
-        <a class="c-timeline__post" href="{{ .Permalink }}"
+        <a class="c-timeline__post" href="{{ .RelPermalink }}"
           ><h3 class="c-timeline__title">{{ .Title }}</h3></a
         >
       </li>

--- a/common-theme/layouts/_default/module.html
+++ b/common-theme/layouts/_default/module.html
@@ -13,7 +13,7 @@
           "module"
         }}
           <li class="c-timeline__entry">
-            <a class="c-timeline__post" href="{{ .Permalink }}"
+            <a class="c-timeline__post" href="{{ .RelPermalink }}"
               ><h3 class="c-timeline__title">{{ .Title }}</h3></a
             >
           </li>

--- a/common-theme/layouts/_default/prep.html
+++ b/common-theme/layouts/_default/prep.html
@@ -11,7 +11,8 @@
       <!-- Blocks will appear here in order listed in the blocks list in the sprint front matter -->
       {{ range .Params.blocks }}
         {{ partial "block/block.html" (dict "block" . "Page"
-          $.Page "Site" $.Site ) }}
+          $.Page "Site" $.Site )
+        }}
       {{ end }}
     </div>
     {{ if gt .Params.blocks 1 }}
@@ -23,5 +24,5 @@
   </solo-view>
 
   {{ $soloView := resources.Get "scripts/solo-view.js" | resources.Minify }}
-  <script src="{{ $soloView.Permalink }}" defer></script>
+  <script src="{{ $soloView.RelPermalink }}" defer></script>
 {{ end }}

--- a/common-theme/layouts/_default/product.html
+++ b/common-theme/layouts/_default/product.html
@@ -8,7 +8,7 @@
         "product"
       }}
         <li class="c-timeline__entry">
-          <a class="c-timeline__post" href="{{ .Permalink }}"
+          <a class="c-timeline__post" href="{{ .RelPermalink }}"
             ><h3 class="c-timeline__title">{{ .Title }}</h3></a
           >
         </li>

--- a/common-theme/layouts/_default/sprint.html
+++ b/common-theme/layouts/_default/sprint.html
@@ -5,7 +5,7 @@
     {{ range sort .Pages "Params.weight" }}
       {{ if in .Params.menu_level "sprint" }}
         <li class="c-timeline__entry">
-          <a class="c-timeline__post" href="{{ .Permalink }}">
+          <a class="c-timeline__post" href="{{ .RelPermalink }}">
             <h3 class="c-timeline__title">{{ .Title }}</h3>
           </a>
         </li>

--- a/common-theme/layouts/_default/success.html
+++ b/common-theme/layouts/_default/success.html
@@ -64,5 +64,5 @@
 
   {{ $confetti := resources.Get "scripts/confetti-checkboxes.js" | resources.Minify }}
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti" defer></script>
-  <script src="{{ $confetti.Permalink }}" type="module" defer></script>
+  <script src="{{ $confetti.RelPermalink }}" type="module" defer></script>
 {{ end }}

--- a/common-theme/layouts/partials/breadcrumbs.html
+++ b/common-theme/layouts/partials/breadcrumbs.html
@@ -3,7 +3,7 @@
     <ol class="c-breadcrumbs__list">
       {{- range after 1 .Ancestors.Reverse }}
         <li class="c-breadcrumbs__item">
-          <a class="c-breadcrumbs__link" href="{{ .Permalink }}"
+          <a class="c-breadcrumbs__link" href="{{ .RelPermalink }}"
             >{{ .Title }}
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -22,7 +22,9 @@
         </li>
       {{- end }}
       <li class="c-breadcrumbs__item">
-        <a class="c-breadcrumbs__link" href="{{ .Permalink }}">{{ .Title }}</a>
+        <a class="c-breadcrumbs__link" href="{{ .RelPermalink }}"
+          >{{ .Title }}</a
+        >
       </li>
     </ol>
   </nav>

--- a/common-theme/layouts/partials/card.html
+++ b/common-theme/layouts/partials/card.html
@@ -1,6 +1,6 @@
 {{ $fallBackEmoji := "🤖" }}
 {{ $BaseURL := .Page.Parent.Permalink }}
-<a class="c-card" href="{{ .URL | absURL }}">
+<a class="c-card" href="{{ relURL .URL }}">
   <h3 class="c-card__title">{{ .Name }}</h3>
   <p class="c-card__description">{{ .Page.Description }}</p>
   <!-- Display emoji -->

--- a/common-theme/layouts/partials/card.html
+++ b/common-theme/layouts/partials/card.html
@@ -1,6 +1,6 @@
 {{ $fallBackEmoji := "🤖" }}
 {{ $BaseURL := .Page.Parent.Permalink }}
-<a class="c-card" href="{{ .URL }}">
+<a class="c-card" href="{{ .URL | absURL }}">
   <h3 class="c-card__title">{{ .Name }}</h3>
   <p class="c-card__description">{{ .Page.Description }}</p>
   <!-- Display emoji -->

--- a/common-theme/layouts/partials/module-tabs.html
+++ b/common-theme/layouts/partials/module-tabs.html
@@ -26,7 +26,7 @@
           "module"
         }}
           <li class="c-timeline__entry">
-            <a class="c-timeline__post" href="{{ .Permalink }}"
+            <a class="c-timeline__post" href="{{ .RelPermalink }}"
               ><h3 class="c-timeline__title">{{ .Title }}</h3></a
             >
           </li>

--- a/common-theme/layouts/partials/scripts.html
+++ b/common-theme/layouts/partials/scripts.html
@@ -3,12 +3,12 @@
 {{/* temporarily load scripts until we track down this page store problem
   https://discourse.gohugo.io/t/page-store-is-sometimes-empty-for-unclear-reasons/44950
 */}}
-<script src="{{ $scripts.Permalink }}" defer></script>
+<script src="{{ $scripts.RelPermalink }}" defer></script>
 {{ $player := resources.Get "scripts/youtube-player.js" | resources.Minify }}
-<script src="{{ $player.Permalink }}" defer></script>
+<script src="{{ $player.RelPermalink }}" defer></script>
 {{ $tabs := resources.Get "scripts/tab-panels.js" | resources.Minify }}
-<script src="{{ $tabs.Permalink }}" type="module" defer></script>
+<script src="{{ $tabs.RelPermalink }}" type="module" defer></script>
 {{ $darkmode := resources.Get "scripts/dark-mode.js" | resources.Minify }}
-<script src="{{ $darkmode.Permalink }}"></script>
+<script src="{{ $darkmode.RelPermalink }}"></script>
 {{ $alertmessage := resources.Get "scripts/alert-message.js" | resources.Minify }}
-<script src="{{ $alertmessage.Permalink }}" defer></script>
+<script src="{{ $alertmessage.RelPermalink }}" defer></script>

--- a/common-theme/layouts/shortcodes/wordlimit.html
+++ b/common-theme/layouts/shortcodes/wordlimit.html
@@ -1,5 +1,5 @@
 <section>
   <word-limit />
   {{ $wordLimit := resources.Get "scripts/word-limit.js" | resources.Minify }}
-  <script src="{{ $wordLimit.Permalink }}" type="module" defer></script>
+  <script src="{{ $wordLimit.RelPermalink }}" type="module" defer></script>
 </section>

--- a/org-cyf/hugo.toml
+++ b/org-cyf/hugo.toml
@@ -1,5 +1,5 @@
 title = "CYF Curriculum"
-
+baseURL = "https://curriculum.codeyourfuture.io/"
 
 [taxonomies]
   category = 'categories' # Content types are blocks, definitions, guides


### PR DESCRIPTION
Fixes #603

On production, absURL was defaulting to / instead of the site root.

Seems like maybe it's because curriculum is a subdomain? In any case, I have added the url explicitly using baseURL

https://gohugo.io/methods/site/baseurl/

If this is the right fix I have some updates to the funding page, which I will open as a second tiny PR

https://deploy-preview-636--cyf-curriculum.netlify.app/guides/contributing/supporters/

#637 