### PR TITLE
How our curriculum works/self-educate fixes

### DIFF
--- a/common-content/en/module/how-our-curriculum-works/importance-of-prep/index.md
+++ b/common-content/en/module/how-our-curriculum-works/importance-of-prep/index.md
@@ -8,4 +8,4 @@ time= 30
 
 In a flipped learning model, learners are expected to **prepare** before they meet up as a community. Therefore, regular preparation is essential for our community to self-educate together. In each sprint week, we expect trainees to work on the prep section beforehand to start building their own mental model of the week's concepts.
 
-Here is an example of prep from JS1 to gain an example of what trainees will be expected to engage with before an in-person session: https://curriculum.codeyourfuture.io/js1/sprints/1/prep/
+Here is an example of prep from the first JavaScript module to gain an example of what trainees will be expected to engage with before an in-person session: https://curriculum.codeyourfuture.io/js1/sprints/1/prep/

--- a/common-content/en/module/how-our-curriculum-works/workshops/index.md
+++ b/common-content/en/module/how-our-curriculum-works/workshops/index.md
@@ -8,6 +8,6 @@ time= 30
 3="Relate the use of workshops to active learning"
 +++
 
-We do at least one active learning [Workshops](https://github.com/CodeYourFuture/CYF-Workshops/) every class day. Workshops are group activities where the community discusses, solves and reflects on problems related to their current sprint. They are an opportunity for practice, critical thinking and dialogue.
+We do at least one active learning [Workshop](https://github.com/CodeYourFuture/CYF-Workshops/) every class day. Workshops are group activities where the community discusses, solves and reflects on problems related to their current sprint. They are an opportunity for practice, critical thinking and dialogue.
 
 We collectively develop workshops here at this repo: https://github.com/CodeYourFuture/CYF-Workshops/. Check out some examples and raise a PR if you've got an idea for a new workshop.

--- a/common-content/en/module/how-our-curriculum-works/workshops/index.md
+++ b/common-content/en/module/how-our-curriculum-works/workshops/index.md
@@ -10,4 +10,4 @@ time= 30
 
 We do at least one active learning [Workshop](https://github.com/CodeYourFuture/CYF-Workshops/) every class day. Workshops are group activities where the community discusses, solves and reflects on problems related to their current sprint. They are an opportunity for practice, critical thinking and dialogue.
 
-We collectively develop workshops here at this repo: https://github.com/CodeYourFuture/CYF-Workshops/. Check out some examples and raise a PR if you've got an idea for a new workshop.
+We collectively develop workshops in this repo: https://github.com/CodeYourFuture/CYF-Workshops/. Check out some examples and raise a PR if you've got an idea for a new workshop.


### PR DESCRIPTION
## What does this change?

Fixes some typos/awkward phrases in the Self-Educate sprint of the How our curriculum works module.

### Common Content?

Block/s

### Common Theme?

Issue number: #issue-number

### Org Content?

Module | Sprint | Page Type | Block Type

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

@CodeYourFuture/global-syllabus 