### PR TITLE
Feature: block viewer  for docs 

### DIFF
--- a/common-theme/archetypes/blocks/index.md
+++ b/common-theme/archetypes/blocks/index.md
@@ -1,7 +1,11 @@
 +++
 title = '{{ replace .Name "-" " " | title }}'
 time = 30
-headless = true
+[[cascade]]
+  [cascade.build]
+    list = 'local'
+    publishResources = true
+    render = 'never'
 facilitation = false
 hide_from_overview=false
 threads = ['unassigned']

--- a/common-theme/assets/styles/04-components/page-header.scss
+++ b/common-theme/assets/styles/04-components/page-header.scss
@@ -79,6 +79,12 @@
       background-color: transparent;
       text-shadow: none;
     }
+    .c-page-header--solo & {
+      max-width: 8ch;
+      overflow-x: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
   }
   &__subtitle {
     display: flex;

--- a/common-theme/layouts/_default/block-viewer.html
+++ b/common-theme/layouts/_default/block-viewer.html
@@ -1,0 +1,60 @@
+{{ define "main" }}
+  <solo-view tabindex="0">
+    {{ $blockTitles := slice .Title }}
+    {{ range .Pages }}
+      {{ $blockTitles = $blockTitles | append .Title }}
+    {{ end }}
+    {{ .Scratch.Set "tocList" $blockTitles }}
+    {{ .Scratch.Set "headerClass" "c-page-header--solo" }}
+    <div slot="header">{{ partial "page-header.html" . }}</div>
+    <div slot="blocks">
+      {{ with .Content }}
+        <section class="l-page__main c-block c-copy">{{ . }}</section>
+      {{ end }}
+      <section class="c-block">
+        <h2>{{ .Title }} block viewer</h2>
+        <p>
+          This block viewer lets you flick through all the existing blocks in
+          the {{ .Title }} folder so you can choose what parts to add to your
+          pages and what parts you might want to create, revise, or leave out.
+        </p>
+        <p>
+          It's literally just an alphabetical list of whatever is in this
+          folder.
+        </p>
+      </section>
+      {{ $currentDir := .File.Dir }}
+      {{ with .Site.GetPage $currentDir }}
+        {{ range .Pages }}
+          <section class="c-block c-block--local">
+            <div class="c-block__body" tabindex="0">
+              <header class="c-block__header">
+                <h2
+                  class="c-block__title e-heading__2"
+                  id="{{ .Title |urlize }}">
+                  {{ .Title }}
+                </h2>
+                {{ partial "time.html" . }}
+              </header>
+              {{ with .Params.Objectives }}
+                <details>
+                  <summary>
+                    <h3 class="e-heading__5">Learning Objectives</h3>
+                  </summary>
+                  {{ partial "objectives/block.html" . }}
+                </details>
+              {{ end }}
+              <div class="c-block__content c-copy">{{ .Content }}</div>
+            </div>
+          </section>
+        {{ end }}
+      {{ end }}
+    </div>
+    <nav slot="nav">
+      <a href="#" class="e-button c-solo-view__back">&larr; Back</a>
+      <a href="#" class="e-button c-solo-view__next">Next &rarr;</a>
+    </nav>
+  </solo-view>
+  {{ $soloView := resources.Get "scripts/solo-view.js" | resources.Minify }}
+  <script src="{{ $soloView.RelPermalink }}" defer></script>
+{{ end }}

--- a/common-theme/layouts/partials/block/data.html
+++ b/common-theme/layouts/partials/block/data.html
@@ -67,7 +67,7 @@
     {{/* TODO pull time from commented out front matter in Github readmes */}}
   {{ end }}
 
-  {{ if "cyf-pd.netlify.app" | in $src }}
+  {{ if or ("cyf-pd.netlify.app" | in $src) ("/pd/"| in $src) }}
     {{ .Scratch.SetInMap "blockData" "type" "pd" }}
     {{ $blockPath := replace $src "https://cyf-pd.netlify.app/blocks/" "pd/blocks/" }}
     {{ $blockPath := replace $blockPath "/readme/" "" }}

--- a/common-theme/layouts/partials/page-header.html
+++ b/common-theme/layouts/partials/page-header.html
@@ -1,14 +1,20 @@
+{{/* This giant chunk of logic is all about whether to produce a table of contents */}}
 {{ $hasTOC := false }}
 {{ $mdTOC := false }}
 {{ $blockTOC := false }}
 {{ $headerClass := .Scratch.Get "headerClass" }}
-{{ if and
-  (gt .Page.WordCount 400) (.Page.TableOfContents)
+{{ $forcedHeadings := .Page.Scratch.Get "tocList"}}
+{{/*  if we have a long page and table of contents is turned on in hugo.toml, 
+or is we have made a forced list of headings,
+then go ahead and make a TOC */}}
+{{ if or $forcedHeadings (and
+  (gt .Page.WordCount 400) (.Page.TableOfContents))
 }}
   {{ $hasTOC = true }}
   {{ $mdTOC = true }}
 {{ end }}
-{{ if (and (or (eq .Layout "prep") (eq .Layout "day-plan")) (gt .Params.blocks 1)) }}
+{{/*  if we have a prep or dayplan layout AND more than one block, then TOC  */}}
+{{ if and (or (eq .Layout "prep") (eq .Layout "day-plan") ) (gt .Params.blocks 1) }}
   {{ $hasTOC = true }}
   {{ $mdTOC = true }}
   {{ $blockTOC = true }}
@@ -53,6 +59,10 @@
       {{ end }}
     {{ end }}
     <!--TOC-->
+    {{/*  We do all that logic up top because here
+    we need to merge in the TOC from the markdown 
+    and the TOC created from blocks set in front matter, 
+    that Hugo can't see by default.  */}}
     {{ if $hasTOC }}
       <div class="c-page-header__toc " id="toc">
         <section class="c-toc" aria-label="Table of contents.">
@@ -71,6 +81,13 @@
                   >
                   {{ if "youtu" | in .src }}📼{{ end }}
                 </li>
+              {{ end }}
+            </ol>
+          {{ end }}
+          {{ with $forcedHeadings }}
+            <ol>
+            {{ range . }}
+                <li><a href="#{{ . | urlize }}" data-pagefind-weight="5">{{ . }}</a></li>
               {{ end }}
             </ol>
           {{ end }}

--- a/common-theme/layouts/partials/time.html
+++ b/common-theme/layouts/partials/time.html
@@ -3,7 +3,7 @@
   1. set in the [[blocks]] array in the frontmatter of prep or day plan ??
   2. set in the front matter of a block ??
   3. set in any external api that is accessed ??
-  4. default 60
+  4. default 60 TODO we want this to be 0 really - can we update the front matter?
 
   The point of setting time is to help trainees and volunteers understand
   how long to spend on activities.
@@ -13,7 +13,17 @@
   TODO: make this opt in for a simple time block if that comes up.
 */}}
 {{ $blockData := .Page.Scratch.Get "blockData" }}
-{{ $time := $blockData.time | default .Page.Params.time | default 0 }}
+{{/* Sometimes we're not using blocks, but local pages, and we might want time then too */}}
+{{ $localBlock := "" }}
+{{ if and $blockData (eq $blockData.type "local") }}
+  {{ $localBlock = .Page.Site.GetPage $blockData.api }}
+  {{ $localBlock = $localBlock.Params.time }}
+{{ else }}
+  {{ $localBlock := .Params.time }}
+{{ end }}
+{{ $time := $blockData.time | default $localBlock | default 60 }}
+
+
 <time
   class="c-block__time"
   tabindex="0"

--- a/common-theme/layouts/partials/time.html
+++ b/common-theme/layouts/partials/time.html
@@ -14,16 +14,16 @@
 */}}
 {{ $blockData := .Page.Scratch.Get "blockData" }}
 {{/* Sometimes we're not using blocks, but local pages, and we might want time then too */}}
-{{ $localBlock := "" }}
-{{ if and $blockData (eq $blockData.type "local") }}
-  {{ $localBlock = .Page.Site.GetPage $blockData.api }}
-  {{ $localBlock = $localBlock.Params.time }}
-{{ else }}
-  {{ $localBlock := .Params.time }}
+{{ $localBlock := "0" }}
+{{ if not $blockData }}
+  {{ $localBlock = .Site.GetPage .File.Path }}
+  {{ $localBlock = $localBlock.Params.Time }}
+{{ end }}
+{{ if eq $blockData.type "local" }}
+  {{ $localBlock = .Site.GetPage $blockData.api }}
+  {{ $localBlock = $localBlock.Params.Time }}
 {{ end }}
 {{ $time := $blockData.time | default $localBlock | default 60 }}
-
-
 <time
   class="c-block__time"
   tabindex="0"

--- a/common-theme/layouts/partials/time.html
+++ b/common-theme/layouts/partials/time.html
@@ -13,11 +13,7 @@
   TODO: make this opt in for a simple time block if that comes up.
 */}}
 {{ $blockData := .Page.Scratch.Get "blockData" }}
-{{ $localBlock := .Page.Site.GetPage $blockData.api }}
-{{ if $localBlock }}
-  {{ $localBlock = $localBlock.Params.time }}
-{{ end }}
-{{ $time := $blockData.time | default $localBlock | default 60 }}
+{{ $time := $blockData.time | default .Page.Params.time | default 0 }}
 <time
   class="c-block__time"
   tabindex="0"

--- a/common-theme/layouts/shortcodes/blocklink.html
+++ b/common-theme/layouts/shortcodes/blocklink.html
@@ -1,4 +1,12 @@
-{{/* shortcode: blocklink.html */}}
+{{/* shortcode: blocklink.html
+
+  {{<blocklink
+  src="https://emojipedia.org/bellhop-bell"
+  name="Example usage"
+  caption="Must exist"
+  time="25"/
+>}}
+*/}}
 {{ $src := .Get "src" }}
 {{ $name := .Get "name" | default "" }}
 {{ $caption := .Get "caption" | default "exist" }}

--- a/common-theme/layouts/shortcodes/columns.html
+++ b/common-theme/layouts/shortcodes/columns.html
@@ -1,3 +1,12 @@
+{{/* Puts anything into columns and distributes them evenly across a page.
+  Example:
+  {{< columns
+>}}Column
+1 <---> Column 2 <---> Column
+3{{< /columns >}}
+
+*/}}
+
 <div class="c-columns">
   {{ $cols := split .Inner "<--->" }}
   {{ range $cols }}

--- a/common-theme/layouts/shortcodes/logos.html
+++ b/common-theme/layouts/shortcodes/logos.html
@@ -1,3 +1,7 @@
+{{/* Shows a load of logos in a grid. Common piece of UI.
+  Usage:  {{< logos "Financial"
+>}}
+*/}}
 {{ $filter := slice (.Get 0) }}
 
 {{ with and $filter $.Site.Data.funding }}

--- a/common-theme/layouts/shortcodes/note.html
+++ b/common-theme/layouts/shortcodes/note.html
@@ -1,3 +1,11 @@
+{{/* Example usage:
+
+  {{<note title="Yo" type="tip"
+>}}
+This is a note.
+{{< /note >}}
+*/}}
+
 <section class="c-note c-note--{{ .Get "type" | default "exercise" }}">
   <h4 class="c-note__title e-heading__4">
     <span class="c-note__title-text">{{ .Get "title" | default "Note" }}</span>


### PR DESCRIPTION
Addresses #469 

I've written another documentation site. I threw away the first one because it didn't address the real questions users have.

To make this work I need to do three main bits of work:

1. Build a new view called block-viewer. I've put this in common-theme because people might want it for something else later. 

This view takes any blocks stored in a folder and displays them in a solo view format so you can page through them to take a quick look. 

Then the rest of the tweaks are stuff I encountered as I wrote the docs today, and are listed in the commit messages.

Once this PR is merged, move on to the actual docs site, which I will open soon common-docs #846 

Then the final piece is making some changes to common-content. Where previously we used headless=true to prevent render, this also suppresses section listing. (Even though it claims not to, it does.) #845 

So instead we're updating it to the new system, build cascade and turning off rendering https://gohugo.io/content-management/build-options

I will add an index to each module folder with a description and so on, and that will create a navigable directory of blocks to view.

## To review

Honestly the main goal here is to check we haven't broken anything. Obviously I have run over things myself but I am only a human bean.

This PR mainly messes around with

- page header -- shows on every page, allows us to manually force a table of contents by passing a slice of headings to the Page Scratch, along with our other manual TOC creation
- time -- I revised this slightly to a) simplify it and b) make it not break if we don't have any $blockData for whatever reason. This should also mean you can use timers on non-block views like single.
- data - I revised the PD block to also work with mounted content as I confidently explained it did this in the docs and then realised the check was missing

