### PR TITLE
Bugfix: events bubble up through multiple WC

### DIFF
--- a/common-theme/assets/scripts/multiple-choice.js
+++ b/common-theme/assets/scripts/multiple-choice.js
@@ -54,7 +54,7 @@ class MultipleChoice extends HTMLElement {
   addListeners() {
     this.radios.forEach((radio) =>
       radio.addEventListener("change", (event) =>
-        this.updateFeedback(Number(event.target.value))
+        this.updateFeedback(Number(event.target.value), { passive: true })
       )
     );
   }

--- a/common-theme/assets/scripts/multiple-choice.js
+++ b/common-theme/assets/scripts/multiple-choice.js
@@ -27,10 +27,14 @@ class MultipleChoice extends HTMLElement {
   render() {
     this.shadowRoot.innerHTML = `
             <style>
+            :host {
+            display:block;
+            max-width: var(--theme-spacing--linelength);
+            }
             ::slotted([slot="feedback"]) {
                 background: var(--theme-color--outline);
                 padding: var(--theme-spacing--1) var(--theme-spacing--gutter);
-                margin: calc(-1 * var(--theme-spacing--6)) var(--theme-spacing--gutter) var(--theme-spacing--4);
+                margin: calc(-1 * var(--theme-spacing--6)) 0 var(--theme-spacing--gutter) 0;
             }
             </style>
             <slot name="quiz"></slot>

--- a/common-theme/assets/scripts/solo-view.js
+++ b/common-theme/assets/scripts/solo-view.js
@@ -14,7 +14,11 @@ class SoloView extends HTMLElement {
       touchEndX: 0,
     };
     // Adding window and doc event listeners
-    window.addEventListener("hashchange", this.handleFragment.bind(this));
+    window.addEventListener(
+      "hashchange",
+      { passive: true },
+      this.handleFragment.bind(this)
+    );
     document.addEventListener("keydown", this.handleKeydown.bind(this));
   }
 
@@ -74,7 +78,7 @@ class SoloView extends HTMLElement {
       { passive: true }
     );
 
-    this.addEventListener("keydown", this.handleKeydown);
+    this.addEventListener("keydown", this.handleKeydown, { passive: true });
   }
 
   // Update current block index

--- a/common-theme/assets/styles/03-elements/forms.scss
+++ b/common-theme/assets/styles/03-elements/forms.scss
@@ -1,5 +1,5 @@
 form {
-  padding: var(--theme-spacing--2);
+  padding: var(--theme-spacing--2) 0;
   width: 100%;
   margin: 0 auto var(--theme-spacing--4);
   border: none;

--- a/common-theme/layouts/partials/multiple-choice.html
+++ b/common-theme/layouts/partials/multiple-choice.html
@@ -33,16 +33,16 @@
         <ol class="c-quiz__list">
            {{range $index, $answer := $answers }}
           <li class="c-quiz__answer">
-            <input
+            <label
+              class="c-quiz__label"
+              for="answer-{{ $index }}"
+              ><input
               class="c-quiz__input"
               type="radio"
               id="answer-{{ $index }}"
               name="answer"
               value="{{ $index }}" />
-            <label
-              class="c-quiz__label"
-              for="answer-{{ $index }}"
-              >{{ $answer }}</label
+            {{ $answer }}</label
             >
           </li>
         {{ end }}


### PR DESCRIPTION
## What does this change?

When my multiple choice component was nested inside the solo-view, the label wasn't triggering the radio selection. This is not accessible - the entire label must be clickable. 

There's no particular reason this association should be blocked in any context, and it's a little murky to me as to why it would do this. However, I fixed it by marking everything I could as passive, which signals that the default event should never be prevented.  I didn't compose a custom event because this native behaviour already exists and I want it to Just Work. 

### Common Theme?

This is common theme, solo-view and multiple choice web components. 

Issue number: #issue-number

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
