### PR TITLE
feature: stub a 404 page

### DIFF
--- a/common-theme/layouts/404.html
+++ b/common-theme/layouts/404.html
@@ -1,0 +1,4 @@
+{{ define "main" }}
+  {{ partial "page-header.html" . }}
+  {{with .Content}}<article class="c-copy">{{ .}}</article>{{end}}
+{{ end }}

--- a/org-cyf/content/404.md
+++ b/org-cyf/content/404.md
@@ -1,0 +1,14 @@
++++
+title="404"
+emoji="🫠"
+description="Page not found"
+layout="404"
++++
+
+Oh dear, you followed a link to nowhere. Here are some things you can do:
+
+{{<note type="next" title="Find your way">}}
+👆🏿 Use search
+👈🏼 [Go back to the homepage](/)
+🤙🏼 [report a broken link](https://github.com/CodeYourFuture/curriculum/issues/new?assignees=&labels=bug&projects=&template=bug-report.md&title=)
+{{</note>}}


### PR DESCRIPTION
## What does this change?

I put a 404 page in. It just renders the site chrome. It would be nice to put a mini sitemap on this view however because we skip a level (skipping over /sprints/ to reduce the pointless clickery) it's a little more involved than the usual

```
{{ template "site-structure" (dict "dir" .Site.Sections) }}

{{ define "site-structure" }}
  <ol>
  {{ range .dir }}
    {{ if (eq .BundleType "branch") }}
        <li><a href="{{ .RelPermalink }}">{{ .Title }}</a>
        {{ template "site-structure" (dict "dir" .Pages) }}
        </li>
    {{ else }}
      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
    {{ end }}
  {{ end }}
  </ol>
{{ end }}
```

So I've skipped it for now in the interests of something being better than nothing.

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

404.html 

related to #649

### Org Content?

<!-- Does this PR changes a whole module, a sprint, a page, or a block on a single organisation's module? -->

content/404.md

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
