### PR TITLE
919 Clicking in-page anchor links obscures the title of the item being clicked to

### DIFF
--- a/common-theme/assets/styles/03-elements/links.scss
+++ b/common-theme/assets/styles/03-elements/links.scss
@@ -19,3 +19,7 @@ a:visited:not([class]),
     outline: 2px dotted;
   }
 }
+
+:target {
+  scroll-margin-top: var(--header-height);
+}


### PR DESCRIPTION
there seem to be a few tiny scroll errors in here so I will fix them up too in a mo, but for now, this is the fix for this specific bug

the other error is on soloview, where the view is jumping around - might come back to that later
