### PR TITLE
Bugfix 733 : tweak mobile usability on solo view

### DIFF
--- a/common-theme/assets/scripts/solo-view.js
+++ b/common-theme/assets/scripts/solo-view.js
@@ -101,7 +101,7 @@ class SoloView extends HTMLElement {
   // Handle swipe gesture
   handleSwipeGesture = (startX, endX) => {
     const deltaX = endX - startX;
-    const swipeThreshold = 30;
+    const swipeThreshold = 96;
     if (deltaX > swipeThreshold) {
       // Swipe right (previous)
       this.navigateBack(new Event("swipe"));

--- a/common-theme/assets/scripts/solo-view.js
+++ b/common-theme/assets/scripts/solo-view.js
@@ -101,7 +101,7 @@ class SoloView extends HTMLElement {
   // Handle swipe gesture
   handleSwipeGesture = (startX, endX) => {
     const deltaX = endX - startX;
-    const swipeThreshold = 96;
+    const swipeThreshold = 144;
     if (deltaX > swipeThreshold) {
       // Swipe right (previous)
       this.navigateBack(new Event("swipe"));

--- a/common-theme/assets/styles/03-elements/base.scss
+++ b/common-theme/assets/styles/03-elements/base.scss
@@ -16,6 +16,13 @@ html {
 html {
   overflow-x: hidden;
 }
+@media (max-width: $c-med) {
+  body {
+    overflow-x: hidden;
+    max-width: 100svw;
+    height: max-content;
+  }
+}
 
 @keyframes fade-in {
   0% {

--- a/common-theme/assets/styles/04-components/page-header.scss
+++ b/common-theme/assets/styles/04-components/page-header.scss
@@ -106,7 +106,7 @@
     .c-page-header--solo & .c-toc {
       max-height: none;
       @media (max-width: $c-med) {
-        max-height: 10vh;
+        max-height: 12ch;
       }
     }
   }

--- a/common-theme/assets/styles/layout/footer.scss
+++ b/common-theme/assets/styles/layout/footer.scss
@@ -2,7 +2,7 @@
   @include grid-assign(github, impressum, mode);
 
   grid-template:
-    "...... . ......... ." var(--theme-spacing--6)
+    "...... . ......... ." calc(2 * var(--theme-spacing--6))
     "github . impressum mode" minmax(0, 1fr)
     "github . ......... mode" var(--theme-spacing--touchtarget)
     "...... . ......... ." var(--theme-spacing--gutter) /


### PR DESCRIPTION
## What does this change?

### Common Theme?

Addresses #733 

1. Increase swipe to 96, or 2x tap target. Could go up to 144 edit, yes, 144
2. Swap 10vh height on toc to 12ch, so it will always show 3-5 lines
3. Kill the side scroll breaking out right

I might fiddle more with the toc later. 

Test on any prep view  eg https://deploy-preview-734--cyf-curriculum.netlify.app/js3/sprints/1/prep/

On a small mobile phone

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
