### PR TITLE
filter for self educate issues

### DIFF
--- a/org-cyf/content/how-our-curriculum-works/sprints/self-educate/backlog/index.md
+++ b/org-cyf/content/how-our-curriculum-works/sprints/self-educate/backlog/index.md
@@ -5,7 +5,7 @@ emoji= '🥞'
 menu_level = ['sprint']
 weight = 2
 backlog= 'Module-How-our-curriculum-works'
-backlog_filter= 'Week 1'
+backlog_filter= 'Self educate'
 +++
 
 This view lists the issues for this sprint. You can think of the issues in this view as **actions** to guide you in your first interactions with the community.


### PR DESCRIPTION
## What does this change?

- Changes "week 1" to "self educate" for the issues in **self educate** section

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
