### PR TITLE
Two small tests for content

### DIFF
--- a/common-theme/layouts/_default/day-plan.html
+++ b/common-theme/layouts/_default/day-plan.html
@@ -4,7 +4,12 @@
       "c-page-header--toc"
     }}
     {{ partial "page-header.html" . }}
-    <section class="l-page__main c-copy">{{ .Content }}</section>
+    {{ with .Content }}
+      <section class="l-page__main c-copy">{{ . }}</section>
+    {{ end }}
+    {{ if not .Params.blocks }}
+      {{ errorf "There are no blocks on the %s page. Make sure this day plan has blocks." $.Page.RelPermalink }}
+    {{ end }}
     <time-stamper>
       <div class="c-block__series c-block__series--timeline">
         {{ range $index, $block := .Params.blocks }}

--- a/common-theme/layouts/_default/success.html
+++ b/common-theme/layouts/_default/success.html
@@ -36,11 +36,16 @@
           {{ range $dayplan.Params.blocks }}
             {{ if . }}{{ $blocks = $blocks | append . }}{{ end }}
           {{ end }}
+          {{/* If you don't have any blocks but you do have places to get them from */}}
+          {{ if and (not $blocks) $dayplan $prep }}
+            {{ errorf "There are no learning objectives on the %s page. Make sure this module has learning objectives." $.Page.RelPermalink }}
+          {{ end }}
           {{/* Deduplicate blocks */}}
           {{ $blocks = $blocks | uniq }}
           {{/* now we need to extract objectives from blocks, some not stored in this repo,
             so we will use the block-data scratch function to get the block data
           */}}
+
           {{ range $blocks }}
             {{ $name := .name }}
             {{ $src := .src }}


### PR DESCRIPTION
## What does this change?


### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes

Here are two small tests to make sure
1. the success page is compiling learning objectives, as this has broken silently before
2. the day plan has blocks on it, because without blocks it has no value

I have **not** added a third, more controversial test, on line 27 of prep.html

```
{{ else}}
  {{ errorf "%s has no blocks in the front matter. Add blocks or remove the page" $.Page.RelPermalink }}
{{ end }}
```
As the sites would currently fail to build (13 blank views in the SDC). But pls consider this. 

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
