### PR TITLE
Don't double-navigate when pressing left/right

### DIFF
--- a/common-theme/assets/scripts/solo-view.js
+++ b/common-theme/assets/scripts/solo-view.js
@@ -89,17 +89,21 @@ class SoloView extends HTMLElement {
 
   // Navigation logic
   navigateBack = (event) => {
-    event.preventDefault();
-    const backIndex = this.state.currentBlockIndex - 1;
-    this.state.tocLinks[backIndex].click();
+    this.navigate(event, this.state.currentBlockIndex - 1);
   };
 
   navigateNext = (event) => {
-    event.preventDefault();
-    const nextIndex = this.state.currentBlockIndex + 1;
-    if (nextIndex < this.state.blocks.length) {
-      this.state.tocLinks[nextIndex].click();
+    this.navigate(event, this.state.currentBlockIndex + 1);
+  };
+
+  navigate = (event, index) => {
+    if (index < 0 || index >= this.state.blocks.length) {
+      return;
     }
+    event.preventDefault();
+    // If we don't stop propagation, if focus is on a child of the main view, we end up double-navigating.
+    event.stopPropagation();
+    this.state.tocLinks[index].click();
   };
 
   // Handle swipe gesture


### PR DESCRIPTION
Previously if you had focused a child element (e.g. by expanding the learning objectives), the event would get handled multiple times.

Instead, stop propagation of the event.

Fixes #907