### PR TITLE
Feature: a mathjax render hook

### DIFF
--- a/common-docs/content/common-theme/blocks/prep/index.md
+++ b/common-docs/content/common-theme/blocks/prep/index.md
@@ -4,7 +4,7 @@ description="The solo study and setup work for a sprint"
 time=1
 [build]
   render= 'never'
-  list='local'
+  list='never'
 +++
 
 ### Block composition

--- a/common-docs/content/common-theme/render-hooks/math.md
+++ b/common-docs/content/common-theme/render-hooks/math.md
@@ -1,0 +1,28 @@
++++
+title="Math"
+description="MathJax scientific notation"
+emoji="🧮"
+menu=["hooks"]
++++
+
+[MathJax](https://www.mathjax.org/) [works on Github](htthttps://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions), too. Any math you write on Github (in a readme or issue for example) will render here in the same way.
+
+I've only set up code blocks to render math for now, so no inline notation.
+
+### Invoke
+
+{{<columns>}}
+
+````
+```math
+\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
+```
+````
+
+<--->
+
+```math
+\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
+```
+
+{{</columns>}}

--- a/common-theme/layouts/_default/_markup/render-codeblock-math.html
+++ b/common-theme/layouts/_default/_markup/render-codeblock-math.html
@@ -1,0 +1,13 @@
+<script
+  id="MathJax-script"
+  defer
+  async
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
+<div class="math" style="width:fit-content">$${{- .Inner | safeHTML }}$$</div>
+
+{{/* GitHub supports math with MathJax so I've bunged it in here too. I've skipped
+  the inline options and just put in the code fence . As my guess is it will
+  constantly break on the GetRemote blocks otherwise.
+  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions
+*/}}


### PR DESCRIPTION
## What does this change?

documentation here: https://deploy-preview-862--cyf-common-docs.netlify.app/common-theme/render-hooks/math/

github has this so we should also. if someone writes math on github we want to display it as they expect

we may need it a bit in the sdc for a couple of things, but actually I want to draw logic and binary, which this doesn't do adequately

We should maybe put in CircuiTikz to draw logic, and something else to do the thing I might want to do with binary, or maybe we use a scrim.

https://www.mathjax.org/
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes

<!--Please reference the ticket you are addressing -->

It's a render hook shortcode to add math with the string `math`

````
```math
````



## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)


