### PR TITLE
694 Create PR Guide link is broken

### DIFF
--- a/org-cyf/static/_redirects
+++ b/org-cyf/static/_redirects
@@ -1,7 +1,7 @@
 # https://docs.netlify.com/routing/redirects/
 
 /contributing.md /guides/contributing 302
-/guides/create-a-pull-request /guides/contributing/pull-request 302
+/guides/create-a-pull-request /guides/contributing/create-a-pull-request 302
 /guides/asking-questions /guides/getting-help/asking-questions 302
 /guides/asking-question /guides/getting-help/asking-questions 302
 /guides/code-review /guides/reviewing/checklist 302

--- a/org-cyf/static/_redirects
+++ b/org-cyf/static/_redirects
@@ -1,6 +1,7 @@
 # https://docs.netlify.com/routing/redirects/
 
 /contributing.md /guides/contributing 302
+/guides/create-a-pull-request /guides/contributing/pull-request 302
 /guides/asking-question /guides/getting-help/asking-questions 302
 /guides/code-review /guides/reviewing/checklist 302
 /guides/code-style-guide /guides/reviewing/style-guide 302

--- a/org-cyf/static/_redirects
+++ b/org-cyf/static/_redirects
@@ -2,6 +2,7 @@
 
 /contributing.md /guides/contributing 302
 /guides/create-a-pull-request /guides/contributing/pull-request 302
+/guides/asking-questions /guides/getting-help/asking-questions 302
 /guides/asking-question /guides/getting-help/asking-questions 302
 /guides/code-review /guides/reviewing/checklist 302
 /guides/code-style-guide /guides/reviewing/style-guide 302


### PR DESCRIPTION
## What does this change?

<!-- Add a description of what your PR changes here -->


### Org Content?

add a redirect for the pr guide as per #694 hat tip to Esma!

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
