### PR TITLE
Use variable automatically set by netlify

### DIFF
--- a/org-cyf-itp/tooling/netlify/helpers/config.ts
+++ b/org-cyf-itp/tooling/netlify/helpers/config.ts
@@ -28,7 +28,8 @@ const config = () => {
           clientSecret: process.env.GITHUB_CLIENT_SECRET,
         },
       },
-      domain: process.env.DOMAIN,
+      // Netlify sets this env var correctly for both prod deploys and deploy previews.
+      domain: process.env.URL,
     },
     { abortEarly: false }
   );


### PR DESCRIPTION
Rather than needing to manually set $DOMAIN in each site, and have the clone button not work on deploy previews.

I'm testing this out for ITP, if it works I'll copy to the other sites.