### PR TITLE
Feature: absolute image paths, get remote images

### DIFF
--- a/common-theme/layouts/_default/_markup/render-image.html
+++ b/common-theme/layouts/_default/_markup/render-image.html
@@ -40,8 +40,12 @@
 
   {{/* Handle external images directly */}}
   {{- if $isExternal -}}
-    {{ $image = (dict "RelPermalink" $src "Width" 0 "Height" 0) }}
-  {{- end -}}
+    {{ with resources.GetRemote $src }}
+      {{ $image = . }}
+    {{ else }}
+      {{ errorf "Unable to get remote resource %q" $src }}
+    {{ end }}
+  {{ end }}
 
   {{/* If the image is found, resize it based on the screen width and display it in the figure */}}
   {{ if $image }}

--- a/common-theme/layouts/_default/_markup/render-image.html
+++ b/common-theme/layouts/_default/_markup/render-image.html
@@ -5,7 +5,7 @@
   {{ $src := .Destination }}
   {{ $alt := .PlainText | safeHTML }}
   {{ $caption := "" }}
-  {{ $image := "" }}
+  {{ $image := false }}
   {{ $srcset := "" }}
   {{ with .Title }}
     {{ $caption = . | safeHTML }}
@@ -25,7 +25,7 @@
     {{ with resources.GetRemote $src }}
       {{ $image = . }}
     {{ else }}
-      {{ errorf "Unable to get remote resource %q" $src }}
+      {{ warnf "Unable to get remote resource %q" $src }}
     {{ end }}
   {{ end }}
 

--- a/common-theme/layouts/_default/_markup/render-image.html
+++ b/common-theme/layouts/_default/_markup/render-image.html
@@ -61,7 +61,6 @@
       {{/* If $image isn't rasterisable, don't try to generate srcset but do generate permalink */}}
       {{ $srcset := $image.RelPermalink }}
     {{ else }}
-      {{ $image = false }}
       {{ warnf "Unsupported media type %q for image %q" $image.MediaType.Type $src }}
     {{ end }}
   {{ end }}
@@ -71,10 +70,11 @@
       <img
         loading="lazy"
         src="{{ $image.RelPermalink }}"
-        srcset="{{ $srcset }}"
-        sizes="(max-width: 480px) 480px, (max-width: 768px) 768px, 1024px"
-        width="{{ $image.Width }}"
-        height="{{ $image.Height }}"
+        {{ if $srcset }}
+          srcset="{{ $srcset }}" sizes="(max-width: 480px) 480px, (max-width:
+          768px) 768px, 1024px" width="{{ $image.Width }}"
+          height="{{ $image.Height }}"
+        {{ end }}
         alt="{{ if $alt }}
           {{ $alt }}
         {{ else }}

--- a/common-theme/layouts/_default/_markup/render-image.html
+++ b/common-theme/layouts/_default/_markup/render-image.html
@@ -1,65 +1,72 @@
-{{/* https://gohugo.io/methods/page/resources/#get */}}
+{{/* https://gohugo.io/methods/page/resources/#get
+  https://gohugo.io/functions/urls/parse/
+*/}}
 {{ if eq .Destination "" }}
   {{ warnf "Image source is empty: %s" .PlainText }}
 {{ else }}
-  {{ $src := .Destination }}
+  {{ $url := urls.Parse .Destination }}
+  {{ $src :=.Destination }}
   {{ $alt := .PlainText | safeHTML }}
-  {{ $caption := "" }}
   {{ $image := false }}
   {{ $srcset := "" }}
-  {{ with .Title }}
-    {{ $caption = . | safeHTML }}
-  {{ end }}
+
   {{/* Check if the source is external to this repo */}}
-  {{ $isRemote := or (strings.HasPrefix $src "http://") (strings.HasPrefix $src "https://") }}
 
   {{/* Case 1: where an image is remote, get it please */}}
-  {{- if $isRemote -}}
+  {{- if $url.IsAbs -}}
     {{/* Most images will be github, and we were previously using jsdelivr, but now let's use github raw */}}
-    {{ if in $src "github.com" }}
+    {{ if eq $url.Hostname "github.com" }}
       {{/* Replace 'blob' or 'tree' with a direct path for raw content */}}
       {{ $src = replace $src "github.com" "raw.githubusercontent.com" }}
       {{ $src = replaceRE "/(blob|tree)/" "/" $src }}
     {{ end }}
 
     {{ with resources.GetRemote $src }}
-      {{ $image = . }}
-    {{ else }}
-      {{ warnf "Unable to get remote resource %q" $src }}
+      {{ with .Err }}
+        {{ warnf "Unable to get remote resource %q" $src }}
+      {{ else }}
+        {{ $image = . }}
+      {{ end }}
     {{ end }}
   {{ end }}
 
-  {{/* Case 2: if it's not an external link, look for the image in Page resources */}}
-  {{ if not $isRemote }}
+  {{/* Case 2: if it's not an absolute link, look for the image in Page resources */}}
+  {{ if not $url.IsAbs }}
     {{/* Check if the image is a resource */}}
-    {{ with $.Page.Resources.GetMatch (printf "%s" $src) }}
+    {{ with $.Page.Resources.GetMatch $src }}
       {{ $image = . }}
     {{ end }}
   {{ end }}
 
   {{/* Case 3: If the image is still not found, try to get it from the assets directory */}}
-  {{- if and (not $image) (not $isRemote) -}}
-    {{ $path := (path.Join "custom-images" $src) }}
-    {{ with resources.Get $path }}
-      {{ $image = . }}
-    {{ end }}
+  {{- if not $image -}}
+    {{ with resources.Get (path.Join "custom-images" $src) }}
+      {{ with .Err }}
+        {{ warnf "Unable to get local resource %q" $src }}
+      {{ else }}
+        {{ $image = . }}
+      {{ end }}
+    {{- end -}}
   {{- end -}}
 
   {{/* If the image is found, resize it based on the screen width and display it in the figure */}}
   {{ if $image }}
-
-    {{/* Perform resizing operations only if $image is a rasterisable resource */}}
-    {{ if and (ne $image.MediaType.SubType "svg")  (ne $image.MediaType.SubType ".gif") }}
+    {{ if in (slice "image/png" "image/jpeg" "image/webp" "image/tiff") $image.MediaType.Type }}
+      {{/* Perform resizing operations only if $image is a rasterisable resource */}}
       {{ $small := (cond (gt $image.Width 480) ($image.Resize "480x webp q75") $image) }}
       {{ $medium := (cond (gt $image.Width 768) ($image.Resize "768x webp q75") $image) }}
       {{ $big := (cond (gt $image.Width 1024) ($image.Resize "1024x webp q75") $image) }}
       {{ $srcset := printf "%s 480w, %s 768w, %s 1024w" $small.RelPermalink $medium.RelPermalink $big.RelPermalink }}
-    {{ else }}
-      {{/* If $image isn't rasterisable, don't try to generate srcset */}}
+    {{ else if in (slice "image/svg+xml" "image/gif") $image.MediaType.Type }}
+      {{/* If $image isn't rasterisable, don't try to generate srcset but do generate permalink */}}
       {{ $srcset := $image.RelPermalink }}
+    {{ else }}
+      {{ $image = false }}
+      {{ warnf "Unsupported media type %q for image %q" $image.MediaType.Type $src }}
     {{ end }}
+  {{ end }}
 
-
+  {{ if $image }}
     <figure>
       <img
         loading="lazy"
@@ -73,7 +80,7 @@
         {{ else }}
           &nbsp;
         {{ end }}" />
-      {{ with $caption }}
+      {{ with .Title }}
         <figcaption>{{ . | markdownify }}</figcaption>
       {{ end }}
     </figure>

--- a/common-theme/layouts/_default/_markup/render-image.html
+++ b/common-theme/layouts/_default/_markup/render-image.html
@@ -75,11 +75,11 @@
           768px) 768px, 1024px" width="{{ $image.Width }}"
           height="{{ $image.Height }}"
         {{ end }}
-        alt="{{ if $alt }}
-          {{ $alt }}
+        {{ if $alt }}
+          alt="{{ $alt }}" data-pagefind-index-attrs="{{ $alt }}"
         {{ else }}
-          &nbsp;
-        {{ end }}" />
+          alt=""
+        {{ end }} />
       {{ with .Title }}
         <figcaption>{{ . | markdownify }}</figcaption>
       {{ end }}

--- a/common-theme/layouts/_default/_markup/render-image.html
+++ b/common-theme/layouts/_default/_markup/render-image.html
@@ -1,45 +1,27 @@
+{{/* https://gohugo.io/methods/page/resources/#get */}}
 {{ if eq .Destination "" }}
   {{ warnf "Image source is empty: %s" .PlainText }}
 {{ else }}
   {{ $src := .Destination }}
   {{ $alt := .PlainText | safeHTML }}
   {{ $caption := "" }}
+  {{ $image := "" }}
+  {{ $srcset := "" }}
   {{ with .Title }}
     {{ $caption = . | safeHTML }}
   {{ end }}
+  {{/* Check if the source is external to this repo */}}
+  {{ $isRemote := or (strings.HasPrefix $src "http://") (strings.HasPrefix $src "https://") }}
 
-  {{/* Check if the source is an external link */}}
-  {{ $isExternal := or (strings.HasPrefix $src "http://") (strings.HasPrefix $src "https://") }}
-  {{/* If this image is served from GitHub, swap to jSDelivr */}}
-  {{ if "github" | in $src }}
-    {{ $src = replace $src "https://github.com/" "https://cdn.jsdelivr.net/gh/" }}
-    {{ $src = replace $src "/blob/" "@" }}
-  {{ end }}
-
-  {{/* Define an image variable and a flag to indicate if it's a resource */}}
-  {{ $image := "" }}
-  {{ $isResource := false }}
-  {{ $srcset := "" }}
-
-  {{/* If it's not an external link, look for the image in Page resources */}}
-  {{ if not $isExternal }}
-    {{/* Check if the image is a resource */}}
-    {{ with $.Page.Resources.GetMatch (printf "%s" $src) }}
-      {{ $image = . }}
-      {{ $isResource = true }}
+  {{/* Case 1: where an image is remote, get it please */}}
+  {{- if $isRemote -}}
+    {{/* Most images will be github, and we were previously using jsdelivr, but now let's use github raw */}}
+    {{ if in $src "github.com" }}
+      {{/* Replace 'blob' or 'tree' with a direct path for raw content */}}
+      {{ $src = replace $src "github.com" "raw.githubusercontent.com" }}
+      {{ $src = replaceRE "/(blob|tree)/" "/" $src }}
     {{ end }}
-  {{ end }}
 
-  {{/* If the image is still not found, try to get it from the assets directory */}}
-  {{- if and (not $image) (not $isExternal) -}}
-    {{ $path := (path.Join "custom-images" $src) }}
-    {{ with resources.Get $path }}
-      {{ $image = . }}
-    {{ end }}
-  {{- end -}}
-
-  {{/* Handle external images directly */}}
-  {{- if $isExternal -}}
     {{ with resources.GetRemote $src }}
       {{ $image = . }}
     {{ else }}
@@ -47,19 +29,33 @@
     {{ end }}
   {{ end }}
 
+  {{/* Case 2: if it's not an external link, look for the image in Page resources */}}
+  {{ if not $isRemote }}
+    {{/* Check if the image is a resource */}}
+    {{ with $.Page.Resources.GetMatch (printf "%s" $src) }}
+      {{ $image = . }}
+    {{ end }}
+  {{ end }}
+
+  {{/* Case 3: If the image is still not found, try to get it from the assets directory */}}
+  {{- if and (not $image) (not $isRemote) -}}
+    {{ $path := (path.Join "custom-images" $src) }}
+    {{ with resources.Get $path }}
+      {{ $image = . }}
+    {{ end }}
+  {{- end -}}
+
   {{/* If the image is found, resize it based on the screen width and display it in the figure */}}
   {{ if $image }}
-    {{/* Extract the file extension from the image URL */}}
-    {{ $ext := path.Ext $src }}
 
-    {{/* Perform resizing operations only if $image is a real image resource and not a GIF */}}
-    {{ if and $isResource (ne $ext ".gif") }}
+    {{/* Perform resizing operations only if $image is a rasterisable resource */}}
+    {{ if and (ne $image.MediaType.SubType "svg")  (ne $image.MediaType.SubType ".gif") }}
       {{ $small := (cond (gt $image.Width 480) ($image.Resize "480x webp q75") $image) }}
       {{ $medium := (cond (gt $image.Width 768) ($image.Resize "768x webp q75") $image) }}
       {{ $big := (cond (gt $image.Width 1024) ($image.Resize "1024x webp q75") $image) }}
       {{ $srcset := printf "%s 480w, %s 768w, %s 1024w" $small.RelPermalink $medium.RelPermalink $big.RelPermalink }}
     {{ else }}
-      {{/* If $image isn't a real resource or is a GIF, don't try to generate srcset */}}
+      {{/* If $image isn't rasterisable, don't try to generate srcset */}}
       {{ $srcset := $image.RelPermalink }}
     {{ end }}
 
@@ -82,7 +78,9 @@
       {{ end }}
     </figure>
   {{ else }}
-    <div title="broken image link" style="font-size: 48px; text-align: center;">
+    <div
+      title="broken image link from {{ $src }}"
+      style="font-size: 48px; text-align: center;">
       🖼️
     </div>
   {{ end }}

--- a/common-theme/layouts/partials/block/link.html
+++ b/common-theme/layouts/partials/block/link.html
@@ -1,6 +1,8 @@
 {{ $blockData := .Page.Scratch.Get "blockData" }}
 {{ $randomImage := (index (resources.Match "custom-images/backgrounds/**.**" | shuffle | first 1) 0) }}
-{{ $randomImage = $randomImage.Resize "480x" }}
+{{ if $randomImage }}
+  {{ $randomImage = $randomImage.Resize "480x" }}
+{{ end }}
 
 
 <section class="c-block c-block--{{ $blockData.type }}">

--- a/common-theme/layouts/partials/block/readme.html
+++ b/common-theme/layouts/partials/block/readme.html
@@ -12,7 +12,10 @@
       {{ partial "time.html" . }}
     </header>
     <div class="c-block__content c-copy">
-      {{ $response.content | base64Decode | replaceRE "<!--(.*?)-->" "$1" | markdownify }}
+      {{ $decodedContent := $response.content | base64Decode }}
+      {{ $strippedComments := $decodedContent | replaceRE "<!--(.*?)-->" "$1" }}
+      {{ $externalPath := replace $response.download_url $response.name "" }}
+      {{ partial "strings/absolute-image-paths.html" (dict "markdownContent" $strippedComments "externalPath" $externalPath) | markdownify }}
     </div>
   </section>
 {{ else }}

--- a/common-theme/layouts/partials/strings/absolute-image-paths.html
+++ b/common-theme/layouts/partials/strings/absolute-image-paths.html
@@ -3,7 +3,6 @@
 {{ $markdownContent := .markdownContent }}
 
 {{/* Replace Markdown image links, targeting anything without a : */}}
-{{ $processedContent := $markdownContent | replaceRE `!\[[^\]]*]\([^:)]*\)` (printf "![$1](%s$2)" $externalPath) }}
-
+{{ $processedContent := $markdownContent | replaceRE `!\[([^\]]+)\]\(([^"http:\/\/|https:\/\/][^)]+)\)` (printf "![$1](%s$2)" $externalPath) }}
 {{/* Output the processed content to be markdownified */}}
 {{ $processedContent }}

--- a/common-theme/layouts/partials/strings/absolute-image-paths.html
+++ b/common-theme/layouts/partials/strings/absolute-image-paths.html
@@ -2,9 +2,8 @@
 {{ $externalPath := .externalPath }}
 {{ $markdownContent := .markdownContent }}
 
-{{/* Replace Markdown image links, assuming they are not already absolute */}}
-
-{{ $processedContent := $markdownContent | replaceRE `!\[([^\]]+)\]\(([^"http:\/\/|https:\/\/][^)]+)\)` (printf "![$1](%s$2)" $externalPath) }}
+{{/* Replace Markdown image links, targeting anything without a : */}}
+{{ $processedContent := $markdownContent | replaceRE `!\[[^\]]*]\([^:)]*\)` (printf "![$1](%s$2)" $externalPath) }}
 
 {{/* Output the processed content to be markdownified */}}
 {{ $processedContent }}

--- a/common-theme/layouts/partials/strings/absolute-image-paths.html
+++ b/common-theme/layouts/partials/strings/absolute-image-paths.html
@@ -6,5 +6,5 @@
 
 {{ $processedContent := $markdownContent | replaceRE `!\[([^\]]+)\]\(([^"http:\/\/|https:\/\/][^)]+)\)` (printf "![$1](%s$2)" $externalPath) }}
 
-{{/* Output the processed content, remove the './' from the URL in the replacement */}}
+{{/* Output the processed content to be markdownified */}}
 {{ $processedContent }}

--- a/common-theme/layouts/partials/strings/absolute-image-paths.html
+++ b/common-theme/layouts/partials/strings/absolute-image-paths.html
@@ -1,0 +1,10 @@
+{{/* absoluteImagePaths.html - Converts relative image paths to absolute GitHub URLs in Markdown content */}}
+{{ $externalPath := .externalPath }}
+{{ $markdownContent := .markdownContent }}
+
+{{/* Replace Markdown image links, assuming they are not already absolute */}}
+
+{{ $processedContent := $markdownContent | replaceRE `!\[([^\]]+)\]\(([^"http:\/\/|https:\/\/][^)]+)\)` (printf "![$1](%s$2)" $externalPath) }}
+
+{{/* Output the processed content, remove the './' from the URL in the replacement */}}
+{{ $processedContent }}


### PR DESCRIPTION
## What does this change?

<!-- Add a description of what your PR changes here -->

### Common Theme?

1. _markup/render-image.html

revise render-image hook to do the following:

- update github links to github raw links (instead of jsdelivr)
- get all remote images and process as local instead of hotlinking
- incidentally, perform a mediatype check instead of file type check so we actually know it's a rasterisable image and not just some other file masquerading as same

2. strings/absolute-image-paths.html

then we made a short partial to run over decoded markdown blobs and regex with the path of the repo it's living in NOTE I DID NOT CONSTRUCT THIS REGEX please review my terrible regex 

3. blocks/readme.html

in the readme block, we added a second and final processing step to turn the relative links absolute. It has to be the last step so we can markdownify it inside the assignment. If we don't do this, I think we have to pass the text to scratch to get it back into the readme block context. However, having it as a separate partial is probably best so we can reuse it in other places if we need to like in issues and pd blocks if that comes up.

So it goes 

README => getJSON readme blob and decode
STRINGS/ABS... => regex over decoded text to replace relative paths with the html path
README => then send that to markdownify

inside markdownify
RENDER_IMAGE => replace github html path with github raw location
then getRemote and download that image

then process, resize etc as any other image

<!--Please reference the ticket you are addressing -->

#222 


## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
