### PR TITLE
add a fallback font stack for emojis

### DIFF
--- a/common-theme/assets/styles/02-variables/fonts.scss
+++ b/common-theme/assets/styles/02-variables/fonts.scss
@@ -4,4 +4,6 @@
     "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
     sans-serif;
   --theme-font--system: 100 100%/2 "Monaco", "Menlo", "Space Grotesk", monospace;
+  --theme-font--emoji: Apple Color Emoji, "Segoe UI Emoji", "Noto Color Emoji",
+    "EmojiOne Color", "Twemoji Mozilla";
 }

--- a/common-theme/assets/styles/04-components/emoji.scss
+++ b/common-theme/assets/styles/04-components/emoji.scss
@@ -1,0 +1,3 @@
+.c-emoji {
+  font-family: var(--theme-font--emoji);
+}

--- a/common-theme/layouts/partials/card.html
+++ b/common-theme/layouts/partials/card.html
@@ -5,7 +5,7 @@
     <p class="c-card__description">{{ . }}</p>
   {{ end }}
   <!-- Display emoji -->
-  <div class="c-card__image">
+  <div class="c-card__image c-emoji">
     {{ .Page.Params.emoji | default "🤖" }}
   </div>
 </a>


### PR DESCRIPTION
## What does this change?

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->
adds an explicit fallback stack of emoji fonts
then assigns that to `c.emoji`

<!--Please reference the ticket you are addressing -->
a gesture towards
Issue number #867 


## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
