### PR TITLE
content: port Launch content

### DIFF
--- a/common-content/en/energisers/bad-interview-answers/index.md
+++ b/common-content/en/energisers/bad-interview-answers/index.md
@@ -1,0 +1,26 @@
++++
+title="Bad Interview Answers"
+emoji="🤦‍♂️"
+hide_from_overview=true
+time=15
+[objectives]
+1="Wake up"
+3="Have a laugh"
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+
++++
+
+### Setup
+
+Grab a list of [common interview questions](https://www.coursera.org/articles/behavioral-interview-questions) from somewhere like Coursera.
+
+### Game {{<timer>}}15{{</timer>}}
+
+1. **Interviewer**: Cold call a random person and ask them an interview question. Choose an ordinary question.
+
+2. **Interviewee**: You must give a terrible answer to this question (keep it clean, please!). Then cold call another person to be the interviewer.
+
+3. **Interviewer**: Give absolutely straight-faced feedback. If you laugh, you’re out and must nominate another player to complete your feedback and return the game to step 1.

--- a/common-content/en/module/piscine/blockers/index.md
+++ b/common-content/en/module/piscine/blockers/index.md
@@ -1,0 +1,22 @@
++++
+title="🚧 Blockers"
+emoji="🚧"
+time=25
+objectives = ["Identify any blockers or dependencies in your project. ", "Sequence the work to be done.","Decouple work to be done in parallel.","Propose solutions to blockers."]
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
++++
+
+Identify any blockers or dependencies in your project. What must be done first? What can be "decoupled" and done in parallel? The better you can identify these, the more efficient your team will be. Discuss these blockers as a team and decide how to solve them while you are all together and can help each other.
+
+#### Describe your blocker
+
+Describing the problem systematically will take you most of the way to resolving the blocker. Use the following template on a ticket on your board:
+
+1. **What you did**: Describe what you have done so far. Give links and code snippets.
+1. **What you expected**: Describe what you expected to happen.
+1. **What actually happened**: Describe what actually happened.
+
+Blockers can feel frustrating, but in reality they are opportunities to explore and solve problems. This is what engineering is all about. 🌱

--- a/common-content/en/module/piscine/development/index.md
+++ b/common-content/en/module/piscine/development/index.md
@@ -1,71 +1,28 @@
 +++
 title="Team Development"
 emoji="🧑🏿‍🔧"
-headless="true"
 time=120
 objectives = [
     "Create a strategy for implementing an application based on a set of user stories.",
     "Interpret business requirements and express them as test cases.",
     "Design interactions with a provided data set.",
     "Open a pull request and iterate on it in response to feedback."]
+[[blocks.nested.blocks]]
+name="Pomodoro"
+src="module/piscine/pomodoro"
+[[blocks.nested.blocks]]
+name="Blockers"
+src="module/piscine/blockers"
+[[blocks.nested.blocks]]
+name="Pair Programming"
+src="module/piscine/pairing"
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
   
 +++
 
 This time is set aside for you to work together as a team to make progress on your project.
 
 Remember: At your interview, you may be asked about _any_ code in your project, not just the code you wrote. You need to understand and be able to explain the code your team mates wrote. Make sure you read their code, review it, and talk to them about it.
-
-Here are some strategies to help you work effectively together:
-
-<details>
-<summary>
-
-### 🍅 Pomodoro
-
-</summary>
-
-Each team member take a small-scoped ticket. Set a timer for {{<timer>}}25{{</timer>}}. Use this focused time to complete your ticket and open a PR.
-
-⌛ Time's up! Take a {{<timer>}}5{{</timer>}} break! Make a cup of tea. Walk around a bit.
-
-Now set a new {{<timer>}}25{{</timer>}} and review each PR as a group.
-
-⌛ Time's up! Take a {{<timer>}}5{{</timer>}} break! Make a cup of tea. Stretch! Look at how much progress you made in one hour. ✨
-
-</details>
-<details>
-<summary>
-
-### 🧭 Pair programming
-
-</summary>
-
-- Switch between driver and navigator roles after {{<timer>}}10{{</timer>}}
-- The "driver" is the person typing on the keyboard, just thinking about what needs to be written
-- The "navigator" reviews what the driver is doing and is thinking about to write next
-- Don't dominate - this is teamwork
-
-⌛ Time's up! Take a {{<timer>}}5{{</timer>}} break! Make a cup of tea. Good job, partners!
-
-</details>
-
-<details>
-<summary>
-
-### 🚧 Blockers
-
-</summary>
-
-Identify any blockers or dependencies in your project. What must be done first? What can be "decoupled" and done in parallel? The better you can identify these, the more efficient your team will be. Discuss these blockers as a team and decide how to solve them while you are all together and can help each other.
-
-#### Describe your blocker
-
-Describing the problem systematically will take you most of the way to resolving the blocker. Use the following template on a ticket on your board:
-
-1. **What you did**: Describe what you have done so far. Give links and code snippets.
-1. **What you expected**: Describe what you expected to happen.
-1. **What actually happened**: Describe what actually happened.
-
-Blockers can feel frustrating, but in reality they are opportunities to explore and solve problems. This is what engineering is all about. 🌱
-
-</details>

--- a/common-content/en/module/piscine/pairing/index.md
+++ b/common-content/en/module/piscine/pairing/index.md
@@ -1,0 +1,18 @@
++++
+title="Pair programming"
+emoji="🧑🏿‍🔧🧑🏿‍🔧"
+time=25
+objectives = [
+    "Drive and navigate in a pair programming session"]
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
++++
+
+- Switch between driver and navigator roles after {{<timer>}}10{{</timer>}}
+- The "driver" is the person typing on the keyboard, just thinking about what needs to be written
+- The "navigator" reviews what the driver is doing and is thinking about to write next
+- Don't dominate - this is teamwork
+
+⌛ Time's up! Take a {{<timer>}}5{{</timer>}} break! Make a cup of tea. Good job, partners!

--- a/common-content/en/module/piscine/pomodoro/index.md
+++ b/common-content/en/module/piscine/pomodoro/index.md
@@ -1,0 +1,19 @@
++++
+title="Pomodoro"
+emoji="🍅"
+time=60
+objectives = [
+    "Complete a small-scoped ticket in 25 minutes"]
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
++++
+
+Each team member, take a small-scoped ticket. Set a timer for {{<timer>}}25{{</timer>}}. Use this focused time to complete your ticket and open a PR.
+
+⌛ Time's up! Take a {{<timer>}}5{{</timer>}} break! Make a cup of tea. Walk around a bit.
+
+Now set a new {{<timer>}}25{{</timer>}} and review each PR as a group.
+
+⌛ Time's up! Take a {{<timer>}}5{{</timer>}} break! Make a cup of tea. Stretch! Look at how much progress you made in one hour. ✨

--- a/common-content/en/module/piscine/review/index.md
+++ b/common-content/en/module/piscine/review/index.md
@@ -1,0 +1,14 @@
++++
+title="Review a Pull Request"
+emoji="🚧"
+time=25
+objectives = ["Step through a pull request", "Ask clarifying questions to secure your understanding", "Ask for changes or offer suggestions"]
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
++++
+
+You have opened at least one pull request this week and likely several more. (If you have not, your tickets are too big and you need to scope them down.)
+
+In this session, you will review a pull request from a teammate, and they will review yours. You should be doing this during the week anyway, but this session is a chance to talk in person, ask clarifying questions, and make changes together.

--- a/org-cyf-launch/content/blocks/application-form/index.md
+++ b/org-cyf-launch/content/blocks/application-form/index.md
@@ -1,0 +1,11 @@
++++
+title="Apply to the Launch Module"
+time= 180
+hide_from_overview=true
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeALGoPPaOWIKUC4_rwe77UfJOAnZR5Y38uGEfmohs4pANGKw/viewform?embedded=true" width="640" height="1880" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>

--- a/org-cyf-launch/content/blocks/demo-time/index.md
+++ b/org-cyf-launch/content/blocks/demo-time/index.md
@@ -1,0 +1,27 @@
++++
+title="Demo Time!"
+description="All teams will show the amazing work they have done so far."
+modules="The Launch"
+week="2"
+skills=["Communication","Confidence"]
+objectives=["Present your achievements in a 5-min demo"]
+time=60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+You have two main goals for today:
+
+1. Make your demo in 5 minutes
+
+2. Appraise your peers' demo, asking questions if you have any.
+
+### Your demo {{< timer >}}5{{< /timer >}}
+
+1. ⏱️ A timekeeper should keep time and call the teams in a random order.
+2. 🪧 Make sure your presentation is up and running.
+3. 🫣 Do some nerve-calming exercises so you feel more confident.
+4. 😅 Smile.
+5. ✨ Present amazingly.

--- a/org-cyf-launch/content/blocks/deploy-early-deploy-often/index.md
+++ b/org-cyf-launch/content/blocks/deploy-early-deploy-often/index.md
@@ -1,0 +1,21 @@
++++
+title="Deploy early, deploy often"
+time= 60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+objectives =['Deploy your project to a live environment']
++++
+
+## Hello, World!
+
+What use are plans without delivery? The most common cause of failure in the Launch is not deploying our code.
+
+We need to deploy our project to a live environment as soon as possible. It is better to have something than nothing. It is better to have a simple version of your project in use than a complex plan that is only a slideshow.
+
+Build the simplest thing you can. Deploy it. Get feedback. Improve it. Repeat.
+
+As a team, you should deploy your project to a live environment **at least once a day**. This is the best way to ensure that you are making progress in manageable steps.
+
+Deploy your project to a live environment now. It can (and should!) just say "Hello, World!".

--- a/org-cyf-launch/content/blocks/design-your-product/index.md
+++ b/org-cyf-launch/content/blocks/design-your-product/index.md
@@ -1,0 +1,32 @@
++++
+title="Design your product"
+description="You now have clarity of what your MVP will be like. The next step is designing your solution."
+modules="The Launch"
+week="1"
+skills=["Teamwork","Problem Solving"]
+objectives=["Design a Minimum Viable Product"]
+time=60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+When designing and defining mock-ups as a team, we bring to life our ideas.
+We discuss which one is the best and then define how we want to move forward.
+
+With mockups, we can show stakeholders what the product might look like. Simple mockups keep it open for them to suggest changes in layout, images, colour, styles, etc.
+
+1. Work on the exercise 3.3 on this [Miro
+   board](https://miro.com/app/board/uXjVM-LblbI=/?share_link_id=993024794808)
+2. Validate your mock-up with stakeholders, business owners or any available user
+
+<iframe width="768" height="432" src="https://miro.com/app/live-embed/uXjVM-LblbI=/?moveToViewport=-40824,8158,3744,2281&embedId=996621620306" frameborder="0" scrolling="no" allow="fullscreen; clipboard-read; clipboard-write" allowfullscreen></iframe>
+
+<details>
+<summary>Brand resources</summary>
+
+Later, you can use these resources to define your brand:
+
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fdesign%2FZ8RyCDpF8PLwGQLcUd3zTCFl%2FCYF-UXUI-Design%3Fnode-id%3D5221-4438%26t%3De9fISMjsUrJtsCB5-1" allowfullscreen></iframe>
+</details>

--- a/org-cyf-launch/content/blocks/development-time/index.md
+++ b/org-cyf-launch/content/blocks/development-time/index.md
@@ -1,0 +1,19 @@
++++
+title="Team Development"
+emoji="🧑🏿‍🔧"
+time=120
+objectives = [
+    "Create a strategy for implementing an application based on a set of user stories.",
+    "Interpret business requirements and express them as test cases.",
+    "Design interactions with a provided data set.",
+    "Open a pull request and iterate on it in response to feedback."]
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+  
++++
+
+This time is set aside for you to work together as a team to make progress on your project. Don't waste it.
+
+Here are some activities you can do during this time:

--- a/org-cyf-launch/content/blocks/entry-criteria/index.md
+++ b/org-cyf-launch/content/blocks/entry-criteria/index.md
@@ -1,0 +1,22 @@
++++
+title="Entry Criteria"
+time=10
+hide_from_overview=true
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+Everyone on a team must be able to contribute to the project. To be invited to join a team for The Launch, you must have
+
+```objectives
+- Kept the commitments you made in your trainee agreement
+- Completed all your mandatory coursework
+- Met your milestones (“At” or “Beyond”)
+- Applied to join the project with your CV, cover letter, and a portfolio
+- Built, tested, deployed and demoed 2 Products using a stack you learned on the SDC, where at least 1 project is completed in a team
+- Passed the interview in which you demo the Full Stack Product. It includes technical and competency-based questions.
+```
+
+Your Launch Project team may ask you to meet some extra conditions to help you personally become more employable. This is at their discretion and will be set out in a Trainee Contract you will sign before the project kickoff.

--- a/org-cyf-launch/content/blocks/how-to-apply/index.md
+++ b/org-cyf-launch/content/blocks/how-to-apply/index.md
@@ -1,0 +1,16 @@
++++
+title="How to apply"
+time= 5
+hide_from_overview=true
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+Please submit your application by the date set by your cohort organisers. Applications received after this date cannot be considered.
+
+**Round 1:** Everyone who meets the requirements above will be invited to the next round
+**Round 2:** Everyone who passes the minimum bar on this technical test will be invited to interview for the roles. During this round, you will demo your Product. The interview includes technical and competency-based questions.
+
+Those successful at the interview will be invited to join the team. Everyone will be offered feedback on their performance, and all unsuccessful candidates are welcome to re-apply in the next round.

--- a/org-cyf-launch/content/blocks/implementation-details/index.md
+++ b/org-cyf-launch/content/blocks/implementation-details/index.md
@@ -6,6 +6,10 @@ week="1"
 skills=["Teamwork","Time/Project Management"]
 objectives=["Identify identities, resources, and data in your proposed system", "Clarify technical jargon"]
 time=30
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
 +++
 
 When planning your work, you have two important aspects: 1) understanding the implementation **constraints** and opportunities and 2) writing your user stories.

--- a/org-cyf-launch/content/blocks/implementation-details/index.md
+++ b/org-cyf-launch/content/blocks/implementation-details/index.md
@@ -1,0 +1,30 @@
++++
+title="Implementation details"
+description="Identifying constraints and opportunities in the implementation of your product."
+modules="The Launch"
+week="1"
+skills=["Teamwork","Time/Project Management"]
+objectives=["Define a user story","Write a user story"]
+time=30
++++
+
+When planning your work, you have two important aspects: 1) understanding the implementation **constraints** and opportunities and 2) writing your user stories.
+
+### Implementation details
+
+Define the implementation details for your product. Discuss your implementation details. During the discussion, clarify the technical jargon so everyone can understand and be part of the discussion.
+
+1. What information will we need and/or provide to do that? For example, what pages could you have, and which endpoints must you use?
+
+2. What entities/resources/data will we have in the system?
+
+3. What information do we need to store to achieve the goals? Define the collections in the database.
+
+4. What are we going to need to expose to the React app? Examples:
+
+5. 1. Are you going to have an endpoint for a resource?
+   2. Do you need calculation or aggregation between the database and the frontend?
+   3. What will the REST API look like?
+6. We sketched out the page previously. Do we need to review it? How could we decompose them into separate [components](https://syllabus.codeyourfuture.io/react/week-1/lesson) to work on?
+
+7. Identify the "edges" between different tasks (e.g. you have to agree on an API so that the backend and frontend match up or on the props passed between a parent component and a child component)

--- a/org-cyf-launch/content/blocks/implementation-details/index.md
+++ b/org-cyf-launch/content/blocks/implementation-details/index.md
@@ -4,7 +4,7 @@ description="Identifying constraints and opportunities in the implementation of 
 modules="The Launch"
 week="1"
 skills=["Teamwork","Time/Project Management"]
-objectives=["Define a user story","Write a user story"]
+objectives=["Identify identities, resources, and data in your proposed system", "Clarify technical jargon"]
 time=30
 +++
 
@@ -25,6 +25,6 @@ Define the implementation details for your product. Discuss your implementation 
 5. 1. Are you going to have an endpoint for a resource?
    2. Do you need calculation or aggregation between the database and the frontend?
    3. What will the REST API look like?
-6. We sketched out the page previously. Do we need to review it? How could we decompose them into separate [components](https://syllabus.codeyourfuture.io/react/week-1/lesson) to work on?
+6. We sketched out the page previously. Do we need to review it? How could we decompose them into separate components to work on?
 
 7. Identify the "edges" between different tasks (e.g. you have to agree on an API so that the backend and frontend match up or on the props passed between a parent component and a child component)

--- a/org-cyf-launch/content/blocks/job-description/index.md
+++ b/org-cyf-launch/content/blocks/job-description/index.md
@@ -1,0 +1,32 @@
++++
+title="Role Description"
+time= 20
+hide_from_overview=true
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+### The Launch - Full Stack Web Developer Role (or other roles)
+
+You will build an MVP product in a cross-functional Agile team. The project is 5 weeks long.
+
+### Duties and responsibilities
+
+- Design, code, verify, test, document, amend and refactor moderately complex programs/scripts
+- Apply agreed standards and tools to achieve a well-engineered result
+- Collaborate in reviews of work with others as appropriate
+- Present your work in technical demonstrations
+
+### Requirements and qualifications
+
+1. You are a CYF trainee in good standing, having completed all your mandatory coursework, met your course milestones and kept your commitments in your Trainee Agreement.
+1. You have a deployed portfolio with at least 6 projects, including 3 mandatory CYF module projects.
+
+#### Technical test: build and deploy a Product using the current stack you learned
+
+**Full Stack**: a full stack product including a simple end-to-end automated testing
+**Front End**: a front-end product including a simple end-to-end automated testing
+**UI/UX Designers**: must be the designer of a product
+**QA/QE**: an automated test suite for a previously built product during the course

--- a/org-cyf-launch/content/blocks/launch-prep/briefing/index.md
+++ b/org-cyf-launch/content/blocks/launch-prep/briefing/index.md
@@ -1,0 +1,25 @@
++++
+title="Your briefing"
+time= 60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+objectives="Ask clarifying questions about the product brief"
++++
+
+The briefing is a document that describes the product you should build. **You will be given a briefing on Slack.** It might be from a new partner, or it might be from {{<our-name>}}.
+
+You can read over likely projects on [/briefings](./briefings)
+
+### What you must do:
+
+      1. Read it by yourself
+
+      2. Discuss it with your team
+
+      3. Raise any questions before the start of the first week
+
+      4. Clarify the questions with the team
+
+If you have one, the Business Owner can help you with this guidance. If not, you as a team will decide. Validate your decisions by asking clarifying questions in Slack to check you are still achieving the goal of the briefing.

--- a/org-cyf-launch/content/blocks/launch-prep/contributions/index.md
+++ b/org-cyf-launch/content/blocks/launch-prep/contributions/index.md
@@ -10,18 +10,15 @@ objectives =['Explain how you be measured during the Launch', ]
 
 These contributions are expected from the trainees on the team:
 
-      1. **Roughly equal pull requests (PR)**: The team members should have roughly equal numbers of Pull requests each. We do not expect everyone to open the same number of PRs or commit the same number of lines of code, but we expect features to be fairly evenly shared.
-         As a quick guide, in a group of four, no one commits more than 33% of the features, and no one commits less than 20%. These contributions will be measured with a tracker similar to [this template](https://docs.google.com/spreadsheets/d/16vSSJgzCZJKF-2pwuBTkKjJJJ9i1CGRqMbYB-HEO5mo/edit?usp=sharing).
+1. **Roughly equal pull requests (PR)**: The team members should have roughly equal numbers of Pull requests each. We do not expect everyone to open the same number of PRs or commit the same number of lines of code, but we expect features to be fairly evenly shared.
+   As a quick guide, in a group of four, no one commits more than 33% of the features, and no one commits less than 20%. These contributions will be measured with a tracker similar to [this template](https://docs.google.com/spreadsheets/d/16vSSJgzCZJKF-2pwuBTkKjJJJ9i1CGRqMbYB-HEO5mo/edit?usp=sharing).
 
-      2. **Full-stack developer = front and back-end work:** A full-stack developer must deliver features that touch each stack part. This means that, at minimum, you must build a component of UI that interacts with the database and configure and manage that entire process. At best, this means multiple features across different parts of the stack.
+2. **Full-stack developer = front and back-end work:** A full-stack developer must deliver features that touch each stack part. This means that, at minimum, you must build a component of UI that interacts with the database and configure and manage that entire process. At best, this means multiple features across different parts of the stack.
 
-      3. **Know how to do these:** create your feature branch, do a good code review, scope down your PRs, mob your paired commits, resolve merge conflicts, and merge your Pull requests (PR).
+3. **Know how to do these:** create your feature branch, do a good code review, scope down your PRs, mob your paired commits, resolve merge conflicts, and merge your Pull requests (PR).
 
+Make sure the whole team understand the [exit criteria](../success). We know it isn’t perfect, but it’s the best way to measure everyone’s input so far.
 
-      Make sure the whole team understand the [exit criteria](../success). We know it isn’t perfect, but it’s the best way to measure everyone’s input so far.
+Find the template for your Launch group and add your team data.
 
-
-      Find the template for your Launch group and add your team data.
-
-
-      If the template hasn’t been set up, do it yourself and share it with the wider teams.
+If the template hasn’t been set up, do it yourself and share it with the wider teams.

--- a/org-cyf-launch/content/blocks/launch-prep/contributions/index.md
+++ b/org-cyf-launch/content/blocks/launch-prep/contributions/index.md
@@ -1,0 +1,27 @@
++++
+title="Contributions to the team"
+time= 15
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+objectives =['Explain how you be measured during the Launch', ]
++++
+
+These contributions are expected from the trainees on the team:
+
+      1. **Roughly equal pull requests (PR)**: The team members should have roughly equal numbers of Pull requests each. We do not expect everyone to open the same number of PRs or commit the same number of lines of code, but we expect features to be fairly evenly shared.
+         As a quick guide, in a group of four, no one commits more than 33% of the features, and no one commits less than 20%. These contributions will be measured with a tracker similar to [this template](https://docs.google.com/spreadsheets/d/16vSSJgzCZJKF-2pwuBTkKjJJJ9i1CGRqMbYB-HEO5mo/edit?usp=sharing).
+
+      2. **Full-stack developer = front and back-end work:** A full-stack developer must deliver features that touch each stack part. This means that, at minimum, you must build a component of UI that interacts with the database and configure and manage that entire process. At best, this means multiple features across different parts of the stack.
+
+      3. **Know how to do these:** create your feature branch, do a good code review, scope down your PRs, mob your paired commits, resolve merge conflicts, and merge your Pull requests (PR).
+
+
+      Make sure the whole team understand the [exit criteria](../success). We know it isn’t perfect, but it’s the best way to measure everyone’s input so far.
+
+
+      Find the template for your Launch group and add your team data.
+
+
+      If the template hasn’t been set up, do it yourself and share it with the wider teams.

--- a/org-cyf-launch/content/blocks/launch-prep/plan/index.md
+++ b/org-cyf-launch/content/blocks/launch-prep/plan/index.md
@@ -1,0 +1,43 @@
++++
+title="Weekly plan"
+time= 20
+hide_from_overview=true
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+objectives=[
+  "Explain the structure of the launch sprint week.",
+  "Schedule your daily stand-up, mid-week check-in, and Saturday meet-ups."
+]
++++
+
+You will continue working in sprints but with some extra meetings to ensure the team is aligned and on the same page.
+
+### 1. Daily Stand-up:
+
+- What? A daily update to your team and from your team to you about your workload. You will post a message every day and read all others, too.
+
+- Why? Ensure everyone knows who is working on what or who is blocked and needs help.
+
+- How? The easiest way is setting up a workflow/bot on Slack and everyone replying on the thread.
+
+### 2. Mid-week check-in
+
+- What? An online meeting during the week which all participants of the team can attend
+
+- Why? Review delivery, go into detail on anything that could not be worked out via Slack or pair programming, re-plan if needed
+
+- How? You can use Google Calendar and Google Meets or even have a workflow on Slack and use the huddle
+
+### 3. Saturday meet-ups
+
+In-person meeting with the following agenda:
+
+- Demo: show what you have worked on this week
+
+- Retrospective: review last week, celebrate and action
+
+- Sprint planning/Backlog Refinement: refine the user stories that will come next and which ones you will tackle in the coming week
+
+- Pair-programming: work together on the stories

--- a/org-cyf-launch/content/blocks/launch-prep/setup/index.md
+++ b/org-cyf-launch/content/blocks/launch-prep/setup/index.md
@@ -1,0 +1,23 @@
++++
+title="Set your team up on GitHub"
+time= 30
+hide_from_overview=true
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+objectives = ['Create a repository and Kanban board for your team using GitHub']
++++
+
+1.  Create a GitHub repository.
+
+- Pick one member to own the repo
+- Everyone else should be invited as a [collaborator](https://help.github.com/en/articles/inviting-collaborators-to-a-personal-repository)
+- You can fork [a starter kit](https://github.com/CodeYourFuture/cyf-final-project-starter-kit) for a basic project
+- Make sure you have the [extension for Paired and Mobbed](https://marketplace.visualstudio.com/items?itemName=RichardKotze.git-mob) PRs
+
+2. **Create a copy of this Project Board to manage your work** - [Project Board](https://github.com/orgs/CodeYourFuture/projects/13) on GitHub
+
+- Agree on which [columns](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/linking-a-repository-to-a-project-board) you need (Backlog, Ready for Dev, Code Review, etc).
+
+- [Link your repo](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/linking-a-repository-to-a-project-board) to your project board so you can do easily create user stories.

--- a/org-cyf-launch/content/blocks/launch-prep/setup/index.md
+++ b/org-cyf-launch/content/blocks/launch-prep/setup/index.md
@@ -20,4 +20,4 @@ objectives = ['Create a repository and Kanban board for your team using GitHub']
 
 - Agree on which [columns](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/linking-a-repository-to-a-project-board) you need (Backlog, Ready for Dev, Code Review, etc).
 
-- [Link your repo](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/linking-a-repository-to-a-project-board) to your project board so you can do easily create user stories.
+- [Link your repo](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/linking-a-repository-to-a-project-board) to your project board so you can easily create user stories.

--- a/org-cyf-launch/content/blocks/launch-prep/team/index.md
+++ b/org-cyf-launch/content/blocks/launch-prep/team/index.md
@@ -1,0 +1,43 @@
++++
+title="Your team"
+time=60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+objectives=['Define your team rules', 'Write a team agreement', 'Create your Slack channel']
++++
+
+Working in teams is one of the hardest things in our professional lives. This is because we are all different and have our opinions, values, and knowledge. Knowing how to work and respect each other is key to being a successful professional in tech.
+
+This exercise will explain your team formation and give tips on what you should define from the start to reduce conflicts.
+
+Your team will have:
+
+- 3 or 4 Developers: these will be other trainees you might know.
+
+- 1 [Tech Lead](https://docs.codeyourfuture.io/volunteers/teams-1/cyf-products-final-projects/roles/tech-lead-1): a volunteer who will support your team with the architecture and design of your product
+
+- 1 [Product Manager](https://docs.codeyourfuture.io/volunteers/teams-1/cyf-products-final-projects/roles/product-owner-cyf-product-or-product-manager-final-projects-1): a volunteer who will work with you to detail the scope and define the user stories
+
+You might also have the following members if a trainee focuses on this career.
+
+- QA (Tester)
+
+- [UI/UX Designer](https://docs.codeyourfuture.io/volunteers/teams-1/cyf-products-final-projects/roles/ui-ux-designer)
+
+You might have a [Business Owner](https://docs.codeyourfuture.io/volunteers/teams-1/cyf-products-final-projects/roles/business-owner-final-projects) representing the charity or organisation you are doing this briefing for. They will give your team insight into the users' needs and the value the product will deliver.
+
+## What do you need to do?
+
+Arrange a team meeting to go through the following agenda. You can use Exercises 1 and 2 of this [Miro board](https://miro.com/app/board/uXjVM-LblbI=/). (Exercise 3 is for the class)
+
+1. **Clarify roles and responsibilities**: review the roles and ensure everyone on the team understands what they are doing and how they will contribute.
+
+2. **Get to know each other**: everyone should say 1 thing/action they like and one they don’t like so that you get to know each other's ways of working. For example, I **_do not like_** having meetings early in the morning because it is my focus time. I **_like_** meetings to have a clear agenda so I can prepare beforehand.
+
+3. **Write a team agreement:** you will all respect these rules as a team. For example, I will let the team know if I cannot make a meeting.; I will prepare for the meetings beforehand.; I will commit my code to production whenever it has been approved and tested
+
+4. **Define your team's name**: you can just be called Team 3, but if you want to create an identity, you have all the freedom. Or it could be the name of the organisation the briefing is for.
+
+5. **Create your Slack channel** and add the relevant participants.

--- a/org-cyf-launch/content/blocks/launch-prep/welcome/index.md
+++ b/org-cyf-launch/content/blocks/launch-prep/welcome/index.md
@@ -1,0 +1,19 @@
++++
+title="Welcome to Launch Prep"
+time= 60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+objectives="Explain the goal of the launch module"
++++
+
+The Launch is the first of many products you will build in teams. To achieve
+this, you will need all your learnings from the year of the professional
+development competencies: communication, teamwork, problem-solving, time
+management and confidence. So make sure you go through the points you know you
+might need an extra reminder for and read them.
+
+But to get you and your team ready for The Launch, there are other things you need to do, too, and this prep work will walk you through them.
+
+Get ready to Launch your career!

--- a/org-cyf-launch/content/blocks/lean-ux/index.md
+++ b/org-cyf-launch/content/blocks/lean-ux/index.md
@@ -1,0 +1,23 @@
++++
+title ="Lean UX Canvas"
+week=1
+skills= ['Teamwork','Time/Project Management']
+objectives= ['Define an MVP on a Lean UX Canvas', 'Define a user story mapping,', 'Define features for your MVP']
+time= 60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+#### Define your product and features
+
+To ensure we can keep the scope lean and everyone understands the product, briefing and features the same way, follow these steps:
+
+Work on this Lean UX Canvas on this [Miro board](https://miro.com/app/board/uXjVM-LblbI=/?share_link_id=993024794808)
+
+<iframe width="768" height="480" src="https://miro.com/app/live-embed/uXjVM-LblbI=/?moveToViewport=-43915,-41973,13319,9517&embedId=557607016342" frameborder="0" scrolling="no" allow="fullscreen; clipboard-read; clipboard-write" allowfullscreen></iframe>
+
+1. Do a user story mapping (an example is on the same [Miro board](https://miro.com/app/board/uXjVM-LblbI=/?share_link_id=993024794808), Exercise 3.2)
+
+2. Define the features that will be included in your MVP.

--- a/org-cyf-launch/content/blocks/lean-ux/index.md
+++ b/org-cyf-launch/content/blocks/lean-ux/index.md
@@ -3,7 +3,7 @@ title ="Lean UX Canvas"
 week=1
 skills= ['Teamwork','Time/Project Management']
 objectives= ['Define an MVP on a Lean UX Canvas', 'Define a user story mapping,', 'Define features for your MVP']
-time= 60
+time= 30
 [build]
   render = 'never'
   list = 'local'

--- a/org-cyf-launch/content/blocks/prep-launch-week-2/index.md
+++ b/org-cyf-launch/content/blocks/prep-launch-week-2/index.md
@@ -6,6 +6,10 @@ week="2"
 skills=["Communication","Time/Project Management"]
 objectives=["Develop a presentation about your team's achievements","Collaborate with your team to have content that any non-developer can understand"]
 time=60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
 +++
 
 <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vRFOEHXgT4r6KciGKgmClkOPaEyU1c7cbmf4Su9YAv7ODY10NjO3Re569iY2tGl1U-4tC9DjzHQ30wr/embed?start=false&loop=false&delayms=3000" frameborder="0" width="960" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>

--- a/org-cyf-launch/content/blocks/prep-launch-week-2/index.md
+++ b/org-cyf-launch/content/blocks/prep-launch-week-2/index.md
@@ -1,0 +1,35 @@
++++
+title="Prep your Demo presentation"
+description="The demo is an Agile ceremony. It celebrates your team's achievement during the past sprint, in our case, the past week. "
+modules="The Launch"
+week="2"
+skills=["Communication","Time/Project Management"]
+objectives=["Develop a presentation about your team's achievements","Collaborate with your team to have content that any non-developer can understand"]
+time=60
++++
+
+<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vRFOEHXgT4r6KciGKgmClkOPaEyU1c7cbmf4Su9YAv7ODY10NjO3Re569iY2tGl1U-4tC9DjzHQ30wr/embed?start=false&loop=false&delayms=3000" frameborder="0" width="960" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+
+The demo is done to the product team and various stakeholders. In our case, it will be to your cohort and all volunteers.
+
+We expect you to watch all other demos and ask questions or give feedback.
+
+#### The demo aims are:
+
+- Demonstrate the _incremental_ progress towards your goal to all your stakeholders (other teams, users, volunteers)
+- Share learnings and gather feedback from other people facing similar challenges to you
+- Practice feeling comfortable speaking in front of larger groups
+
+## Develop your presentation
+
+1. Create a copy of [this deck](https://docs.google.com/presentation/d/1TzlBcMQ9DdDoV_M6jiyvoozMShvQI1XvlUzWhzvysFc/edit?usp=drive_link)
+
+2. Update the content on each slide wherever you see
+
+3. Keep the content short (and sweet!)
+
+4. Decide what you can demo. Something visual, like layout changes, are fine, but it should also be technical, e.g. “this is how we derived this value”
+
+5. Decide who will speak - it’s important everyone in the team takes a turn
+
+6. Practice! Your update should take no longer than {{<timer>}}5{{</timer>}}

--- a/org-cyf-launch/content/blocks/retrospective/index.md
+++ b/org-cyf-launch/content/blocks/retrospective/index.md
@@ -1,0 +1,90 @@
++++
+title="Retrospective"
+description="Retrospective is another important ceremony in the Agile framework. In the same way, you talk to users to gather their feedback and act on it; this is the time for your team to discuss what is going well and what isn’t."
+modules="The Launch"
+week="2"
+skills=["Communication","Confidence","Teamwork"]
+objectives=["Assess the positive and negative traits in your team","Solve conflicts as part of a team"]
+time=30
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+Retrospective is about celebrating what is going well, identifying what isn’t going well, and agreeing on actions to improve your team processes.
+
+Be honest and kind when talking about the examples.
+
+## Our retrospective
+
+1. Open the chosen board.
+
+2. Give everyone {{<timer>}}5{{</timer>}} to add their points. Use 1 sticky note per point. Do not write more than 1 sentence on a note.
+
+3. Start reviewing the examples.
+
+- Usually, we start with the positive ones first.
+- Ask the person who wrote the example to give more input to the group
+- Open it up for questions and detailing
+
+4. Agree on an action for that example, if applicable.
+
+- Write the action on the board
+- Define who in the team will be responsible for delivering it
+- Agree on a deadline.
+
+<details>
+<summary>
+
+#### Example cooldown board
+
+</summary>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fboard%2Fc91AygW0mjctiKrxXUj08i%2FUntitled%3Fnode-id%3D0-1%26t%3DxNb7kktqfLSS7yk9-1" allowfullscreen></iframe>
+</details>
+
+## Cooling period (optional) {{< timer >}}25{{< /timer >}}
+
+### Solving conflicts as part of a team
+
+Conflicts are part of life. It can occur more often in high-pressure moments, such as delivering a product in a short period. It might happen at any moment in the week, but the retrospective usually brings them up
+more clearly.
+
+<details>
+<summary>
+
+#### Team conflict
+
+</summary>
+
+If you see that you and your team struggle to collaborate, communicate or work together positively, and conflict is getting heated, you can use this cooling technique:
+
+1. Stop working and take a 5-minute break.
+
+2. Reflect on what you think is working well and what is not working.
+
+3. Discuss your preferred ways to communicate.
+
+4. Re-establish how you will work together as a team.
+
+5. Create a 5-step action plan about how they will resolve further challenges.
+</details>
+
+<details>
+<summary>
+
+#### Individual conflict
+
+</summary>
+
+If the conflict is about one specific individual, they must talk to a volunteer about the following:
+
+1. Their strengths and weaknesses.
+
+2. Reflections on how they will work together with the team.
+
+3. Clear action plan to resolve further challenges.
+
+This must be done so the trainee can work on the team again.
+
+</details>

--- a/org-cyf-launch/content/blocks/scope-and-limits/index.md
+++ b/org-cyf-launch/content/blocks/scope-and-limits/index.md
@@ -4,6 +4,10 @@ week=1
 skills= ['Teamwork','Time/Project Management']
 objectives= ['Collaborate on defining and limiting scope', 'Agree strategies to handle complexity']
 time= 15
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
 +++
 
 The goal of this first meeting is to define what you will deliver as a team. When product teams work together, planning and preparation gets everyone on the same page. It means you might not be coding very much today, but will help you code more effectively over the weeks ahead.

--- a/org-cyf-launch/content/blocks/scope-and-limits/index.md
+++ b/org-cyf-launch/content/blocks/scope-and-limits/index.md
@@ -1,0 +1,37 @@
++++
+title ="Scope and limits"
+week=1
+skills= ['Teamwork','Time/Project Management']
+objectives= ['Collaborate on defining and limiting scope', 'Agree strategies to handle complexity']
+time= 15
++++
+
+The goal of this first meeting is to define what you will deliver as a team. When product teams work together, planning and preparation gets everyone on the same page. It means you might not be coding very much today, but will help you code more effectively over the weeks ahead.
+
+Learning how to do this work will make you a better software developer and ensure you develop features that have value to your users.
+
+{{<note type="tip">}}
+It's important that software works and that people can use it.
+{{</note>}}
+
+Discuss and agree on the points below with your product team. Set a timer for {{<timer>}}15{{</timer>}} minutes.
+
+### Minimum Viable Product (MVP)
+
+1. What is an [MVP](https://www.agilealliance.org/glossary/mvp/) (Minimum Viable Product)?
+
+2. How can you avoid increasing scope?
+
+3. How do we define what should be part of the MVP?
+
+### Functions
+
+1. What does it mean for your website to be interactive?
+
+2. The product must be completed in four weeks of work. How can we make sure the scope is the right size?
+
+3. Be well-defined: what {{<tooltip title="artefacts">}}Readmes, docs, diagrams, kanbans, user stories... Artefacts are documents produced during software builds that describe and illustrate its functions.{{</tooltip>}} can we use to ensure all functions are well-defined?
+
+4. Visual design complexity: how can we avoid making our user interface too complicated?
+
+5. Answers to questions: trainees are learning, so how can we, as a team, learn without giving each other just the answers - or expecting immediate answers from your peers?

--- a/org-cyf-launch/content/blocks/sprint-planning/index.md
+++ b/org-cyf-launch/content/blocks/sprint-planning/index.md
@@ -6,6 +6,10 @@ week = 1
 skills = ['Time/Project Management','Teamwork']
 objectives = ['Plan 1 sprint','Prioritise user stories']
 time = 30
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
 +++
 
 Agile software teams often work in ‘sprints’: specific chunks of time where we commit to a development goal.

--- a/org-cyf-launch/content/blocks/sprint-planning/index.md
+++ b/org-cyf-launch/content/blocks/sprint-planning/index.md
@@ -1,0 +1,36 @@
++++
+title = 'Sprint planning'
+description = 'Plan the upcoming week of work as a team'
+modules = 'The Launch'
+week = 1
+skills = ['Time/Project Management','Teamwork']
+objectives = ['Plan 1 sprint','Prioritise user stories']
+time = 30
++++
+
+Agile software teams often work in ‘sprints’: specific chunks of time where we commit to a development goal.
+
+> Goal: Get the homepage working.
+
+We set a single goal and focus on reaching it together as a team.
+
+This helps us work on the most important thing. We’ll have lots of ideas for different things we can build, and we don’t want to get distracted. And it should encourage us to work together as a team.
+
+For this project, we’ll be doing 1 week sprints. So, we should plan and start a new sprint at the start of each week.
+
+Sprint planning is the process of planning our week, specifically focused on our development backlog and picking which user stories to include.
+exercises:
+
+### Plan the sprint
+
+1. As a group, review the Backlog of user stories on your Project Board
+
+2. Discuss the user stories - make sure they all have a detailed description of what you need to build and check that everyone in the team understands them. You can check this by asking everyone - would you feel comfortable implementing this yourself? (if no, check why not and add more information)
+
+3. Arrange the user stories in priority order - put the most important ones first. These stories should help us reach our MVP and solve customer problems faster.
+
+4. Start moving the user stories from your Backlog column to the Prioritised column. Keep going until you have enough for a week of work - this is your ‘sprint’. Estimating how much you can do in a week might be tricky. Tip: not enough is better than too much. We can always add more later.
+
+5. Describe your week of work as a goal in a single sentence. Keep it focused on your product, not the technology. For example, “Goal: Get the homepage working” is better than “Goal: Setup the SQL database.”
+
+6. Post your goal to the class Slack channel, e.g. “This week's sprint goal for the Amazing Coderz team is: Get the homepage working!”

--- a/org-cyf-launch/content/blocks/user-research/index.md
+++ b/org-cyf-launch/content/blocks/user-research/index.md
@@ -6,6 +6,10 @@ week="2"
 skills=["Communication"]
 objectives=["Incorporate user feedback into your next project"]
 time=60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
 +++
 
 When we build products, we build them for someone to use. The best way to test that the features, design or functionality makes sense is by asking the user’s opinion.

--- a/org-cyf-launch/content/blocks/user-research/index.md
+++ b/org-cyf-launch/content/blocks/user-research/index.md
@@ -1,0 +1,43 @@
++++
+title="User research"
+description="User research is a great way of building empathy towards the users of your products. The users will also be able to give your feedback and ensure you are going in the right direction with your development. "
+modules="The Launch"
+week="2"
+skills=["Communication"]
+objectives=["Incorporate user feedback into your next project"]
+time=60
++++
+
+When we build products, we build them for someone to use. The best way to test that the features, design or functionality makes sense is by asking the user’s opinion.
+
+However, don’t rush off and implement everything a user tells you. Use their input to amend existing features going in the wrong direction; add _new_ ideas to your _backlog_ for future prioritisation.
+
+### Talk to users
+
+Collaborate with non-technical stakeholders
+
+#### Identify the users
+
+- Identify between 2 - 5 users of your products
+
+- Ask a range of people (of different sex, gender, ethnicity, etc).
+
+#### The research
+
+- Share the briefing you received with the user beforehand.
+
+- Demo your product to them.
+
+- Ask them: “What are your thoughts?” or some generic questions. Ask open questions.
+
+- Make notes of their input and ask why they need this. Understanding the **why** will give you insight into what their problems are.
+
+- Thank them for their time and ask if they could talk to you again next week.
+
+#### The outcome of the research
+
+- Compile the feedback
+
+- Share it with your team on your Slack channel
+
+- Define which changes you will make. These should become tickets on your board. _(Remember: not every feedback has to be incorporated in your MVP)_

--- a/org-cyf-launch/content/blocks/what-is-the-launch-module/index.md
+++ b/org-cyf-launch/content/blocks/what-is-the-launch-module/index.md
@@ -1,0 +1,46 @@
+---
+title: What is the Launch module
+description: An exercise to understand the Launch module and its benefits, outcome and challenges.
+modules: The Launch
+week: "1"
+skills:
+  - Teamwork
+objectives:
+  - Explain the Launch module
+time: 30
+prep: Everyone must have done the prep work
+introduction: We have a lot of first-time volunteers helping at the Launch
+  module, so it is always good to ensure they and the current volunteers and
+  trainees understand what the module is about.
+---
+
+### Motivation
+
+We have a lot of first-time volunteers helping at the Launch, so it is always good to ensure both volunteers and trainees understand what the module is about.
+
+Discuss the following questions as a cohort (trainees and volunteers):
+
+1. What have the trainees **learned before** joining the Launch module? Think about Tech Ed and Professional Development (PD) learnings.
+
+2. What will be the main **challenges for the trainees**?
+
+3. What will be the main **challenges for the volunteers**?
+
+4. **Why** do we do the Launch module?
+
+5. What should we make sure we **don’t do** at the Launch module?
+
+6. What are we doing on the **Saturday sessions**?
+
+7. How many **mid-week check-ins** should each team have?
+
+8. What are the **common mistakes** made by teams?
+
+9. How will you **deal with the conflicts** below?
+
+   - **Safeguarding**: someone is at risk, and you don’t know what to do.
+   - **Abusive behaviour**: could include [code of conduct](https://codeyourfuture.io/about/code-of-conduct/) violation.
+   - **Disengagement**: a trainee or volunteer not participating
+   - **Poor technical contributions:** The trainee is contributing, but the code is not good enough or actively bad; the team cannot deliver weekly releases
+
+10. **Would you hire this trainee?** Why is this question important for trainees and volunteers to have in mind? And if you would not hire them, what should you do?

--- a/org-cyf-launch/content/blocks/what-is-the-launch-module/index.md
+++ b/org-cyf-launch/content/blocks/what-is-the-launch-module/index.md
@@ -1,18 +1,16 @@
----
-title: What is the Launch module
-description: An exercise to understand the Launch module and its benefits, outcome and challenges.
-modules: The Launch
-week: "1"
-skills:
-  - Teamwork
-objectives:
-  - Explain the Launch module
-time: 30
-prep: Everyone must have done the prep work
-introduction: We have a lot of first-time volunteers helping at the Launch
-  module, so it is always good to ensure they and the current volunteers and
-  trainees understand what the module is about.
----
++++
+title="What is the Launch module"
+description="An exercise to understand the Launch module and its benefits, outcome and challenges."
+modules="The Launch"
+week="1"
+skills=["Teamwork"]
+objectives=["Identify the goals of the Launch module", "Explore the challenges of the Launch module", "Propose solutions to the challenges of the Launch module"]
+time=30
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
++++
 
 ### Motivation
 

--- a/org-cyf-launch/content/blocks/writing-user-stories/index.md
+++ b/org-cyf-launch/content/blocks/writing-user-stories/index.md
@@ -1,0 +1,58 @@
+---
+title: Writing user stories
+description: Clear user stories with defined acceptance criteria ensure we can
+  deliver a feature efficiently and with less re-work.
+modules: The Launch
+week: "1"
+skills:
+  - Teamwork
+  - Time/Project Management
+objectives:
+  - Planning your work as a team
+time: 60
+prep: Ensure your team has a clear MVP and Design
+introduction: "When planning your work, you have two important aspects:
+  understanding the implementation constraints and opportunities and writing
+  your user stories."
+exercises:
+  - name: Implementation details
+    time: 30
+    goal: Define the implementation details for your product
+    content: >-
+      Discuss your implementation details. During the discussion, ensure that
+      the technical jargon is clarified to the team so everyone can understand
+      and be part of the discussion.
+
+
+      1. What information will they need and/or provide to do that? For example, what pages could you have, and which endpoints must you use?
+
+      2. What entities/resources/data will we have in the system?
+
+      3. What information do we need to store to achieve the goals? Define the collections in the database.
+
+      4. What are we going to need to expose to the React app? Examples:
+
+      5. 1. Are you going to have an endpoint for a resource
+         2. Do you need calculation or aggregation between the database and the frontend
+         3. What will the REST API look like
+      6. You sketched out the page previously. Do we need to review it? How could we decompose them into separate [components](https://syllabus.codeyourfuture.io/react/week-1/lesson) to work on?
+
+      7. Identify the "edges" between different tasks (e.g. you have to agree on an API so that the backend and frontend match up or on the props passed between a parent component and a child component)
+  - name: Write the user stories
+    time: 30
+    goal: Write user stories for the planning session
+    content: >-
+      When raising your tickets, you can have two types of tickets: 
+
+
+      * a user story, which focussed on business value (Format: AS A \[role], I WANT \[action], SO THAT \[outcome] + acceptance criteria \[rules/scenarios])
+
+      * technical ticket, which is a step in the direction of a user story (Background \[why], acceptance criteria \[rules/scenarios]
+
+
+      1. Discuss and agree on the first 5 or 6 user stories that need to be done. Just use titles to identify them.
+
+      2. Work on 1 user story and 1 technical ticket together as a team.
+
+      3. Now, each team member chooses one ticket and writes it. Think about clarity so that anyone outside the team can understand it, too. They will be discussed in the next session.
+---

--- a/org-cyf-launch/content/blocks/writing-user-stories/index.md
+++ b/org-cyf-launch/content/blocks/writing-user-stories/index.md
@@ -1,58 +1,23 @@
----
-title: Writing user stories
-description: Clear user stories with defined acceptance criteria ensure we can
-  deliver a feature efficiently and with less re-work.
-modules: The Launch
-week: "1"
-skills:
-  - Teamwork
-  - Time/Project Management
-objectives:
-  - Planning your work as a team
-time: 60
-prep: Ensure your team has a clear MVP and Design
-introduction: "When planning your work, you have two important aspects:
-  understanding the implementation constraints and opportunities and writing
-  your user stories."
-exercises:
-  - name: Implementation details
-    time: 30
-    goal: Define the implementation details for your product
-    content: >-
-      Discuss your implementation details. During the discussion, ensure that
-      the technical jargon is clarified to the team so everyone can understand
-      and be part of the discussion.
++++
+title="Writing user stories"
+description="Clear user stories with defined acceptance criteria ensure we can deliver a feature efficiently and with less re-work."
+modules="The Launch"
+week="1"
+skills=["Teamwork","Time/Project Management"]
+objectives=["Define a user story","Write a user story", "Write a technical ticket"]
+time=60
++++
 
+> AS A \[role], I WANT \[action], SO THAT \[outcome]
 
-      1. What information will they need and/or provide to do that? For example, what pages could you have, and which endpoints must you use?
+Set a timer for {{<timer>}}15{{</timer>}} and write user stories for the planning session. When raising your tickets, you can have two types of tickets:
 
-      2. What entities/resources/data will we have in the system?
+- a **user story**, which is focused on business value (Format: AS A \[role], I WANT \[action], SO THAT \[outcome] + acceptance criteria \[rules/scenarios])
 
-      3. What information do we need to store to achieve the goals? Define the collections in the database.
+- a **technical ticket**, which is a step in the direction of a user story (Background \[why], acceptance criteria \[rules/scenarios]
 
-      4. What are we going to need to expose to the React app? Examples:
+1. {{<timer>}}5{{</timer>}} Discuss and agree on the first 5 or 6 user stories that need to be done. Just use titles to identify them.
 
-      5. 1. Are you going to have an endpoint for a resource
-         2. Do you need calculation or aggregation between the database and the frontend
-         3. What will the REST API look like
-      6. You sketched out the page previously. Do we need to review it? How could we decompose them into separate [components](https://syllabus.codeyourfuture.io/react/week-1/lesson) to work on?
+2. {{<timer>}}5{{</timer>}} Work on 1 user story and 1 technical ticket together as a team.
 
-      7. Identify the "edges" between different tasks (e.g. you have to agree on an API so that the backend and frontend match up or on the props passed between a parent component and a child component)
-  - name: Write the user stories
-    time: 30
-    goal: Write user stories for the planning session
-    content: >-
-      When raising your tickets, you can have two types of tickets: 
-
-
-      * a user story, which focussed on business value (Format: AS A \[role], I WANT \[action], SO THAT \[outcome] + acceptance criteria \[rules/scenarios])
-
-      * technical ticket, which is a step in the direction of a user story (Background \[why], acceptance criteria \[rules/scenarios]
-
-
-      1. Discuss and agree on the first 5 or 6 user stories that need to be done. Just use titles to identify them.
-
-      2. Work on 1 user story and 1 technical ticket together as a team.
-
-      3. Now, each team member chooses one ticket and writes it. Think about clarity so that anyone outside the team can understand it, too. They will be discussed in the next session.
----
+3. {{<timer>}}5{{</timer>}} Now, each team member chooses one ticket and writes it. Think about clarity so that anyone outside the team can understand it, too. They will be discussed in the next session.

--- a/org-cyf-launch/content/blocks/writing-user-stories/index.md
+++ b/org-cyf-launch/content/blocks/writing-user-stories/index.md
@@ -6,6 +6,10 @@ week="1"
 skills=["Teamwork","Time/Project Management"]
 objectives=["Define a user story","Write a user story", "Write a technical ticket"]
 time=60
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false 
 +++
 
 > AS A \[role], I WANT \[action], SO THAT \[outcome]

--- a/org-cyf-launch/content/prep/index.md
+++ b/org-cyf-launch/content/prep/index.md
@@ -1,13 +1,21 @@
 +++
-title = 'prep'
+title = 'apply'
 description = 'Getting ready to launch'
 layout = 'prep'
 emoji= '🧑🏾‍💻'
 menu_level = ['module']
 menu=["apply"]
 weight = 1
-backlog= 'Module-The-Launch'
 [[blocks]]
-name="Prep for Launch"
-src="https://cyf-pd.netlify.app/blocks/launch-prep/readme/"
+name="Entry Criteria"
+src="blocks/entry-criteria"
+[[blocks]]
+name="Role Description"
+src="blocks/job-description"
+[[blocks]]
+name="How to apply"
+src="blocks/how-to-apply"
+[[blocks]]
+name="Application Form"
+src="blocks/application-form"
 +++

--- a/org-cyf-launch/content/sprints/1/day-plan/index.md
+++ b/org-cyf-launch/content/sprints/1/day-plan/index.md
@@ -17,10 +17,13 @@ name="Morning Break"
 src="blocks/morning-break"
 [[blocks]]
 name="Prep your product"
-src="https://cyf-pd.netlify.app/blocks/prep-and-plan-your-product/readme/"
+src="blocks/scope-and-limits"
+[[blocks]]
+name="Lean UX Canvas"
+src="blocks/lean-ux"
 [[blocks]]
 name="Design your product"
-src="https://cyf-pd.netlify.app/blocks/design-your-product/readme/"
+src="blocks/design-your-product"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"

--- a/org-cyf-launch/content/sprints/1/day-plan/index.md
+++ b/org-cyf-launch/content/sprints/1/day-plan/index.md
@@ -8,10 +8,10 @@ backlog= 'Module-The-Launch'
 backlog_filter= 'Week 1'
 [[blocks]]
 name="Energiser"
-src="https://cyf-pd.netlify.app/blocks/employability-energiser/readme/"
+src="energisers/bad-interview-answers"
 [[blocks]]
 name="Launch overview"
-src="https://cyf-pd.netlify.app/blocks/what-is-the-launch-module/readme/"
+src="blocks/what-is-the-launch-module"
 [[blocks]]
 name="Morning Break"
 src="blocks/morning-break"

--- a/org-cyf-launch/content/sprints/1/day-plan/index.md
+++ b/org-cyf-launch/content/sprints/1/day-plan/index.md
@@ -22,21 +22,24 @@ src="blocks/scope-and-limits"
 name="Lean UX Canvas"
 src="blocks/lean-ux"
 [[blocks]]
-name="Design your product"
-src="blocks/design-your-product"
+name="Deploy early, deploy often"
+src="blocks/deploy-early-deploy-often"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"
 [[blocks]]
-name="Writing user stories"
-src="https://cyf-pd.netlify.app/blocks/writing-user-stories/readme/"
+name="Design your product"
+src="blocks/design-your-product"
 [[blocks]]
-name="Sprint planning"
-src="https://cyf-pd.netlify.app/blocks/sprint-planning/readme/"
+name="Implementation details"
+src="blocks/implementation-details"
 [[blocks]]
 name="Afternoon Break"
 src="blocks/afternoon-break"
 [[blocks]]
-name="Project Work"
-src="module/portfolio/project"
+name="Writing user stories"
+src="blocks/writing-user-stories"
+[[blocks]]
+name="Sprint planning"
+src="blocks/sprint-planning"
 +++

--- a/org-cyf-launch/content/sprints/1/prep/index.md
+++ b/org-cyf-launch/content/sprints/1/prep/index.md
@@ -12,7 +12,7 @@ name="Welcome to Launch Prep"
 src="blocks/launch-prep/welcome"
 [[blocks]]
 name="Your team"
-src="blocks/launch-prep/your-team"
+src="blocks/launch-prep/team"
 [[blocks]]
 name="Weekly plan"
 src="blocks/launch-prep/plan"

--- a/org-cyf-launch/content/sprints/1/prep/index.md
+++ b/org-cyf-launch/content/sprints/1/prep/index.md
@@ -8,6 +8,21 @@ weight = 1
 backlog= 'Module-The-Launch'
 backlog_filter= 'Week 1'
 [[blocks]]
-name="Prep for Launch"
-src="https://cyf-pd.netlify.app/blocks/launch-prep/readme/"
+name="Welcome to Launch Prep"
+src="blocks/launch-prep/welcome"
+[[blocks]]
+name="Your team"
+src="blocks/launch-prep/your-team"
+[[blocks]]
+name="Weekly plan"
+src="blocks/launch-prep/plan"
+[[blocks]]
+name="Contributions"
+src="blocks/launch-prep/contributions"
+[[blocks]]
+name="Your brief"
+src="blocks/launch-prep/briefing"
+[[blocks]]
+name="Setting up your repo"
+src="blocks/launch-prep/setup"
 +++

--- a/org-cyf-launch/content/sprints/2/day-plan/index.md
+++ b/org-cyf-launch/content/sprints/2/day-plan/index.md
@@ -5,30 +5,34 @@ layout = 'day-plan'
 emoji= '🧑🏽‍🤝‍🧑🏽'
 menu_level = ['sprint']
 weight = 3
-backlog= 'Module-The-Launch'
-backlog_filter= 'Week 2'
 [[blocks]]
 name="Energiser"
-src="https://cyf-pd.netlify.app/blocks/employability-energiser/readme/"
+src="energisers/telephone"
 [[blocks]]
 name="Demo Time"
-src="https://cyf-pd.netlify.app/blocks/demo-time/readme/"
+src="blocks/demo-time/"
 [[blocks]]
 name="Morning Break"
 src="blocks/morning-break"
 [[blocks]]
 name="Retrospective"
-src="https://cyf-pd.netlify.app/blocks/retrospective/readme/"
+src="blocks/retrospective"
+[[blocks]]
+name="Sprint Planning"
+src="blocks/sprint-planning/"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"
 [[blocks]]
-name="Sprint Planning"
-src="https://cyf-pd.netlify.app/blocks/sprint-planning/readme/"
-[[blocks]]
-name="Afternoon Break"
-src="blocks/afternoon-break"
-[[blocks]]
-name="Project work"
-src="module/portfolio/project"
+name="Development Time"
+src="blocks/development-time"
+  [[blocks.nested.blocks]]
+    name="Pomodoro"
+    src="module/piscine/pomodoro"
+  [[blocks.nested.blocks]]
+    name="Blockers"
+    src="module/piscine/blockers"
+  [[blocks.nested.blocks]]
+    name="Pair Programming"
+    src="module/piscine/pairing"
 +++

--- a/org-cyf-launch/content/sprints/2/prep/index.md
+++ b/org-cyf-launch/content/sprints/2/prep/index.md
@@ -9,8 +9,8 @@ backlog= 'Module-The-Launch'
 backlog_filter= 'Week 2'
 [[blocks]]
 name="Prep your Demo"
-src="https://cyf-pd.netlify.app/blocks/prep-launch-week-2/readme/"
+src="blocks/prep-launch-week-2"
 [[blocks]]
 name="User research"
-src="https://cyf-pd.netlify.app/blocks/user-research/readme/"
+src="blocks/user-research"
 +++

--- a/org-cyf-launch/content/sprints/3/day-plan/index.md
+++ b/org-cyf-launch/content/sprints/3/day-plan/index.md
@@ -5,30 +5,34 @@ layout = 'day-plan'
 emoji= '🧑🏽‍🤝‍🧑🏽'
 menu_level = ['sprint']
 weight = 3
-backlog= 'Module-The-Launch'
-backlog_filter= 'Week 3'
 [[blocks]]
 name="Energiser"
-src="https://cyf-pd.netlify.app/blocks/employability-energiser/readme/"
+src="energisers/telephone"
 [[blocks]]
 name="Demo Time"
-src="https://cyf-pd.netlify.app/blocks/demo-time/readme/"
+src="blocks/demo-time/"
 [[blocks]]
 name="Morning Break"
 src="blocks/morning-break"
 [[blocks]]
 name="Retrospective"
-src="https://cyf-pd.netlify.app/blocks/retrospective/readme/"
+src="blocks/retrospective"
+[[blocks]]
+name="Sprint Planning"
+src="blocks/sprint-planning/"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"
 [[blocks]]
-name="Sprint Planning"
-src="https://cyf-pd.netlify.app/blocks/sprint-planning/readme/"
-[[blocks]]
-name="Afternoon Break"
-src="blocks/afternoon-break"
-[[blocks]]
-name="Project work"
-src="module/portfolio/project"
+name="Development Time"
+src="blocks/development-time"
+  [[blocks.nested.blocks]]
+    name="Blockers"
+    src="module/piscine/blockers"
+  [[blocks.nested.blocks]]
+    name="Pair Programming"
+    src="module/piscine/pairing"
+  [[blocks.nested.blocks]]
+    name="Code Review"
+    src="module/piscine/review"
 +++

--- a/org-cyf-launch/content/sprints/3/day-plan/index.md
+++ b/org-cyf-launch/content/sprints/3/day-plan/index.md
@@ -7,7 +7,7 @@ menu_level = ['sprint']
 weight = 3
 [[blocks]]
 name="Energiser"
-src="energisers/telephone"
+src="energisers/blockers"
 [[blocks]]
 name="Demo Time"
 src="blocks/demo-time/"

--- a/org-cyf-launch/content/sprints/3/prep/index.md
+++ b/org-cyf-launch/content/sprints/3/prep/index.md
@@ -5,12 +5,10 @@ layout = 'prep'
 emoji= '🧑🏾‍💻'
 menu_level = ['sprint']
 weight = 1
-backlog= 'Module-The-Launch'
-backlog_filter= 'Week 3'
 [[blocks]]
 name="Prep your Demo"
-src="https://cyf-pd.netlify.app/blocks/prep-launch-week-2/readme/"
+src="blocks/prep-launch-week-2"
 [[blocks]]
 name="User research"
-src="https://cyf-pd.netlify.app/blocks/user-research/readme/"
+src="blocks/user-research"
 +++

--- a/org-cyf-launch/content/sprints/4/day-plan/index.md
+++ b/org-cyf-launch/content/sprints/4/day-plan/index.md
@@ -1,33 +1,38 @@
 +++
 title = 'day-plan'
+description="Last day to work together in person"
 layout = 'day-plan'
 emoji= '🧑🏽‍🤝‍🧑🏽'
 menu_level = ['sprint']
 weight = 3
-backlog= 'Module-The-Launch'
-backlog_filter= 'Week 4'
 [[blocks]]
 name="Energiser"
-src="https://cyf-pd.netlify.app/blocks/employability-energiser/readme/"
+src="energisers/telephone"
 [[blocks]]
 name="Demo Time"
-src="https://cyf-pd.netlify.app/blocks/demo-time/readme/"
+src="blocks/demo-time/"
 [[blocks]]
 name="Morning Break"
 src="blocks/morning-break"
 [[blocks]]
 name="Retrospective"
-src="https://cyf-pd.netlify.app/blocks/retrospective/readme/"
+src="blocks/retrospective"
+[[blocks]]
+name="Sprint Planning"
+src="blocks/sprint-planning/"
 [[blocks]]
 name="Lunch"
 src="blocks/lunch"
 [[blocks]]
-name="Sprint Planning"
-src="https://cyf-pd.netlify.app/blocks/sprint-planning/readme/"
-[[blocks]]
-name="Afternoon Break"
-src="blocks/afternoon-break"
-[[blocks]]
-name="Project work"
-src="module/portfolio/project"
+name="Development Time"
+src="blocks/development-time"
+  [[blocks.nested.blocks]]
+    name="Pomodoro"
+    src="module/piscine/pomodoro"
+  [[blocks.nested.blocks]]
+    name="Pair Programming"
+    src="module/piscine/pairing"
+  [[blocks.nested.blocks]]
+    name="Blockers"
+    src="module/piscine/blockers"
 +++

--- a/org-cyf-launch/content/sprints/4/day-plan/index.md
+++ b/org-cyf-launch/content/sprints/4/day-plan/index.md
@@ -7,7 +7,7 @@ menu_level = ['sprint']
 weight = 3
 [[blocks]]
 name="Energiser"
-src="energisers/telephone"
+src="energisers/wemoji"
 [[blocks]]
 name="Demo Time"
 src="blocks/demo-time/"

--- a/org-cyf-launch/content/sprints/4/prep/index.md
+++ b/org-cyf-launch/content/sprints/4/prep/index.md
@@ -5,12 +5,10 @@ description='Your product is viable and the team is ready to launch'
 emoji= '🧑🏾‍💻'
 menu_level = ['sprint']
 weight = 1
-backlog= 'Module-The-Launch'
-backlog_filter= 'Week 4'
 [[blocks]]
 name="Prep your Demo"
-src="https://cyf-pd.netlify.app/blocks/prep-launch-week-2/readme/"
+src="blocks/prep-launch-week-2"
 [[blocks]]
 name="User research"
-src="https://cyf-pd.netlify.app/blocks/user-research/readme/"
+src="blocks/user-research"
 +++

--- a/org-cyf-launch/content/success/index.md
+++ b/org-cyf-launch/content/success/index.md
@@ -1,12 +1,52 @@
 +++
-title = 'success'
-description = 'success description'
+title = 'exit criteria'
+description = 'Success means: being employable. '
 layout = 'success'
 emoji= '✅'
 menu_level = ['module']
+menu=['demo']
 weight = 11
-backlog= 'Module-The-Launch'
 [[objectives]]
-1="Achieve the individual, project and team criteria described in the Exit Launch document."
-
+1="Achieve the individual criteria"
+2="Achieve the project criteria"
+3="Achieve the team criteria"
 +++
+
+To succeed at {{<our-name>}}, you must successfully deliver a team project, including a “Demo Day” demonstration. Successful delivery includes:
+
+1. 🧑🏿‍💻 [Individual criteria](#individual)
+1. 💼 [Project criteria](#project)
+1. 🧑🏾‍🤝‍🧑🏼[Team criteria](#team)
+
+## 🧑🏿‍💻 Individual criteria {#individual}
+
+You must demonstrate the skills description for your role during your team project.
+
+These are mapped in our Team Roles: CodeYourFuture Certification Mappings [external]
+
+[**You must write your code**](https://docs.codeyourfuture.io/organisation/agreements-and-rules/student-agreement#1.-do-your-work). 1:1 pairing sessions may happen at any point during your team project or beforehand. You must be able to explain your code to another developer.
+
+To demonstrate you are a full-stack developer, you must build features across the full stack. If you exclusively build front-end features during this project, you will be considered a front end developer.
+
+## 💼 Project criteria {#project}
+
+A successful Launch Project must also meet these criteria:
+
+- It works
+- It is deployed, and the link shared with CYF
+- The repo is public on Github and the link shared with CYF
+- The planning board is public on Github and the link shared with CYF
+- It addresses the brief
+
+## 🧑🏾‍🤝‍🧑🏼 Team criteria {#team}
+
+- The Launch Project trainees must work together in an Agile team.
+- Developers must meet the contribution guidelines.
+
+## In other words
+
+> You have to build it together, it has to work, and you have to show us.
+
+{{<our-name>}} has no automatic progress, but many chances exist. If you don’t meet these criteria, you can try again until you do.
+
+## Objectives

--- a/org-cyf-launch/go.mod
+++ b/org-cyf-launch/go.mod
@@ -4,8 +4,9 @@ go 1.22.5
 
 require (
 	github.com/CodeYourFuture/CYF-PD v1.0.1-0.20240721130916-d70fc853a278 // indirect
+	github.com/CodeYourFuture/CYF-Projects/micro-front-end v0.0.0-20240802103347-3eb0ebf8ad9b // indirect
 	github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240121151641-e52b73ad527d // indirect
-	github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240121151641-e52b73ad527d // indirect
+	github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240404150408-303505d03061 // indirect
 )
 
 replace github.com/CodeYourFuture/curriculum/common-content => ../common-content

--- a/org-cyf-launch/go.sum
+++ b/org-cyf-launch/go.sum
@@ -1,5 +1,7 @@
 github.com/CodeYourFuture/CYF-PD v1.0.1-0.20240721130916-d70fc853a278 h1:QkyzRerSZyumZ4gxoE7gehj86zWdDY7O4K9pqW8OLtg=
 github.com/CodeYourFuture/CYF-PD v1.0.1-0.20240721130916-d70fc853a278/go.mod h1:DJj2pdPceTBoHErILtnZMEYPZZuC8W9Fmt/faaW2tcw=
+github.com/CodeYourFuture/CYF-Projects/micro-front-end v0.0.0-20240802103347-3eb0ebf8ad9b h1:iQyvh1DWWbx55Qvs923X2liMosQmQNlFumOrEmgq7c8=
+github.com/CodeYourFuture/CYF-Projects/micro-front-end v0.0.0-20240802103347-3eb0ebf8ad9b/go.mod h1:MutmCRXM0wOmDQrZGMmn6jSWHHst5j1AUuf7hwrbILI=
 github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240121151641-e52b73ad527d h1:WfPdLoNvxOrNx3GB+DpYlpEH57v98h0KWXpidN+xdOo=
 github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240121151641-e52b73ad527d/go.mod h1:e3J+XphCBJJ8kf6S9ykVxNY1VKPWJoYuDFXEizlDpCI=
 github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240121151641-e52b73ad527d h1:ILE8f9gXLEPEyrJVBdFRVa0Uszf9OVdK4LjXZjCLUag=

--- a/org-cyf-launch/hugo.toml
+++ b/org-cyf-launch/hugo.toml
@@ -10,6 +10,11 @@ baseURL = "https://curriculum.codeyourfuture.io/"
       source = "en"
       target = "content"
   [[module.imports]]
+    path = "github.com/CodeYourFuture/CYF-Projects/micro-front-end" 
+    [[module.imports.mounts]]
+      source = "content"
+      target = "content/briefings"
+  [[module.imports]]
     path = "github.com/CodeYourFuture/CYF-PD" 
     [[module.imports.mounts]]
       source = "content/blocks"
@@ -41,6 +46,7 @@ org = "https://github.com/CodeYourFuture"
 repo = "https://github.com/CodeYourFuture/curriculum/"
 pdrepo = "CYF-PD"
 root = "curriculum"
+our_name="Code Your Future"
 
 # We use a proxy which concatenates paginated responses, otherwise we miss results.
 # Daniel is currently hosting this code https://github.com/illicitonion/github-issue-proxy but we should work out a long-term maintainable solution to this problem.

--- a/org-cyf-launch/package.json
+++ b/org-cyf-launch/package.json
@@ -16,10 +16,7 @@
   },
   "homepage": "https://github.com/CodeYourFuture/curriculum#readme",
   "dependencies": {
-    "@codemirror/lang-javascript": "^6.1.8",
-    "@codemirror/theme-one-dark": "^6.1.2",
     "@netlify/functions": "^1.6.0",
-    "codemirror": "^6.0.1",
     "cookie": "^0.5.0",
     "dotenv": "^16.3.1",
     "joi": "^17.9.2",


### PR DESCRIPTION
## What does this change?

After consultation with Karen, I've ported the Launch content to its own website. 

> https://deploy-preview-870--cyf-launch.netlify.app/

I have gone through all the links and copied the content into Launch local blocks.  I made these minor edits: I've turned links into embeds where possible. I switched up the energisers and fixed the timings where they didn't make sense. I broke up some long sentences and fixed a few typos. I'm sure TL will want to do many more revisions anyway so I left it there.

I've stored the blocks locally here because this team will have a CMS and make edits directly, unlike the other teams. 

We might move this whole site out to its own repo at some point. This is a very small job.

I will now remove the content from the PD repo so we don't double up.

The next stage is to put a CMS on the Launch. 

### Common Content?

<!-- Does this PR add content to the common-content module? -->

Yes I broke up some activities from the piscine and nested them in now we have nestable blocks


### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

The Launch | ALL 

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
