### PR TITLE
Only fetch github issues that aren't pull requests

### DIFF
--- a/common-theme/layouts/partials/issues.html
+++ b/common-theme/layouts/partials/issues.html
@@ -1,5 +1,5 @@
 {{ $repo := .Params.backlog }}
-{{ $issuesUrl := print .Site.Params.issuesorgapi $repo "/issues?per_page=100&state=open&direction=asc&type=issue" }}
+{{ $issuesUrl := print .Site.Params.searchapi (printf "/issues?q=repo:CodeYourFuture/%s+type:issue+state:open&per_page=100" $repo) }}
 {{ $filter := .Params.backlog_filter }}
 {{ $currentPath := .Page.RelPermalink }}
 <!-- api call -->
@@ -11,7 +11,7 @@
 <!-- if no object show error -->
 {{ if ne $issues nil }}
   <!-- range over issues list and pull out useful data -->
-  {{ range $issues }}
+  {{ range $issues.items }}
 
     {{ $showIssue := true }}
     <!-- if a filter exists, only show issues with the right label -->

--- a/org-cyf/hugo.toml
+++ b/org-cyf/hugo.toml
@@ -40,6 +40,7 @@ repo = "https://github.com/CodeYourFuture/curriculum/"
 pdrepo = "CYF-PD"
 root = "curriculum"
 orgapi = "https://api.github.com/repos/CodeYourFuture/"
+searchapi="https://api.github.com/search"
 # We use a proxy which concatenates paginated responses, otherwise we miss results.
 # Daniel is currently hosting this code https://github.com/illicitonion/github-issue-proxy but we should work out a long-term maintainable solution to this problem.
 issuesorgapi = "https://github-issue-proxy.illicitonion.com/repos/CodeYourFuture/"


### PR DESCRIPTION
## What does this change?

In `issues.html` we currently fetch all issues using the following endpoint `/{repo_name}/issues?per_page=100&state=open&direction=asc&type=issue` but it isn't working as expected. It is fetching all of the earliest issues by default and the `type` query isn't filtering for issues _and_ not pull requests. This only becomes obvious on repos like Full-Stack-Project-Assessment where there are loads of existing pull requests (that are being pulled as issues) that were created before the new set of issues for the project.

I don't think there is a way to filter out the pull requests with the current endpoint so I suggest using the `/search/issues` endpoint instead.

