### PR TITLE
Persisting confetti checkbox values in localStorage

### DIFF
--- a/common-theme/assets/scripts/confetti-checkboxes.js
+++ b/common-theme/assets/scripts/confetti-checkboxes.js
@@ -47,6 +47,9 @@ class ConfettiCheckboxes extends HTMLElement {
         );
         if (this.allChecked) {
           this.triggerConfetti();
+          this.updateAnnouncer("Well done! You've completed all the objectives!");
+        } else {
+          this.updateAnnouncer("");
         }
       });
     });
@@ -57,6 +60,10 @@ class ConfettiCheckboxes extends HTMLElement {
       resize: true,
       useWorker: true,
     })({ particleCount: 200, spread: 170 });
+  }
+
+  updateAnnouncer(text) {
+    this.querySelector("#announcer").textContent = text;
   }
 }
 

--- a/common-theme/assets/scripts/confetti-checkboxes.js
+++ b/common-theme/assets/scripts/confetti-checkboxes.js
@@ -28,11 +28,20 @@ class ConfettiCheckboxes extends HTMLElement {
     this.allChecked = false;
 
     this.addCheckboxListeners();
+    this.initialiseCheckboxValues();
+  }
+
+  initialiseCheckboxValues() {
+    this.checkboxes.forEach((checkbox, index) => {
+      const savedValue = localStorage.getItem(`confetti-checks-${window.location.pathname}-${index}`)
+      checkbox.checked = savedValue === 'true';
+    });
   }
 
   addCheckboxListeners() {
-    this.checkboxes.forEach((checkbox) => {
+    this.checkboxes.forEach((checkbox, index) => {
       checkbox.addEventListener("change", () => {
+        localStorage.setItem(`confetti-checks-${window.location.pathname}-${index}`, checkbox.checked)
         this.allChecked = Array.from(this.checkboxes).every(
           (checkbox) => checkbox.checked
         );

--- a/common-theme/layouts/partials/objectives/block.html
+++ b/common-theme/layouts/partials/objectives/block.html
@@ -5,3 +5,4 @@
     </li>
   {{ end }}
 </ul>
+<div id="announcer" aria-live="polite"></div>


### PR DESCRIPTION
## What does this change?

Persists confetti checkbox values in localStorage so trainees can track progress across sessions.

### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #758 

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

@CodeYourFuture/global-syllabus 
