### PR TITLE
fix block link images

### DIFF
--- a/common-theme/assets/styles/04-components/block.scss
+++ b/common-theme/assets/styles/04-components/block.scss
@@ -34,6 +34,10 @@
   &--local {
     overflow: hidden;
   }
+  &--link {
+    padding: var(--theme-spacing--2) var(--theme-spacing--gutter)
+      var(--theme-spacing--3) 0;
+  }
 
   &--youtube {
     text-align: center;
@@ -64,40 +68,6 @@
     box-shadow: none;
     border: none;
     padding-bottom: 0;
-  }
-  // this is a card slide up on local block
-  // I had it as a flip but it was too busy at full screen
-  // in fact it's really just not good enough -- TODO take it out and we should go again
-  &__body,
-  &__footer {
-    min-width: 100%;
-    transition: all 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
-  }
-  &__body {
-    .is-active & {
-      & ~ .c-block__footer {
-        transform: translate(0%, -100%);
-      }
-    }
-  }
-  &__footer {
-    // the rest is visual
-    @include pattern(dots, var(--theme-color--pop), b, false, 0.2);
-    border-top: var(--theme-border--thick);
-    border-image: linear-gradient(
-        to right,
-        var(--theme-color--pop) var(--theme-type-size--1),
-        var(--theme-color--accent) var(--theme-type-size--1)
-      )
-      1 stretch;
-    background-color: var(--theme-color--paper-fade);
-    padding: var(--theme-spacing--gutter);
-    margin: var(--theme-spacing--gutter) 0 0
-      calc(-1 * var(--theme-spacing--gutter));
-
-    // this part moves it offscreen
-    transform: translate(0%, 100%);
-    position: absolute;
   }
 
   &__time {

--- a/common-theme/layouts/partials/block/link.html
+++ b/common-theme/layouts/partials/block/link.html
@@ -1,10 +1,7 @@
 {{ $blockData := .Page.Scratch.Get "blockData" }}
-{{ $randomImage := (index (resources.Match "custom-images/backgrounds/**.**" | shuffle | first 1) 0) }}
-{{ if and $randomImage (eq $randomImage.MediaType.Type "image") }}
-  {{ $randomImage = $randomImage.Resize "480x" }}
-{{ else }}
-  {{ $randomImage = false }}
-{{ end }}
+{{ $randomImage := resources.Match "images/backgrounds/**.**"| shuffle | first 1 }}
+{{ $chip := index $randomImage 0 }}
+{{ $chip = $chip.Resize "480x" }}
 
 
 <section class="c-block c-block--{{ $blockData.type }}">
@@ -12,9 +9,9 @@
     id="{{ $blockData.name |urlize }}"
     href="{{ $blockData.sot }}"
     class="c-chip">
-    {{ if $randomImage }}
+    {{ with $chip }}
       <img
-        src="{{ $randomImage.RelPermalink }}"
+        src="{{ $chip.RelPermalink }}"
         alt="{{ $blockData.name }}"
         class="c-chip__icon" />
     {{ end }}


### PR DESCRIPTION
the block link images were gone because the images were in flux and the location wasn't reliable. Now it's a fixed location 