### PR TITLE
promote guides to main menu

### DIFF
--- a/org-cyf-guides/content/_index.md
+++ b/org-cyf-guides/content/_index.md
@@ -2,5 +2,7 @@
 title = 'Guides'
 description = 'A collection of guides, references, resources that do not belong to a specific day or week.'
 emoji= '📚'
+menu=["syllabus"]
+weight=1
 map=['volunteers', 'learners', 'everyone']
 +++

--- a/org-cyf-itp/hugo.toml
+++ b/org-cyf-itp/hugo.toml
@@ -20,19 +20,6 @@ baseURL = "https://programming.codeyourfuture.io/"
       source = "content/blocks"
       target = "content/pd/blocks"
       
-[menus]
-    [[menus.secondary]]
-        name = "Guides 👈🏾"
-        weight = 1
-        url = "/guides"
-     [[menus.secondary]]
-        name = "Join Us 👋🏿"
-        weight = 2
-        url = "https://codeyourfuture.io/volunteers/"
-    [[menus.secondary]]
-        name = "Support 🫶🏼"
-        weight = 3
-        url = "https://codeyourfuture.io/donate/"
 
 [markup]
 # I've configured markdown so you don't have to

--- a/org-cyf-launch/content/demo day/_index.md
+++ b/org-cyf-launch/content/demo day/_index.md
@@ -3,6 +3,6 @@ title = 'demo day'
 description = 'Demo your project to the world'
 emoji= '🚀'
 menu_level = ['module']
-menu="demo"
+menu=["demo", "syllabus"]
 weight = 11
 +++

--- a/org-cyf-launch/content/sprints/1/_index.md
+++ b/org-cyf-launch/content/sprints/1/_index.md
@@ -1,9 +1,9 @@
 +++
-title = 'Sprint 1'
+title = 'sprint 1'
 description = 'The plan for the week'
 layout = 'sprint'
 emoji= '🛹'
 menu_level = ['module']
-menu=["develop"]
+menu=["develop", "syllabus"]
 weight = 2
 +++

--- a/org-cyf-launch/content/sprints/2/_index.md
+++ b/org-cyf-launch/content/sprints/2/_index.md
@@ -1,9 +1,9 @@
 +++
-title = 'Sprint 2'
+title = 'sprint 2'
 description = 'The plan for the week'
 layout = 'sprint'
 emoji= '🛴'
 menu_level = ['module']
-menu=["develop"]
+menu=["develop", "syllabus"]
 weight = 3
 +++

--- a/org-cyf-launch/content/sprints/3/_index.md
+++ b/org-cyf-launch/content/sprints/3/_index.md
@@ -1,9 +1,9 @@
 +++
-title = 'Sprint 3'
+title = 'sprint 3'
 description = 'The plan for the week'
 layout = 'sprint'
 emoji= '🛵'
 menu_level = ['module']
-menu=["develop"]
+menu=["develop", "syllabus"]
 weight = 4
 +++

--- a/org-cyf-launch/content/sprints/4/_index.md
+++ b/org-cyf-launch/content/sprints/4/_index.md
@@ -1,9 +1,9 @@
 +++
-title = 'Sprint 4'
+title = 'sprint 4'
 description = 'The plan for the week'
 layout = 'sprint'
 emoji= '🛺'
 menu_level = ['module']
 weight = 5
-menu=["develop"]
+menu=["develop", "syllabus"]
 +++

--- a/org-cyf-launch/go.mod
+++ b/org-cyf-launch/go.mod
@@ -16,3 +16,5 @@ replace github.com/CodeYourFuture/curriculum/common-content => ../common-content
 replace github.com/CodeYourFuture/curriculum/org-cyf-theme => ../org-cyf-theme
 
 replace github.com/CodeYourFuture/curriculum/common-theme => ../common-theme
+
+replace github.com/CodeYourFuture/curriculum/org-cyf-guides => ../org-cyf-guides

--- a/org-cyf-launch/go.mod
+++ b/org-cyf-launch/go.mod
@@ -5,11 +5,14 @@ go 1.22.6
 require (
 	github.com/CodeYourFuture/CYF-PD v1.0.1-0.20240721130916-d70fc853a278 // indirect
 	github.com/CodeYourFuture/CYF-Projects/micro-front-end v0.0.0-20240802103347-3eb0ebf8ad9b // indirect
-	github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240121151641-e52b73ad527d // indirect
-	github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240404150408-303505d03061 // indirect
+	github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240818070728-e8702788f7cb // indirect
+	github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240818070728-e8702788f7cb // indirect
+	github.com/CodeYourFuture/curriculum/org-cyf-guides v0.0.0-20240820155314-7287ff7c75f9 // indirect
 	github.com/CodeYourFuture/curriculum/org-cyf-theme v0.0.0-20240818070728-e8702788f7cb // indirect
 )
 
 replace github.com/CodeYourFuture/curriculum/common-content => ../common-content
+
 replace github.com/CodeYourFuture/curriculum/org-cyf-theme => ../org-cyf-theme
+
 replace github.com/CodeYourFuture/curriculum/common-theme => ../common-theme

--- a/org-cyf-launch/go.sum
+++ b/org-cyf-launch/go.sum
@@ -6,5 +6,7 @@ github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240121151641-e52b73
 github.com/CodeYourFuture/curriculum/common-content v0.0.0-20240121151641-e52b73ad527d/go.mod h1:e3J+XphCBJJ8kf6S9ykVxNY1VKPWJoYuDFXEizlDpCI=
 github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240121151641-e52b73ad527d h1:ILE8f9gXLEPEyrJVBdFRVa0Uszf9OVdK4LjXZjCLUag=
 github.com/CodeYourFuture/curriculum/common-theme v0.0.0-20240121151641-e52b73ad527d/go.mod h1:kzt+J4JYp5C3GD1dX0rf7vY5fsTUc6Drrn+7p7pjmLg=
+github.com/CodeYourFuture/curriculum/org-cyf-guides v0.0.0-20240820155314-7287ff7c75f9 h1:bFPocaQD67r+RbrU9xDA9R9uavn10myYzwZvKBG/iqU=
+github.com/CodeYourFuture/curriculum/org-cyf-guides v0.0.0-20240820155314-7287ff7c75f9/go.mod h1:7EBadJB9OQSvx72Xhm4wN8reQYSwFNzbsiXtMhLuUQ4=
 github.com/CodeYourFuture/curriculum/org-cyf-theme v0.0.0-20240818070728-e8702788f7cb h1:P0mRDAC+Sh+7D+8Mlcyb6Sqid3w0asdincQMS9QLvpI=
 github.com/CodeYourFuture/curriculum/org-cyf-theme v0.0.0-20240818070728-e8702788f7cb/go.mod h1:Wv6VAMOIp5v0eZiHWSGzanDAIfK+prnnPK0hUPeFvwk=

--- a/org-cyf-launch/hugo.toml
+++ b/org-cyf-launch/hugo.toml
@@ -1,5 +1,5 @@
 title = "The Launch"
-baseURL = "https://curriculum.codeyourfuture.io/"
+baseURL = "https://launch.codeyourfuture.io/"
 
 [module]
   [[module.imports]]

--- a/org-cyf-launch/hugo.toml
+++ b/org-cyf-launch/hugo.toml
@@ -10,6 +10,11 @@ baseURL = "https://curriculum.codeyourfuture.io/"
       source = "content"
       target = "content/briefings"
   [[module.imports]]
+    path = "github.com/CodeYourFuture/curriculum/org-cyf-guides" 
+    [[module.imports.mounts]]
+      source = "content"
+      target = "content/guides"
+  [[module.imports]]
     path = "github.com/CodeYourFuture/CYF-PD" 
     [[module.imports.mounts]]
       source = "content/blocks"

--- a/org-cyf-sdc/hugo.toml
+++ b/org-cyf-sdc/hugo.toml
@@ -15,21 +15,7 @@ baseURL = "https://sdc.codeyourfuture.io/"
       source = "content/blocks"
       target = "content/pd/blocks"
 
-[menus]
-    [[menus.secondary]]
-        name = "Guides 👈🏾"
-        weight = 1
-        url = "/guides"
-     [[menus.secondary]]
-        name = "Join Us 👋🏿"
-        weight = 2
-        url = "https://codeyourfuture.io/volunteers/"
-    [[menus.secondary]]
-        name = "Support 🫶🏼"
-        weight = 3
-        url = "https://codeyourfuture.io/donate/"
 
-      
 [params]
 googleFonts="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&family=Inter:wght@400;600&display=swap"
 

--- a/org-cyf-theme/data/courses/itd.toml
+++ b/org-cyf-theme/data/courses/itd.toml
@@ -1,4 +1,5 @@
 name="Intro to Digital"
+url="https://cyf-itd.netlify.app/"
 weight=1
 menu="start here"
 code="itd"

--- a/org-cyf-theme/hugo.toml
+++ b/org-cyf-theme/hugo.toml
@@ -22,9 +22,9 @@ baseURL = "https://curriculum.codeyourfuture.io/"
 # Default menus     
 [menus]
     [[menus.secondary]]
-        name = "Guides 👈🏾"
+        name = "Main Curriculum 👈🏾"
         weight = 1
-        url = "https://curriculum.codeyourfuture.io/guides"
+        url = "https://curriculum.codeyourfuture.io/"
      [[menus.secondary]]
         name = "Join Us 👋🏿"
         weight = 2

--- a/org-cyf-tracks/hugo.toml
+++ b/org-cyf-tracks/hugo.toml
@@ -6,6 +6,11 @@ baseURL = "https://tracks.codeyourfuture.io/"
   [[module.imports]]
     path = "github.com/CodeYourFuture/curriculum/org-cyf-theme"
   [[module.imports]]
+    path = "github.com/CodeYourFuture/curriculum/org-cyf-guides" 
+    [[module.imports.mounts]]
+      source = "content"
+      target = "content/guides"
+  [[module.imports]]
     path = "github.com/CodeYourFuture/CYF-PD" 
     [[module.imports.mounts]]
       source = "content/blocks"

--- a/org-cyf-tracks/hugo.toml
+++ b/org-cyf-tracks/hugo.toml
@@ -16,4 +16,3 @@ baseURL = "https://tracks.codeyourfuture.io/"
       source = "content/blocks"
       target = "content/pd/blocks"
       
-theme = "common-theme"

--- a/org-cyf/hugo.toml
+++ b/org-cyf/hugo.toml
@@ -12,9 +12,9 @@ target = "content/guides"
       
 [menus]
   [[menus.secondary]]
-    name = "Guides 👈🏾"
+    name = "CYF 👈🏾"
     weight = 1
-    url = "/guides"
+    url = "https://codeyourfuture.io"
   [[menus.secondary]]
     name = "Join Us 👋🏿"
     weight = 2


### PR DESCRIPTION
and mount it where we want it

I've moved the guides to the main menu by adding it the syllabus menu
I've updated the link in the secondary menu from Guides to direct back to main curriculum
Except for on main curriculum where it goes to the main CYF site
