### PR TITLE
fix up overview to show again

### DIFF
--- a/common-theme/layouts/overview/list.html
+++ b/common-theme/layouts/overview/list.html
@@ -4,8 +4,11 @@
   {{ partial "page-header.html" . }}
 
   {{ .Page.Content }}
-
-  {{ range .Site.Menus.syllabus }}
+  {{ $overviewMenu := .Page.Params.overview_menu }}
+  {{ if not $overviewMenu }}
+    {{ errorf "You must define a menu in your overview_menu front matter param" }}
+  {{ end }}
+  {{ range index .Site.Menus $overviewMenu }}
     {{ $moduleURL := .URL }}
     {{ $moduleTitle := .Page.Params.Title }}
     <!-- We lazily show the module title only if there's actual content under it.-->

--- a/common-theme/layouts/overview/list.html
+++ b/common-theme/layouts/overview/list.html
@@ -1,5 +1,4 @@
 {{ define "main" }}
-
   {{ $site := .Site }}
 
   {{ partial "page-header.html" . }}
@@ -13,22 +12,26 @@
     {{ $hasShownModuleTitle := false }}
 
     {{ range where $site.Pages "Section" .Page.Section }}
+      {{ $thisSection := .Section }}
+
       {{ if or (not .Params.Theme) (not (in .Params.menu_level "module")) }}
         {{ continue }}
       {{ end }}
       {{ $themePage := . }}
       {{ $relevantBlocksPage := or .Params.blocks_page_for_overview "prep" }}
-      {{ range where $site.Pages "Section" $themePage.Section }}
-        {{ if not (strings.HasPrefix .Path (printf "%s/%s/" (path.Dir $themePage.Path) $relevantBlocksPage)) }}
-          {{ continue }}
-        {{ end }}
+      {{/* this is the same strategy used on success page. Look there for how to add extra pages */}}
+      {{ $prep := .Site.GetPage (printf "%sprep/index.md"
+        .CurrentSection.RelPermalink)
+      }}
+      {{ with $prep }}
         {{ if not $hasShownModuleTitle }}
           <h4><a href="{{ $moduleURL }}">{{ $moduleTitle }}</a></h4>
           {{ $hasShownModuleTitle = true }}
         {{ end }}
-        <!-- This is a pretty sketchy way to make this link URL, but there doesn't seem to be an obvious way to get this link otherwise.-->
-        <h5><a href="/{{ path.Dir .Path }}">{{ $themePage.Params.Theme }}</a></h5>
-        <ol style="list-style: none;">
+        <h5>
+          <a href="{{ $prep.Permalink }}">{{ $themePage.Params.Theme }}</a>
+        </h5>
+        <ol>
           {{ range .Params.blocks }}
             {{ $block := ($site.GetPage .src) }}
             {{ if or $block.Params.hide_from_overview (strings.Contains .src "https:") }}
@@ -36,9 +39,8 @@
             {{ end }}
             <li>{{ $block.Title }}</li>
           {{ end }}
-        {{ end }}
-      </ol>
+        </ol>
+      {{ end }}
     {{ end }}
-
   {{ end }}
 {{ end }}

--- a/org-cyf/content/overview/_index.md
+++ b/org-cyf/content/overview/_index.md
@@ -1,6 +1,7 @@
 +++
 title="Course overview"
 layout="overview"
+overview_menu="syllabus"
 +++
 
 ## Objective


### PR DESCRIPTION
## What does this change?

<!-- Add a description of what your PR changes here -->


### Common Theme?

overview page - changed the get file lines to get page object instead
now the themes and blocks show up again

<!--Please reference the ticket you are addressing -->

Issue number: #issue-number

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
