### PR TITLE
Issue cloning always goes via curriculum.

### DIFF
--- a/common-theme/layouts/partials/issues.html
+++ b/common-theme/layouts/partials/issues.html
@@ -46,7 +46,7 @@
               {{ .title }}
               <a class="c-issue__link" href="{{ .html_url }}">🔗</a>
               <a
-                href="/api/clone?state={{ dict "issue" .number "module" $repo "sprint" $filter "prevPath" $currentPath | jsonify }}"
+                href="https://curriculum.codeyourfuture.io/api/clone?state={{ dict "issue" .number "module" $repo "sprint" $filter "prevURL" (urls.AbsLangURL $currentPath) | jsonify }}"
                 class="e-button"
                 data-props="{{ $currentPath }}">
                 Clone

--- a/org-cyf/tooling/netlify/functions/clone.ts
+++ b/org-cyf/tooling/netlify/functions/clone.ts
@@ -47,9 +47,9 @@ const handler: Handler = async (event: HandlerEvent, context) => {
 
   const gh = await githubServiceBuilder(token);
 
-  const { module, sprint, issue, prevPath } = stateOrFail;
+  const { module, sprint, issue, prevURL } = stateOrFail;
 
-  const url = new URL(prevPath || "/", config().domain);
+  const url = new URL(prevURL);
 
   // if issue is defined, we clone just that issue
   if (issue) {

--- a/org-cyf/tooling/netlify/helpers/types.ts
+++ b/org-cyf/tooling/netlify/helpers/types.ts
@@ -16,7 +16,7 @@ export class CloneResponse {
 }
 
 export type RequestState = {
-  prevPath: string;
+  prevURL: string;
   module: string;
   sprint?: string;
   issue?: number;

--- a/org-cyf/tooling/netlify/helpers/util.ts
+++ b/org-cyf/tooling/netlify/helpers/util.ts
@@ -33,7 +33,7 @@ export const checkState = (
         "Content-Type": "text/html",
       },
       body: htmlRedirect(
-        state.prevPath || "/",
+        state.prevURL,
         4000,
         "State must have a module (github repo) to copy issues from. Redirecting you back to where you were.."
       ),


### PR DESCRIPTION
We don't currently have cloning functionality correctly set up on any of the other sites.

Rather than needing to set it up properly, and maintain copies of the netlify functions for each site, let's just use one copy of the netlify functions on curriculum. and redirect back to the appropriate site after cloning.

If we choose not to do this, we need to also set up a GitHub OAuth app per site, because a GitHub OAuth app is only allowed one callback domain.

It's possible we will need to futz with CORS for this, we'll see.

Once this works, I'll delete the other copies of the netlify function code.