### PR TITLE
Bugfix 990: bad link

### DIFF
--- a/common-theme/layouts/_default/_markup/render-link.html
+++ b/common-theme/layouts/_default/_markup/render-link.html
@@ -1,4 +1,4 @@
-{{- $link := .Destination -}}
+{{- $link := strings.Trim .Destination "\"" -}}
 {{- $isRemote := strings.HasPrefix $link "http" -}}
 {{- if not $isRemote -}}
   {{ $url := urls.Parse .Destination }}


### PR DESCRIPTION
## What does this change?

It seems like sometimes Hugo is recognising a link and sending it through its markdown render loop into this render hook, but this render hook uses Go parse https://pkg.go.dev/net/url#Parse and can't handle spaces or quotes. 

So I trimmed 'em.

I think I probably want to log bad links, but not fail all builds when one link somewhere is bad -- that seems like a terrible development experience! Anyone who wants to sort that out please do.

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes

<!--Please reference the ticket you are addressing -->

Fixes #990

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
