### PR TITLE
855 Data Groups / Sprint 1 - Explicitly ask trainees to code-along with prep?

### DIFF
--- a/common-content/en/blocks/prep-dir-tests/index.md
+++ b/common-content/en/blocks/prep-dir-tests/index.md
@@ -1,0 +1,36 @@
++++
+title = 'Prep dir'
+time = 5
+facilitation = false
+emoji= '🧩'
+[objectives]
+    1='Touch files for the first problem'
+    2="Open the first problem in your prep directory"
+    3="Use the terminal to control VSCode"
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+### 📄 Touch files for the first problem
+
+Find the first problem in your prep for this module and create the files you'll need to work on it.
+
+1. In your `prep` directory, create a test file for the problem. For example, if the first problem is about calculating the mean, you would create a file called `mean.test.js`.
+1. In your `prep` directory, create a matching file for the problem. For example, `mean.js`.
+
+Do this in your VSCode terminal by running the following commands:
+
+```bash
+touch mean.test.js
+touch mean.js
+```
+
+In the same directory, open your test file by running:
+
+```bash
+code mean.test.js
+```
+
+You'll be writing in a "test driven development" style. This means you will write a test for the problem first, then write the code to make the test pass.

--- a/common-content/en/blocks/prep-dir/index.md
+++ b/common-content/en/blocks/prep-dir/index.md
@@ -1,0 +1,28 @@
++++
+title = 'Prep dir'
+time = 10
+facilitation = false
+emoji= '🧩'
+[objectives]
+    1='Create a working prep directory for the module'
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+### 📂 Create a working directory for the module
+
+1. Fork the coursework module (always linked in every backlog) and open it in VSCode.
+1. In your VSCode terminal, navigate to the root of your project directory.
+1. Create a new directory called `prep` to store all the files you'll be working on for this module.
+
+As you work through the module, you'll be creating files in this directory to code along with the prep content. You are expected to code along with the prep content.
+
+For simple one liners, use the terminal REPL to run the code. For more complex problems, create files in the `prep` directory and write the code there. Make commented notes as you go along explaining why you're doing what you're doing. Your future self will thank you.
+
+### 🔑 The most important thing is to secure your understanding
+
+The prep content is designed to help you understand the concepts you'll be working with in the module. Don't just read it, code along with it. Also take notes, draw diagrams, pose your own questions and try to answer them.
+
+To really understand programming, you need to write the code yourself, and do the exercises. You must [take active part](https://www.pnas.org/doi/10.1073/pnas.1319030111) in your learning to succeed.

--- a/common-content/en/module/how-our-curriculum-works/active-learning/index.md
+++ b/common-content/en/module/how-our-curriculum-works/active-learning/index.md
@@ -12,6 +12,6 @@ time=10
 
 +++
 
-Active learning is at the heart of our educational philosophy. It is about encouraging learners to build, explore and discuss new concepts instead of being passive recipients of knowledge.
+[Active learning](https://www.pnas.org/doi/10.1073/pnas.1319030111) is at the heart of our educational philosophy. It is about encouraging learners to build, explore and discuss new concepts instead of being passive recipients of knowledge.
 
 {{<youtube>}}https://www.youtube.com/watch?v=-GydYPMc74g{{</youtube>}}

--- a/common-content/en/module/js2/character-limit/index.md
+++ b/common-content/en/module/js2/character-limit/index.md
@@ -31,8 +31,8 @@ Try typing in the character limit box above and observing the behaviour as you t
 
 We can define _acceptance criteria_ for this component:
 
-> _Given_ an textarea and a character limit of 200,
-> _When_ a user types characters into the textarea
+> _Given_ an textarea and a character limit of 200  
+> _When_ a user types characters into the textarea  
 > _Then_ the interface should update with how many characters they've got left
 
 ### 🏁 Starting point
@@ -65,4 +65,4 @@ In the user interface, we will start off with some static html:
 </html>
 ```
 
-> To implement the acceptance criterion, we'll need to interact with the elements on the page. We'll need a way to **access** and **update** elements based off **user interactions**.
+To implement the acceptance criterion, we'll need to interact with the elements on the page. We'll need a way to **access** and **update** elements based off **user interactions**.

--- a/common-content/en/module/js2/mean/index.md
+++ b/common-content/en/module/js2/mean/index.md
@@ -15,11 +15,11 @@ emoji= '🧩'
 
 Let's consider a problem where we calculate the [mean of a list of numbers](https://www.mathsisfun.com/mean.html).
 
-_Given_ an array of numbers,
+_Given_ an array of numbers
 _When_ we call `calculateMean` with the array of numbers
 _Then_ we get the mean
 
-Let's create a test to check its functionality:
+Let's create a test to check its functionality. In your `prep` dir, `touch mean.js && touch mean.test.js`. Write the following test in the `mean.test.js` file.
 
 ```js
 test("calculates the mean of a list of numbers", () => {

--- a/common-content/en/module/js2/median/index.md
+++ b/common-content/en/module/js2/median/index.md
@@ -17,13 +17,13 @@ Let's define another problem.
 
 We want to _calculate_ the [median](https://www.bbc.co.uk/bitesize/guides/zwhgk2p/revision/2) value from an array of numbers.
 
-_Given_ an array of numbers in _ascending order_,
-_When_ we call `calculateMedian` with this array
+_Given_ an array of numbers in _ascending order_  
+_When_ we call `calculateMedian` with this array  
 _Then_ we get the median value
 
 We calculate the median of a list of numbers by finding the middle value in the list.
 
-Let's start with a test to check the **return value** of `calculateMedian` given an ordered list of numbers.
+Let's start with a test to check the **return value** of `calculateMedian` given an ordered list of numbers. In your `prep` dir, `touch median.js && touch median.test.js`. Write the following test in the `median.test.js` file.
 
 ```js
 test("calculates the median of a list of odd length", function () {
@@ -42,7 +42,7 @@ So we can implement `calculateMedian`.
 We can summarise our approach as follows.
 
 ```mermaid
-flowchart TD
+flowchart LR
     A[Step 1: Find the middle index of the array] --> B[Step 2: Get the middle item]
     B --> C[Step 3: Return the middle item]
 ```

--- a/common-content/en/module/js2/multiple-params/index.md
+++ b/common-content/en/module/js2/multiple-params/index.md
@@ -19,6 +19,8 @@ Let's consider the case when there are multiple query parameters in the query st
 In the case when the query string has multiple query parameters, then each key-value pair is separated by an ampersand character `&`.
 {{</note>}}
 
+Write this test in the `parse-query-string.test.js` file.
+
 ```js
 test("given a query string with multiple key-value pairs, returns them in object form", function () {
   const input = "sort=lowest&colour=yellow";

--- a/common-content/en/module/js2/no-params/index.md
+++ b/common-content/en/module/js2/no-params/index.md
@@ -23,7 +23,7 @@ What we want in the case that the query string is an empty string, is something 
 
 An empty object behaves this way, so it makes sense to return an empty object.
 
-We can write a test case as follows:
+Let's create a test to explore this idea. In your `prep` dir, `touch parse-query-string.js && touch parse-query-string.test.js`. Write the following test in the `parse-query-string.test.js` file.
 
 ```js
 test("given a query string with no query parameters, returns an empty object", function () {

--- a/common-content/en/module/js2/one-pair/index.md
+++ b/common-content/en/module/js2/one-pair/index.md
@@ -14,8 +14,7 @@ emoji= '🧩'
 
 +++
 
-Let's consider another test case: when the query string contains a single key-value pair.
-We can write a test:
+Let's consider another test case: when the query string contains a single key-value pair Write a test in the `parse-query-string.test.js` file.
 
 ```js
 test("given a query string with one pair of query params, returns them in object form", function () {

--- a/common-content/en/module/js2/ordered-data/index.md
+++ b/common-content/en/module/js2/ordered-data/index.md
@@ -47,7 +47,8 @@ However, instead of _ordering_ data with _indexes_, we can label data with **key
 We can look up values in this table by the **key**. With data stored like this, we can see what values like ` "Manchester"` actually mean - in this case, it refers to a city of residence for the user.
 
 In JavaScript, we can use an {{<tooltip title="object">}}An **object** is a collection of properties. Each property is a key-value pair{{</tooltip>}}to store data in a table-like way, where we can look up data using a **key**.
-We can declare an object in the following way:
+
+We can declare an object like this.
 
 ```js
 const profileData = {

--- a/common-content/en/module/js2/query-string/index.md
+++ b/common-content/en/module/js2/query-string/index.md
@@ -5,7 +5,7 @@ time = 10
 facilitation = false
 emoji= '🧩'
 [objectives]
-1='Identify the query string section of a url'
+1='Identify the query string section of a URL'
 2='Identify query parameters within a query string'
 3='Explain why an object is a more useful structure for storing query parameters than a string' 
 [build]
@@ -17,13 +17,13 @@ emoji= '🧩'
 
 Let’s define a problem.
 
-Websites have addresses called urls like this: "https://example.com/widgets". Urls often have {{<tooltip title="query strings">}}Query strings go at the end of a url and are used to specify more information about the content you get back from a request to a server{{</tooltip>}}too. Here is an example of a url with a query string on the end:
+Websites have addresses called <abbr title="Uniform Resource Locator">[URLs](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_URL)</abbr> like this: "https://example.com/widgets". URLs often have {{<tooltip title="query strings">}}Query strings go at the end of a URL and are used to specify more information about the content you get back from a request to a server{{</tooltip>}}too. Here is an example of a URL with a query string on the end:
 
 https://example.com/widgets?colour=blue&sort=newest
 
-For the url above, the **query string** is `"colour=blue&sort=newest"`. Query strings consist of **query parameters**, separated by an ampersand character `&`. `colour=blue` is a query parameter: we say that `colour` is the key and `blue` is the value.
+For this URL, the **query string** is `"colour=blue&sort=newest"`. Query strings consist of **query parameters**, separated by an ampersand character `&`. `colour=blue` is a query parameter: we say that `colour` is the key and `blue` is the value.
 
-urls must always be strings. However, a string isn't a useful data type for accessing query parameters. Given a key like `colour`, accessing the value from a query string stored as a string is not straightforward. However, objects are ideal for looking up values with keys.
+URLs must always be strings. However, a string isn't a useful data type for accessing query parameters. Given a key like `colour`, accessing the value from a query string stored as a string is not straightforward. However, objects are ideal for looking up values with keys.
 
 We're going to implement a function `parseQueryString` to extract the query parameters from a query string and store them in an object:
 

--- a/org-cyf-itp/content/data-groups/prep/index.md
+++ b/org-cyf-itp/content/data-groups/prep/index.md
@@ -5,4 +5,10 @@ layout = 'prep'
 emoji= '🧑🏾‍💻'
 menu_level = ['module']
 weight = 1
+[[blocks]]
+name="Prep dir"
+src="blocks/prep-dir"
+[[blocks]]
+name="Creating test files"
+src="blocks/prep-dir-tests"
 +++

--- a/org-cyf-itp/content/structuring-data/prep/index.md
+++ b/org-cyf-itp/content/structuring-data/prep/index.md
@@ -23,4 +23,7 @@ src="module/js1/data"
 [[blocks]]
 name="REPL"
 src="module/js1/repl"
+[[blocks]]
+name="Prep dir"
+src="blocks/prep-dir"
 +++


### PR DESCRIPTION
## What does this change?

Add a bunch of cues throughout to actually code along
Explicitly direct trainees to create a folder in their coursework dir to codealong in
Add motivations for active learning eg The Research

### Common Content?

<!-- Does this PR add content to the common-content module? -->

Yep


Fixes #855

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Data groups | Prep 
Data groups | Sprint 1 | Prep
Data groups | Sprint 2 | Prep
Data groups | Sprint 3 | Prep
Structuring and testing data | Prep


## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
