### PR TITLE
Bugfix: dedupe learning objectives better

### DIFF
--- a/common-theme/layouts/_default/success.html
+++ b/common-theme/layouts/_default/success.html
@@ -41,10 +41,17 @@
             {{ errorf "There are no learning objectives on the %s page. Make sure this module has learning objectives." $.Page.RelPermalink }}
           {{ end }}
           {{/* Deduplicate blocks */}}
-          {{ $blocks = $blocks | uniq }}
-          {{/* now we need to extract objectives from blocks, some not stored in this repo,
-            so we will use the block-data scratch function to get the block data
-          */}}
+          {{ $uniqueSrcs := slice }}
+          {{ $dedupedBlocks := slice }}
+
+          {{ range $blocks }}
+            {{ if not (in $uniqueSrcs .src) }}
+              {{ $uniqueSrcs = $uniqueSrcs | append .src }}
+              {{ $dedupedBlocks = $dedupedBlocks | append . }}
+            {{ end }}
+          {{ end }}
+
+          {{ $blocks = $dedupedBlocks }}
 
           {{ range $blocks }}
             {{ $name := .name }}


### PR DESCRIPTION
## What does this change?

On success pages, learning objectives are repeated in this case

How it works now

Given a success page
When a block is repeated on a day plan or prep page
And it has different values for name or time
Then it will be repeated on the success page

How it should work

Given a success page
When a block is repeated on a day plan or prep page
And it has different values for name or time
Then it will be shown once on the success page
And the learning objectives will not be repeated

Learning objectives belong to blocks, so don't exist in a block list, where each block has the mandatory properties name and src, plus some other optionals like time or caption.

However, as the .src  must always be repeated for it to actually be a repeat, we can dedupe the slice of blocks where .src is unique.


### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes

<!--Please reference the ticket you are addressing -->

Issue number: I actually started writing this bug up and as I wrote the above it was obvious it was a tiny fix.


## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
