### PR TITLE
Feature: add a gradio codeblock

### DIFF
--- a/common-theme/layouts/_default/_markup/render-codeblock-gradio.html
+++ b/common-theme/layouts/_default/_markup/render-codeblock-gradio.html
@@ -1,0 +1,17 @@
+{{/* this converts a fenced code block to a gradio lite playground
+  it's pretty slow, so use it wisely
+  it's looking for ```gradio
+*/}}
+<script
+  type="module"
+  crossorigin
+  src="https://cdn.jsdelivr.net/npm/@gradio/lite/dist/lite.js"></script>
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@gradio/lite/dist/lite.css" />
+{{/* TODO, slice files, create requirements delimiter
+  https://www.gradio.app/guides/gradio-lite#more-examples-adding-additional-files-and-requirements
+*/}}
+<gradio-lite playground>
+  <gradio-file name="app.py" entrypoint>{{ .Inner |safeHTML }}</gradio-file>
+</gradio-lite>


### PR DESCRIPTION
## What does this change?

adds a render hook for gradio-lite playgrounds using Pyodide
https://www.gradio.app/guides/gradio-lite#what-is-gradio-lite
With @gradio/lite, you can write regular Python code for your Gradio applications, and they will run seamlessly in the browser 

This is a bit slow in my view -- 5 seconds to load on my machine.  I've done a super simple minimal implementation. If it proves useful and we want things like requirements and separate files, we can elaborate later.

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes

This is a render hook, so just like with `mermaid` or `objectives` it expects a fenced code block with the string `gradio` after the opening three ticks.

It loads Gradio using Pyodide and renders a Python playground. I have put it on the string gradio and not `python` because I expect we will want to build more jupyter notebooks at some point? 

## Test

write a fenced code block in any markdown block with the string gradio appended

```gradio
import gradio as gr

def greet(name):
    return "Hello, " + name + "!"

gr.Interface(greet, "textbox", "textbox").launch()
```
<img width="1435" alt="Screenshot 2024-07-11 at 17 38 04" src="https://github.com/CodeYourFuture/curriculum/assets/42203406/92c30a91-5e93-4890-a201-24441eb39adf">


## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
