### PR TITLE
add h2 to preamble

### DIFF
--- a/org-cyf/content/js3/prep/index.md
+++ b/org-cyf/content/js3/prep/index.md
@@ -14,6 +14,8 @@ name="Technical Writing 101"
 src="https://github.com/CodeYourFuture/Module-JS3/issues/243"
 +++
 
+## Stretch 
+
 In JS3, you will spend a lot of time working on code written by other people. Other people will be working on your code. This means you will need to practice your technical communication skills.
 
 This coursework is set as stretch, so it's not mandatory; we just think it's a really good idea.


### PR DESCRIPTION
This should be fixed a bit more robustly but for now let's add in the missing h2 #713  - opening this on github just as a markdown edit

## What does this change?

### Org Content?

JS3 | Prep |

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
