### PR TITLE
stub static cms PREVIEW

### DIFF
--- a/content/employability/example-post/index-md.md
+++ b/content/employability/example-post/index-md.md
@@ -1,0 +1,5 @@
+---
+title: Example post
+description: example description
+emoji: 🥳
+---

--- a/org-cyf-guides/static/admin/config.yml
+++ b/org-cyf-guides/static/admin/config.yml
@@ -1,0 +1,76 @@
+backend:
+  name: git-gateway
+  branch: main
+publish_mode: editorial_workflow
+media_folder: static/img
+public_folder: /img
+collections:
+  - name: "employability"
+    identifier_field: toml
+    label: "Employability"
+    folder: "content/employability"
+    create: true
+    path: "{{slug}}/index.md"
+    editor:
+      preview: true
+    fields:
+      - { label: "Title", name: "title", widget: "string", required: true }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: true,
+        }
+       - { label: "Emoji", name: "emoji", widget: "string", required: true }
+  - name: "contributing"
+  identifier_field: toml
+    label: "Contributing"
+    folder: "content/contributing"
+    create: true
+    path: "{{slug}}/index.md"
+    editor:
+      preview: true
+    fields:
+      - { label: "Title", name: "title", widget: "string", required: true }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: true,
+        }
+      - { label: "Emoji", name: "emoji", widget: "string", required: true }
+  - name: "deploying"
+    identifier_field: toml
+    label: "deploying"
+    folder: "content/deploying"
+    create: true
+    path: "{{slug}}/index.md"
+    editor:
+      preview: true
+    fields:
+      - { label: "Title", name: "title", widget: "string", required: true }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: true,
+        }
+      - { label: "Emoji", name: "emoji", widget: "string", required: true }
+  - name: "contributing"
+  identifier_field: toml
+    label: "Reviewing"
+    folder: "content/reviewing"
+    create: true
+    path: "{{slug}}/index.md"
+    editor:
+      preview: true
+    fields:
+      - { label: "Title", name: "title", widget: "string", required: true }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: true,
+        }
+      - { label: "Emoji", name: "emoji", widget: "string", required: true }
+  

--- a/org-cyf-guides/static/admin/config.yml
+++ b/org-cyf-guides/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: feature/cms
+  branch: main
 publish_mode: editorial_workflow
 media_folder: static/img
 public_folder: /img
@@ -32,7 +32,7 @@ collections:
           label: "Emoji",
           name: "emoji",
           widget: "string",
-          pattern: ['/\p{Emoji_Presentation}/gu', "Must be an emoji"],
+          pattern: ["^.{1,2}$", "No more than 2 characters allowed"],
           required: true,
         }
       - { label: "Content", name: "body", widget: "markdown", required: true }

--- a/org-cyf-guides/static/admin/config.yml
+++ b/org-cyf-guides/static/admin/config.yml
@@ -14,7 +14,13 @@ collections:
     editor:
       preview: true
     fields:
-      - { label: "Title", name: "title", widget: "string", const pattern = ['^.{1,55}$', 'Must have between 1 and 55 characters'], required: true }
+      - {
+          label: "Title",
+          name: "title",
+          widget: "string",
+          pattern: ["^.{1,55}$", "Must have between 1 and 55 characters"],
+          required: true,
+        }
       - { label: "Publish Date", name: "date", widget: "datetime" }
       - {
           label: "Description",
@@ -29,4 +35,4 @@ collections:
           pattern: ['/\p{Emoji_Presentation}/gu', "Must be an emoji"],
           required: true,
         }
-      - { label: "Body", name: "body", widget: "markdown", required: true }
+      - { label: "Content", name: "body", widget: "markdown", required: true }

--- a/org-cyf-guides/static/admin/config.yml
+++ b/org-cyf-guides/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: main
+  branch: feature/cms
 publish_mode: editorial_workflow
 media_folder: static/img
 public_folder: /img
@@ -21,56 +21,4 @@ collections:
           widget: "string",
           required: true,
         }
-       - { label: "Emoji", name: "emoji", widget: "string", required: true }
-  - name: "contributing"
-  identifier_field: toml
-    label: "Contributing"
-    folder: "content/contributing"
-    create: true
-    path: "{{slug}}/index.md"
-    editor:
-      preview: true
-    fields:
-      - { label: "Title", name: "title", widget: "string", required: true }
-      - {
-          label: "Description",
-          name: "description",
-          widget: "string",
-          required: true,
-        }
       - { label: "Emoji", name: "emoji", widget: "string", required: true }
-  - name: "deploying"
-    identifier_field: toml
-    label: "deploying"
-    folder: "content/deploying"
-    create: true
-    path: "{{slug}}/index.md"
-    editor:
-      preview: true
-    fields:
-      - { label: "Title", name: "title", widget: "string", required: true }
-      - {
-          label: "Description",
-          name: "description",
-          widget: "string",
-          required: true,
-        }
-      - { label: "Emoji", name: "emoji", widget: "string", required: true }
-  - name: "contributing"
-  identifier_field: toml
-    label: "Reviewing"
-    folder: "content/reviewing"
-    create: true
-    path: "{{slug}}/index.md"
-    editor:
-      preview: true
-    fields:
-      - { label: "Title", name: "title", widget: "string", required: true }
-      - {
-          label: "Description",
-          name: "description",
-          widget: "string",
-          required: true,
-        }
-      - { label: "Emoji", name: "emoji", widget: "string", required: true }
-  

--- a/org-cyf-guides/static/admin/config.yml
+++ b/org-cyf-guides/static/admin/config.yml
@@ -14,11 +14,19 @@ collections:
     editor:
       preview: true
     fields:
-      - { label: "Title", name: "title", widget: "string", required: true }
+      - { label: "Title", name: "title", widget: "string", const pattern = ['^.{1,55}$', 'Must have between 1 and 55 characters'], required: true }
+      - { label: "Publish Date", name: "date", widget: "datetime" }
       - {
           label: "Description",
           name: "description",
           widget: "string",
           required: true,
         }
-      - { label: "Emoji", name: "emoji", widget: "string", required: true }
+      - {
+          label: "Emoji",
+          name: "emoji",
+          widget: "string",
+          pattern: ['/\p{Emoji_Presentation}/gu', "Must be an emoji"],
+          required: true,
+        }
+      - { label: "Body", name: "body", widget: "markdown", required: true }

--- a/org-cyf-guides/static/admin/index.html
+++ b/org-cyf-guides/static/admin/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Content Manager</title>
+    <!-- Include the script that enables Netlify Identity on this page. -->
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@staticcms/app@^4.0.0/dist/main.css"
+    />
+    <link rel="cms-config-url" type="text/yaml" href="/admin/config.yml" />
+  </head>
+  <body>
+    <!-- Include the script that builds the page-->
+    <script src="https://unpkg.com/@staticcms/app@^4.0.0/dist/static-cms-app.js"></script>
+    <script>
+      CMS.init();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What does this change?


### Org Content?

CYF GUIDES > admin 

Ported the static CMS setup hanging out in a stale PR on CYF PD to see if we can give people some access to content on the guides impl. 

Just want to preview this to see what it's like really

https://deploy-preview-752--cyf-guides.netlify.app/admin/
https://app.netlify.com/sites/cyf-guides/overview

OK here's the deal.

I'm going to put this CMS on guides and just for employability for now.  I will likely also put it on common content BUT not if it means people start bypassing the review process. 

If we feel we want these on more sections, we can add them in per collection or per module. But we can't bypass the review process or we will get more low quality text creeping back in. So I reserve the right to remove these CMS-es if this happens. Stern face! (I do mean this - I will take it away)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
