### PR TITLE
Add netlify deploy script

### DIFF
--- a/common-content/deploy-netlify.sh
+++ b/common-content/deploy-netlify.sh
@@ -1,0 +1,1 @@
+../deploy-netlify.sh

--- a/common-theme/deploy-netlify.sh
+++ b/common-theme/deploy-netlify.sh
@@ -1,0 +1,1 @@
+../deploy-netlify.sh

--- a/deploy-netlify.sh
+++ b/deploy-netlify.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# We set --baseURL on netlify so that any references to .Permalink end up pointing at deploy preview pages, rather than being hard-coded to point at the production URLs.
+hugo --minify --baseURL $DEPLOY_PRIME_URL && npx pagefind --site "public"

--- a/org-cyf-guides/deploy-netlify.sh
+++ b/org-cyf-guides/deploy-netlify.sh
@@ -1,0 +1,1 @@
+../deploy-netlify.sh

--- a/org-cyf-itp/deploy-netlify.sh
+++ b/org-cyf-itp/deploy-netlify.sh
@@ -1,0 +1,1 @@
+../deploy-netlify.sh

--- a/org-cyf-piscine/deploy-netlify.sh
+++ b/org-cyf-piscine/deploy-netlify.sh
@@ -1,0 +1,1 @@
+../deploy-netlify.sh

--- a/org-cyf-sdc/deploy-netlify.sh
+++ b/org-cyf-sdc/deploy-netlify.sh
@@ -1,0 +1,1 @@
+../deploy-netlify.sh

--- a/org-cyf/deploy-netlify.sh
+++ b/org-cyf/deploy-netlify.sh
@@ -1,0 +1,1 @@
+../deploy-netlify.sh

--- a/org-mcb/deploy-netlify.sh
+++ b/org-mcb/deploy-netlify.sh
@@ -1,0 +1,1 @@
+../deploy-netlify.sh


### PR DESCRIPTION
We were previously not setting --baseURL which means that deploy previews have internal links to the prod deploys rather than the deploy previews.

Instead we introduce a script so that we can edit for all of the sites without needing to go change several site configs each time we want to make a change.