### PR TITLE
965 Tooltips can be hidden behind header

### DIFF
--- a/common-theme/assets/styles/04-components/tooltip.scss
+++ b/common-theme/assets/styles/04-components/tooltip.scss
@@ -33,7 +33,7 @@ tool-tip {
     var(--theme-color--paper)
   );
   color: var(--theme-color--ink);
-  bottom: 100%;
+  top: 1.5em;
   left: 50%;
   transform: translateX(-50%);
 }


### PR DESCRIPTION
position the tooltip from top instead of bottom to avoid the header
we don't really want to start trying to manipulate the z-index from inside a landmark so let's just move it down instead of up and and it will be mostly fine


<img width="975" alt="Screenshot 2024-09-22 at 12 48 52" src="https://github.com/user-attachments/assets/7af6567d-0f56-4b7f-907e-2310523bc20a">
