### PR TITLE
feature: remove pin to CYF inside data.html

### DIFF
--- a/common-theme/layouts/partials/block/data.html
+++ b/common-theme/layouts/partials/block/data.html
@@ -47,7 +47,7 @@
 {{ else }}
   {{ if "github" | in $src }}
     {{/* Change base URL to api.github.com */}}
-    {{ $newSrc := replace $src "https://github.com/CodeYourFuture/" "https://api.github.com/repos/CodeYourFuture/" }}
+    {{ $newSrc := replace $src "https://github.com/" "https://api.github.com/repos/" }}
 
     {{ if (in $src "issues") }}
       {{ .Scratch.SetInMap "blockData" "type" "issue" }}


### PR DESCRIPTION
I had this on the previous version
and just remembered it while fixing up migracode
