### PR TITLE
add nav for sprints

### DIFF
--- a/common-theme/assets/styles/04-components/page-footer.scss
+++ b/common-theme/assets/styles/04-components/page-footer.scss
@@ -5,6 +5,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    text-transform: lowercase;
   }
 
   &__this {

--- a/common-theme/layouts/_default/sprint.html
+++ b/common-theme/layouts/_default/sprint.html
@@ -14,4 +14,26 @@
       {{ end }}
     </ol>
   </article>
+  <footer class="c-page-footer">
+    <nav class="c-page-footer__nav">
+      <!--These aren't quite sections so prev and next won't appear, but we can fake it-->
+      {{ $thisPageWeight := .Page.Weight }}
+      {{ $PrevInSection := .Page.Parent }}
+      {{ $NextInSection := .Page.Parent }}
+      {{ range where .Site.Pages "Section" .Section }}
+        {{ if and (in .Params.menu_level "module") (eq .Weight (sub $thisPageWeight 1)) }}
+          {{ $PrevInSection = . }}
+        {{ end }}
+        {{ if and (in .Params.menu_level "module") (eq .Weight (add $thisPageWeight 1)) }}
+          {{ $NextInSection = . }}
+        {{ end }}
+      {{ end }}
+
+      ←<a href="{{ $PrevInSection.RelPermalink }}"
+        >{{ $PrevInSection.Title }}</a
+      >
+      <a href="{{ $NextInSection.RelPermalink }}">{{ $NextInSection.Title }}</a
+      >→
+    </nav>
+  </footer>
 {{ end }}


### PR DESCRIPTION
## What does this change?

Adds a tiny section nav to sprint views

Because it's annoying me editing the url all the time to sprint around

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

yep, no ticket, just would like it and it seemed simple

Go to http://localhost:1313/user-data/sprints/3/ for example and see the same section nav appear as is already on other pages

I added a return to the module parent at the end but you could rm this and have it empty if you prefer -- get your hands on it


## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
