### PR TITLE
Bugfixes: update hugo module name

### DIFF
--- a/org-cyf-itp/content/overview/_index.md
+++ b/org-cyf-itp/content/overview/_index.md
@@ -1,6 +1,7 @@
 +++
 title="Course overview"
 layout="overview"
+overview_menu="programming"
 +++
 
 ## Objective

--- a/org-cyf-itp/go.mod
+++ b/org-cyf-itp/go.mod
@@ -1,4 +1,4 @@
-module github.com/CodeYourFuture/curriculum/org-cyf
+module github.com/CodeYourFuture/curriculum/org-cyf-itp
 
 go 1.21.3
 

--- a/org-cyf-itp/go.sum
+++ b/org-cyf-itp/go.sum
@@ -1,9 +1,5 @@
-github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240114132825-493a89648721 h1:txnduLXqSKf3XHb/g74uhpGltb9FgyrdrMeC/Ce3vr0=
-github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240114132825-493a89648721/go.mod h1:w5rIm9hJlHD+CYpQEVMWE/6WaE/EiLmYVs18Kw/iH0s=
 github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240121151641-e52b73ad527d h1:WfPdLoNvxOrNx3GB+DpYlpEH57v98h0KWXpidN+xdOo=
 github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240121151641-e52b73ad527d/go.mod h1:e3J+XphCBJJ8kf6S9ykVxNY1VKPWJoYuDFXEizlDpCI=
-github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240114132825-493a89648721 h1:GSd+9AsvXJEjy2AvsP79YBpmMRhxydDhVvlbD5x5DKg=
-github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240114132825-493a89648721/go.mod h1:lWiQfXWr0Uc517tksx7D5p5ZoXo9bxRoJ0or+z9mRyk=
 github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240121151641-e52b73ad527d h1:ILE8f9gXLEPEyrJVBdFRVa0Uszf9OVdK4LjXZjCLUag=
 github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240121151641-e52b73ad527d/go.mod h1:kzt+J4JYp5C3GD1dX0rf7vY5fsTUc6Drrn+7p7pjmLg=
 github.com/CodeYourFuture/curriculum/org-cyf-guides v0.0.0-20240606160122-fc5c72085f6b h1:GHzTJJAonmevEAYcLIz8E9D8t0GuvfU9Ke+98cDQnws=


### PR DESCRIPTION
## What does this change?



### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

updated name of Hugo module from org-cyf to org-cyf-itp
I need this to pull this course into a portal

Also the fixed overview page wants a nominated menu so I nominated one so the site would build -- Daniel loves to fail a build and I love to pass them :P 

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
