### PR TITLE
Decouple step instructions to specific modules

### DIFF
--- a/common-content/en/module/how-our-curriculum-works/day-plan/index.md
+++ b/common-content/en/module/how-our-curriculum-works/day-plan/index.md
@@ -7,12 +7,6 @@ time= 30
     2="Identify some frequently used blocks in a module"
 +++
 
-Cohorts meet once a week in person.  Together, we develop our understanding of the topics we are working on this week. We use a **day plan** to organise this day. A day plan is an agenda with workshops, study sessions and activities to make the most of our time together. 
+Cohorts meet once a week in person. Together, we develop our understanding of the topics we are working on this week. We use a **day plan** to organise this day. A day plan is an agenda with workshops, study sessions and activities to make the most of our time together.
 
 There's a day plan for every sprint of every module. Each day plan lists a series of activities, with timings, instructions, and links to resources.
-
-### Steps 👣
-
-1. Go to the [module page for HTML-CSS](../../../html-css/)
-1. Briefly check the day plans for each sprint in this module
-1. Which blocks recur most often? Why do you think this is the case?

--- a/common-content/en/module/how-our-curriculum-works/importance-of-prep/index.md
+++ b/common-content/en/module/how-our-curriculum-works/importance-of-prep/index.md
@@ -6,6 +6,4 @@ time= 30
     1="Explain the importance of prep"
 +++
 
-In a flipped learning model, learners are expected to **prepare** before they meet up as a community. Therefore, regular preparation is essential for our community to self-educate together. In each sprint week, we expect trainees to work on the prep section beforehand to start building their own mental model of the week's concepts.
-
-Here is an example of prep from the first JavaScript module to gain an example of what trainees will be expected to engage with before an in-person session: https://curriculum.codeyourfuture.io/js1/sprints/1/prep/
+In a flipped learning model, learners are expected to **prepare** before they meet up as a community. Therefore, regular preparation is essential for our community to self-educate together. In each sprint week, we expect trainees to work on the prep section beforehand to start building their mental model of the week's concepts.

--- a/common-content/en/module/how-our-curriculum-works/morning-orientation-block/index.md
+++ b/common-content/en/module/how-our-curriculum-works/morning-orientation-block/index.md
@@ -11,7 +11,6 @@ We use the morning orientation block to gather the community together. We nomina
 
 ### Steps 👣
 
-1. Go to the [🗓️ day plan for JS3 sprint 1](https://curriculum.codeyourfuture.io/js3/sprints/1/day-plan/)
-1. Locate the morning orientation block in the day plan
-1. Read the instructions for the morning orientation block
+1. Search for **morning orientation** on the curriculum website
+1. Find a day plan view where the morning orientation is used
 1. Check the learning objectives on the morning orientation block

--- a/common-content/en/module/how-our-curriculum-works/study-groups/index.md
+++ b/common-content/en/module/how-our-curriculum-works/study-groups/index.md
@@ -11,7 +11,7 @@ In a flipped classroom, we spend our time in class focused on active learning: w
 
 ### Steps 👣
 
-1. Go to the [🗓️ day plan for Module-HTML-CSS sprint 1](https://curriculum.codeyourfuture.io/Module-HTML-CSS/sprints/1/day-plan/)
-1. Locate a **study groups** block on the day plan
+1. Search for **study group** on the curriculum website
+1. Find a day plan that uses the **study group** block
 1. Read the instructions on the block
 1. Check the learning objectives for the study group block


### PR DESCRIPTION
## What does this change?

Some of the **How our curriculum works** blocks currently point to other modules that won't exist in the new ITP. Just updating the instructions so the blocks are more reusable and less coupled to any particular module.

### Common Content?

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #issue-number

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Module | Sprint | Page Type | Block Type

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
