### PR TITLE
Bugfix: return objectives to success page on sprint view

### DIFF
--- a/common-theme/layouts/_default/success.html
+++ b/common-theme/layouts/_default/success.html
@@ -52,7 +52,7 @@
             {{ if or (eq $blockData.type "readme") (eq $blockData.type "pd") }}
               {{ partial "objectives/parsed" (dict "blockData" $blockData "pageContext" $pageContext) }}
             {{ end }}
-            {{ if or (eq $blockData.type "local_module") (eq $blockData.type "local_course") }}
+            {{ if or (eq $blockData.type "local") (eq $blockData.type "local_course") }}
               {{ partial "objectives/lookup.html" (dict "blockData" $blockData "pageContext" $pageContext) }}
             {{ end }}
 


### PR DESCRIPTION
## What does this change?

We used to collate all objectives blocks from readmes, PD, and local blocks on this page.

At some point without noticing we accidentally disabled objectives on local blocks.

This PR returns those objectives. I renamed the comparison to `local` from `local_module`. Clearly, this was once called local_module. It was renamed when we moved to using Hugo modules, I think?

Hat tip to Mitch for the fix!

### Common Theme?

layouts/success (SPRINTS)

Issue number: #679 

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->

# Test

compare 

https://curriculum.codeyourfuture.io/html-css/sprints/2/success/
https://deploy-preview-688--cyf-curriculum.netlify.app/html-css/sprints/2/success/
