### PR TITLE
Trim leading - from objective bullet points

### DIFF
--- a/common-theme/layouts/partials/objectives/block.html
+++ b/common-theme/layouts/partials/objectives/block.html
@@ -1,7 +1,7 @@
 <ul class="c-objectives__list">
   {{ range . }}
     <li class="c-objectives__item">
-      <label><input type="checkbox" />{{ . }}</label>
+      <label><input type="checkbox" />{{ strings.TrimPrefix "- " . }}</label>
     </li>
   {{ end }}
 </ul>


### PR DESCRIPTION
We already have a checkbox acting as a bullet point, we don't need an additional `-` which is an artifact of being a markdown bulleted list.