### PR TITLE
Add morning orientation block to all ITP day plans

### DIFF
--- a/common-content/en/module/induction/install-vscode/index.md
+++ b/common-content/en/module/induction/install-vscode/index.md
@@ -9,7 +9,7 @@ emoji= '🧩'
     2='Identify the key parts of the VSCode interface'
 +++
 
-We use VS Code to write all of our code in the course. It is known as an Integrated Developer Environment (IDE) and really helps you write great code!
+We use VS Code to write all of our code in the course. It is known as an Integrated Development Environment (IDE) and really helps you write great code!
 
 
 [🔗 Download and install VSCode now](https://code.visualstudio.com/)

--- a/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
@@ -8,6 +8,10 @@ weight = 3
 name="Energiser"
 src="blocks/energiser"
 [[blocks]]
+name="Morning orientation"
+src="blocks/morning-orientation"
+time=15
+[[blocks]]
 name="Workshop"
 src="blocks/workshop"
 time="120"

--- a/org-cyf-itp/content/data-groups/sprints/2/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/2/day-plan/index.md
@@ -8,6 +8,10 @@ weight = 3
 name="Energiser"
 src="blocks/energiser"
 [[blocks]]
+name="Morning orientation"
+src="blocks/morning-orientation"
+time=15
+[[blocks]]
 name="Workshop"
 src="blocks/workshop"
 time="120"

--- a/org-cyf-itp/content/data-groups/sprints/3/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/3/day-plan/index.md
@@ -8,6 +8,10 @@ weight = 3
 name="Energiser"
 src="blocks/energiser"
 [[blocks]]
+name="Morning orientation"
+src="blocks/morning-orientation"
+time=15
+[[blocks]]
 name="Workshop"
 src="blocks/workshop"
 time="120"

--- a/org-cyf-itp/content/structuring-data/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/structuring-data/sprints/1/day-plan/index.md
@@ -8,6 +8,10 @@ weight = 3
 name="Energiser"
 src="blocks/energiser"
 [[blocks]]
+name="Morning orientation"
+src="blocks/morning-orientation"
+time=15
+[[blocks]]
 name="Workshop"
 src="blocks/workshop"
 time="120"

--- a/org-cyf-itp/content/structuring-data/sprints/2/day-plan/index.md
+++ b/org-cyf-itp/content/structuring-data/sprints/2/day-plan/index.md
@@ -8,6 +8,10 @@ weight = 3
 name="Energiser"
 src="blocks/energiser"
 [[blocks]]
+name="Morning orientation"
+src="blocks/morning-orientation"
+time=15
+[[blocks]]
 name="Workshop"
 src="blocks/workshop"
 time="120"

--- a/org-cyf-itp/content/structuring-data/sprints/3/day-plan/index.md
+++ b/org-cyf-itp/content/structuring-data/sprints/3/day-plan/index.md
@@ -8,6 +8,10 @@ weight = 3
 name="Energiser"
 src="blocks/energiser"
 [[blocks]]
+name="Morning orientation"
+src="blocks/morning-orientation"
+time=15
+[[blocks]]
 name="Workshop"
 src="blocks/workshop"
 time="120"

--- a/org-cyf-itp/content/user-data/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/user-data/sprints/1/day-plan/index.md
@@ -8,6 +8,10 @@ weight = 3
 name="Energiser"
 src="blocks/energiser"
 [[blocks]]
+name="Morning orientation"
+src="blocks/morning-orientation"
+time=15
+[[blocks]]
 name="Workshop"
 src="blocks/workshop"
 time="120"

--- a/org-cyf-itp/content/user-data/sprints/2/day-plan/index.md
+++ b/org-cyf-itp/content/user-data/sprints/2/day-plan/index.md
@@ -8,6 +8,10 @@ weight = 3
 name="Energiser"
 src="blocks/energiser"
 [[blocks]]
+name="Morning orientation"
+src="blocks/morning-orientation"
+time=15
+[[blocks]]
 name="Workshop"
 src="blocks/workshop"
 time="120"

--- a/org-cyf-itp/content/user-data/sprints/3/day-plan/index.md
+++ b/org-cyf-itp/content/user-data/sprints/3/day-plan/index.md
@@ -8,6 +8,10 @@ weight = 3
 name="Energiser"
 src="blocks/energiser"
 [[blocks]]
+name="Morning orientation"
+src="blocks/morning-orientation"
+time=15
+[[blocks]]
 name="Workshop"
 src="blocks/workshop"
 time="120"


### PR DESCRIPTION
## What does this change?

Add morning orientation block to all ITP day plans

### Common Content?

Minor change, making IDE = Integrated Development Environment

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #671 

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Module

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

@CodeYourFuture/itp-syllabus-team 