### PR TITLE
Use correct variable for map module length

### DIFF
--- a/common-theme/layouts/partials/map.html
+++ b/common-theme/layouts/partials/map.html
@@ -1,25 +1,26 @@
 {{ with .Params.map }}
   <div class="c-map">
     <h1 class="e-heading c-map__start is-none--lt-container">👉🏾</h1>
-    {{ range $i, $currentMapSection := . }}
+    {{ range $i, $currentMapSectionName := . }}
+      {{ $currentMapSectionModules := index site.Menus $currentMapSectionName }}
       <section class="c-map__block">
         <h2 class="e-heading c-map__title">
           📍{{ $i }}:
-          {{ $currentMapSection }}
+          {{ $currentMapSectionName }}
         </h2>
         <ol class="c-map__timeline">
           {{/* Check if a menu for the current map section exists */}}
-          {{ with index site.Menus $currentMapSection }}
+          {{ if $currentMapSectionModules }}
             {{/* Range over the items in the menu */}}
-            {{ range $iterator, $module := . }}
+            {{ range $iterator, $module := $currentMapSectionModules }}
               <li
                 class="c-map__stop"
-                style="--layer:{{ sub (len $currentMapSection) (add $iterator 1) }}">
+                style="--layer:{{ sub (len $currentMapSectionModules) (add $iterator 1) }}">
                 {{ partial "card.html" $module }}
               </li>
             {{ end }}
           {{ else }}
-            <li>No items found for {{ $currentMapSection }}</li>
+            <li>No items found for {{ $currentMapSectionName }}</li>
           {{ end }}
         </ol>
       </section>


### PR DESCRIPTION
Previously we were using the length of the _name_ as if it was the number of modules.

This introduces more explicit variable names for both.