### PR TITLE
add a page class so custom themes can target pages easily

### DIFF
--- a/common-theme/layouts/_default/baseof.html
+++ b/common-theme/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]>      <html class="no-js"> <!<![endif]-->
-<html lang="en">
+<html lang="en" class="p-{{ (.Layout | default .Kind ) | urlize | lower }}">
   {{- partial "head.html" . -}}
   <body>
     <a class="c-skip-link e-button" id="skip-link" href="#main">Skip to main</a>


### PR DESCRIPTION
## What does this change?

### Common Theme?

add a page class so when building other layouts it's easy to target specific pages without hassle

```scss
.p-home {
overrides here
}
```

### Org Content?

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
