### PR TITLE
906 Tooltip hovers can be overlapped / cropped

### DIFF
--- a/common-theme/assets/styles/04-components/block.scss
+++ b/common-theme/assets/styles/04-components/block.scss
@@ -31,9 +31,6 @@
     margin: auto 0 auto auto;
   }
 
-  &--local {
-    overflow: hidden;
-  }
   &--link {
     padding: var(--theme-spacing--2) var(--theme-spacing--gutter)
       var(--theme-spacing--3) 0;


### PR DESCRIPTION

<img width="756" alt="Screenshot 2024-09-20 at 09 00 47" src="https://github.com/user-attachments/assets/8ae6f326-98cb-45a4-9fb3-aa4e797c1002">
Fixes #906 

rm overflow hidden

this rule was handling a notes block and as we don't have this block we definitely don't need the acrobatics this rule would produce if we kept it