### PR TITLE
Update Asking questions guide

### DIFF
--- a/org-cyf/content/guides/getting-help/asking-questions/index.md
+++ b/org-cyf/content/guides/getting-help/asking-questions/index.md
@@ -8,7 +8,7 @@ Often trainees at Code Your Future find it difficult to get help. This is becaus
 
 {{<note type="activity" title="Asking Questions workshop" >}}
 
-If you have not completed the [Asking Questions workshop](../../html-css/sprints/2/day-plan/index.md#asking-questions) during the HTML-CSS module, find a small group of people to do that together before reading further.
+If you have not completed the [Asking Questions workshop](https://workshops.codeyourfuture.io/#asking-questions), find a small group of people to do that together before reading further.
 
 It is important to understand how your current mental model helps you to ask a good question.
 


### PR DESCRIPTION
remove coupling to HTML-CSS module

## What does this change?

I changed the link and wording to link to the asking questions workshop instead of a specific day, as this could move.


### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Guide | Asking Questions

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
