### PR TITLE
908 Backlog appears to be sorted before Prep in navigation

### DIFF
--- a/common-docs/hugo.toml
+++ b/common-docs/hugo.toml
@@ -73,3 +73,9 @@ getenv = ["^HUGO_CURRICULUM_GITHUB_BEARER_TOKEN$"]
       unsafe = true
 
 theme = "common-theme"
+
+#this makes the section nav go the right way
+# because of this 'unexpected behaviour' https://gohugo.io/methods/page/nextinsection/
+[page]
+  nextPrevInSectionSortOrder = 'asc'
+  nextPrevSortOrder = 'asc'

--- a/common-theme/hugo.toml
+++ b/common-theme/hugo.toml
@@ -37,7 +37,11 @@ description = "A free and open source software development programme."
 # orgapi = "https://api.github.com/repos/YOUR_ORG_HERE/"
 # pdrepo = "PD-curriculum-repo"
 
-#markdown configs cannot be inherited so are not set
+#markdown configs cannot be inherited so are not set, look in org-cyf-theme for examples
+# this seems also to not be heritable but you do need it
+[page]
+  nextPrevInSectionSortOrder = 'asc'
+  nextPrevSortOrder = 'asc'
 
 [caches.getjson]
 # Disable caching of fetches - we want every build to get up to date content for issues, so that if people make clarifications or fixes to issues, we pick them up.
@@ -53,4 +57,3 @@ getenv = ["^HUGO_CURRICULUM_GITHUB_BEARER_TOKEN$"]
   [module.hugoVersion]
     extended = true
     min = "0.133.0"
-

--- a/org-cyf-guides/hugo.toml
+++ b/org-cyf-guides/hugo.toml
@@ -4,4 +4,9 @@ baseURL = "https://guides.codeyourfuture.io/"
 [module]
   [[module.imports]]
     path = "github.com/CodeYourFuture/curriculum/org-cyf-theme"
-  
+
+#this makes the section nav go the right way
+# because of this 'unexpected behaviour' https://gohugo.io/methods/page/nextinsection/
+[page]
+  nextPrevInSectionSortOrder = 'asc'
+  nextPrevSortOrder = 'asc'

--- a/org-cyf-itd/hugo.toml
+++ b/org-cyf-itd/hugo.toml
@@ -29,6 +29,8 @@ description="Meet the world of tech in 30 days"
 # Enable HTML codeblocks, e.g. for <details> blocks
       unsafe = true
 
+#this makes the section nav go the right way
+# because of this 'unexpected behaviour' https://gohugo.io/methods/page/nextinsection/
 [page]
   nextPrevInSectionSortOrder = 'asc'
   nextPrevSortOrder = 'asc'

--- a/org-cyf-itp/hugo.toml
+++ b/org-cyf-itp/hugo.toml
@@ -30,3 +30,9 @@ baseURL = "https://programming.codeyourfuture.io/"
     [markup.goldmark.renderer]
 # Enable HTML codeblocks, e.g. for <details> blocks
       unsafe = true
+
+#this makes the section nav go the right way
+# because of this 'unexpected behaviour' https://gohugo.io/methods/page/nextinsection/
+[page]
+  nextPrevInSectionSortOrder = 'asc'
+  nextPrevSortOrder = 'asc'

--- a/org-cyf-launch/hugo.toml
+++ b/org-cyf-launch/hugo.toml
@@ -30,3 +30,9 @@ baseURL = "https://launch.codeyourfuture.io/"
     [markup.goldmark.renderer]
 # Enable HTML codeblocks, e.g. for <details> blocks
       unsafe = true
+
+#this makes the section nav go the right way
+# because of this 'unexpected behaviour' https://gohugo.io/methods/page/nextinsection/
+[page]
+  nextPrevInSectionSortOrder = 'asc'
+  nextPrevSortOrder = 'asc'

--- a/org-cyf-piscine/hugo.toml
+++ b/org-cyf-piscine/hugo.toml
@@ -16,3 +16,9 @@ googleFonts="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500
     [markup.goldmark.renderer]
 # Enable HTML codeblocks, e.g. for <details> blocks
       unsafe = true
+
+#this makes the section nav go the right way
+# because of this 'unexpected behaviour' https://gohugo.io/methods/page/nextinsection/
+[page]
+  nextPrevInSectionSortOrder = 'asc'
+  nextPrevSortOrder = 'asc'

--- a/org-cyf-sdc/hugo.toml
+++ b/org-cyf-sdc/hugo.toml
@@ -28,3 +28,8 @@ googleFonts="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500
     [markup.goldmark.renderer]
 # Enable HTML codeblocks, e.g. for <details> blocks
       unsafe = true
+#this makes the section nav go the right way
+# because of this 'unexpected behaviour' https://gohugo.io/methods/page/nextinsection/
+[page]
+  nextPrevInSectionSortOrder = 'asc'
+  nextPrevSortOrder = 'asc'

--- a/org-cyf/hugo.toml
+++ b/org-cyf/hugo.toml
@@ -59,3 +59,8 @@ target = "content/guides"
   url="https://systems.codeyourfuture.io/"
   weight = 7
 
+#this makes the section nav go the right way
+# because of this 'unexpected behaviour' https://gohugo.io/methods/page/nextinsection/
+[page]
+  nextPrevInSectionSortOrder = 'asc'
+  nextPrevSortOrder = 'asc'


### PR DESCRIPTION
this is a Hugo declared "unexpected behaviour" which I had fixed in itd when I saw it but failed to propagate

https://gohugo.io/methods/page/nextinsection/

apparently this page object is not heritable or not yet so I've copied it to all sites config FOR NOW

It seems like it's a mistake that this page object config is not heritable from common-theme, so I've added it in there and will check in a few months to see if we can remove these copypastas

It should be a common-theme setting, not a per site
