### PR TITLE
bugfix: markdown config cannot be inherited

### DIFF
--- a/common-docs/hugo.toml
+++ b/common-docs/hugo.toml
@@ -62,4 +62,14 @@ maxAge="6h"
 getenv = ["^HUGO_CURRICULUM_GITHUB_BEARER_TOKEN$"]
 
 
+[markup]
+# I've configured markdown so you don't have to
+  [markup.tableOfContents]
+    endLevel = 2
+    ordered = true
+    startLevel = 2
+    [markup.goldmark.renderer]
+# Enable HTML codeblocks, e.g. for <details> blocks
+      unsafe = true
+
 theme = "common-theme"

--- a/common-theme/hugo.toml
+++ b/common-theme/hugo.toml
@@ -37,32 +37,7 @@ description = "A free and open source software development programme."
 # orgapi = "https://api.github.com/repos/YOUR_ORG_HERE/"
 # pdrepo = "PD-curriculum-repo"
 
-[markup]
-# I've configured markdown so you don't have to
-  [markup.tableOfContents]
-    endLevel = 2
-    ordered = true
-    startLevel = 2
-  [markup.highlight]
-    lineNos = false
-    codeFences = true
-    guessSyntax = true
-  [markup.goldmark]
-    strikethrough=false
-    [markup.goldmark.extensions.extras.delete]
-        enable = true
-    [markup.goldmark.extensions.extras.insert]
-        enable = true
-    [markup.goldmark.extensions.extras.mark]
-        enable = true
-    [markup.goldmark.extensions.extras.subscript]
-        enable = true
-    [markup.goldmark.extensions.extras.superscript]
-        enable = true
-    [markup.goldmark.renderer]
-# Enable HTML codeblocks, e.g. for <details> blocks
-      unsafe = true
-      hardWraps = true
+#markdown configs cannot be inherited so are not set
 
 [caches.getjson]
 # Disable caching of fetches - we want every build to get up to date content for issues, so that if people make clarifications or fixes to issues, we pick them up.

--- a/common-theme/hugo.toml
+++ b/common-theme/hugo.toml
@@ -38,20 +38,31 @@ description = "A free and open source software development programme."
 # pdrepo = "PD-curriculum-repo"
 
 [markup]
-[markup.tableOfContents]
-endLevel = 2
-ordered = true
-startLevel = 2
-[markup.highlight]
-lineNos = false
-codeFences = true
-guessSyntax = true
-[markup.goldmark.renderer]
+# I've configured markdown so you don't have to
+  [markup.tableOfContents]
+    endLevel = 2
+    ordered = true
+    startLevel = 2
+  [markup.highlight]
+    lineNos = false
+    codeFences = true
+    guessSyntax = true
+  [markup.goldmark]
+    strikethrough=false
+    [markup.goldmark.extensions.extras.delete]
+        enable = true
+    [markup.goldmark.extensions.extras.insert]
+        enable = true
+    [markup.goldmark.extensions.extras.mark]
+        enable = true
+    [markup.goldmark.extensions.extras.subscript]
+        enable = true
+    [markup.goldmark.extensions.extras.superscript]
+        enable = true
+    [markup.goldmark.renderer]
 # Enable HTML codeblocks, e.g. for <details> blocks
-unsafe = true
-hardWraps = true
-disableKinds = ["taxonomy", "term"]
-footnote= true
+      unsafe = true
+      hardWraps = true
 
 [caches.getjson]
 # Disable caching of fetches - we want every build to get up to date content for issues, so that if people make clarifications or fixes to issues, we pick them up.
@@ -65,6 +76,6 @@ getenv = ["^HUGO_CURRICULUM_GITHUB_BEARER_TOKEN$"]
 
 [module]
   [module.hugoVersion]
-    extended = false
-    min = "0.116.0"
+    extended = true
+    min = "0.133.0"
 

--- a/org-cyf-itd/hugo.toml
+++ b/org-cyf-itd/hugo.toml
@@ -18,3 +18,13 @@ description="Meet the world of tech in 30 days"
         name = "Support 🫶🏼"
         weight = 3
         url = "https://codeyourfuture.io/donate/"
+
+[markup]
+# I've configured markdown so you don't have to
+  [markup.tableOfContents]
+    endLevel = 2
+    ordered = true
+    startLevel = 2
+    [markup.goldmark.renderer]
+# Enable HTML codeblocks, e.g. for <details> blocks
+      unsafe = true

--- a/org-cyf-itp/hugo.toml
+++ b/org-cyf-itp/hugo.toml
@@ -34,4 +34,12 @@ baseURL = "https://programming.codeyourfuture.io/"
         weight = 3
         url = "https://codeyourfuture.io/donate/"
 
-theme = "common-theme"
+[markup]
+# I've configured markdown so you don't have to
+  [markup.tableOfContents]
+    endLevel = 2
+    ordered = true
+    startLevel = 2
+    [markup.goldmark.renderer]
+# Enable HTML codeblocks, e.g. for <details> blocks
+      unsafe = true

--- a/org-cyf-launch/hugo.toml
+++ b/org-cyf-launch/hugo.toml
@@ -14,8 +14,14 @@ baseURL = "https://curriculum.codeyourfuture.io/"
     [[module.imports.mounts]]
       source = "content/blocks"
       target = "content/pd/blocks"
-  [module.hugoVersion]
-    extended = true
-    min = "0.116.0"
 
-theme = "common-theme"
+
+[markup]
+# I've configured markdown so you don't have to
+  [markup.tableOfContents]
+    endLevel = 2
+    ordered = true
+    startLevel = 2
+    [markup.goldmark.renderer]
+# Enable HTML codeblocks, e.g. for <details> blocks
+      unsafe = true

--- a/org-cyf-piscine/assets/custom-theme/states/dark.scss
+++ b/org-cyf-piscine/assets/custom-theme/states/dark.scss
@@ -1,0 +1,4 @@
+.is-dark-mode,
+:root:has(.is-dark-mode) {
+  @include dark-palette;
+}

--- a/org-cyf-piscine/assets/custom-theme/states/light.scss
+++ b/org-cyf-piscine/assets/custom-theme/states/light.scss
@@ -1,0 +1,4 @@
+.is-light-mode,
+:root:has(.is-light-mode) {
+  @include light-palette;
+}

--- a/org-cyf-piscine/hugo.toml
+++ b/org-cyf-piscine/hugo.toml
@@ -7,4 +7,12 @@ title = "CYF Piscine"
 [params]
 googleFonts="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&family=Inter:wght@400;600&display=swap"
 
-theme = "common-theme"
+[markup]
+# I've configured markdown so you don't have to
+  [markup.tableOfContents]
+    endLevel = 2
+    ordered = true
+    startLevel = 2
+    [markup.goldmark.renderer]
+# Enable HTML codeblocks, e.g. for <details> blocks
+      unsafe = true

--- a/org-cyf-sdc/assets/custom-theme/states/dark.scss
+++ b/org-cyf-sdc/assets/custom-theme/states/dark.scss
@@ -1,0 +1,4 @@
+.is-dark-mode,
+:root:has(.is-dark-mode) {
+  @include dark-palette;
+}

--- a/org-cyf-sdc/assets/custom-theme/states/light.scss
+++ b/org-cyf-sdc/assets/custom-theme/states/light.scss
@@ -1,0 +1,4 @@
+.is-light-mode,
+:root:has(.is-light-mode) {
+  @include light-palette;
+}

--- a/org-cyf-sdc/hugo.toml
+++ b/org-cyf-sdc/hugo.toml
@@ -33,4 +33,12 @@ baseURL = "https://sdc.codeyourfuture.io/"
 [params]
 googleFonts="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&family=Inter:wght@400;600&display=swap"
 
-theme = "common-theme"
+[markup]
+# I've configured markdown so you don't have to
+  [markup.tableOfContents]
+    endLevel = 2
+    ordered = true
+    startLevel = 2
+    [markup.goldmark.renderer]
+# Enable HTML codeblocks, e.g. for <details> blocks
+      unsafe = true

--- a/org-cyf-theme/assets/custom-theme/states/dark.scss
+++ b/org-cyf-theme/assets/custom-theme/states/dark.scss
@@ -1,0 +1,4 @@
+.is-dark-mode,
+:root:has(.is-dark-mode) {
+  @include dark-palette;
+}

--- a/org-cyf-theme/assets/custom-theme/states/light.scss
+++ b/org-cyf-theme/assets/custom-theme/states/light.scss
@@ -1,0 +1,4 @@
+.is-light-mode,
+:root:has(.is-light-mode) {
+  @include light-palette;
+}

--- a/org-cyf-theme/hugo.toml
+++ b/org-cyf-theme/hugo.toml
@@ -14,6 +14,7 @@ baseURL = "https://curriculum.codeyourfuture.io/"
       source = "en"
       target = "content"
 
+
 [taxonomies]
 # Taxonomies common to CYF sites
   activity = 'activities'
@@ -59,22 +60,3 @@ maxAge = 0
 # Allow accessing a GitHub bearer token to avoid rate limits when doing HTTP fetches to the GitHub API.
 # This can be generated at https://github.com/settings/tokens?type=beta and needs read-only access to all public CYF GitHub repos.
 getenv = ["^HUGO_CURRICULUM_GITHUB_BEARER_TOKEN$"]
-
-[markup]
-# I've configured markdown so you don't have to
-[markup.tableOfContents]
-endLevel = 2
-ordered = true
-startLevel = 2
-[markup.highlight]
-lineNos = false
-codeFences = true
-guessSyntax = true
-[markup.goldmark.renderer]
-# Enable HTML codeblocks, e.g. for <details> blocks
-unsafe = true
-hardWraps = true
-footnote= true
-
-# You can only load one theme and this is it
-theme = "common-theme"


### PR DESCRIPTION
#885 

this is sort of weirdly alluded to here

https://gohugo.io/hugo-modules/theme-components/

> Also note that a component that is part of a theme can have its own configuration file, e.g. hugo.toml. There are currently some restrictions to what a theme component can configure.

... Yeah
