### PR TITLE
Tweaks to ITP overview

### DIFF
--- a/common-content/en/module/html-css/what-are-forms/index.md
+++ b/common-content/en/module/html-css/what-are-forms/index.md
@@ -4,6 +4,7 @@ title = 'What are forms?'
 time = 60
 facilitation = false
 emoji= '🧩'
+hide_from_overview = true
 [objectives]
     1='Define form, field, and input'
     2='Define form elements and attributes'

--- a/common-content/en/module/induction/checkout-a-commit/index.md
+++ b/common-content/en/module/induction/checkout-a-commit/index.md
@@ -1,5 +1,5 @@
 +++
-title = 'Inspect a commit'
+title = 'Inspecting a commit'
 
 time ="15"
 facilitation = false

--- a/common-content/en/module/induction/cyf-blog/index.md
+++ b/common-content/en/module/induction/cyf-blog/index.md
@@ -3,6 +3,7 @@ title = 'Blog'
 time ="5"
 facilitation = false
 emoji= '📝'
+hide_from_overview = true
 [build]
   render = 'never'
   list = 'local'

--- a/common-content/en/module/induction/development-process/index.md
+++ b/common-content/en/module/induction/development-process/index.md
@@ -3,6 +3,7 @@ title = 'Development process'
 time ="10"
 facilitation = false
 emoji= '🧰'
+hide_from_overview = true
 [build]
   render = 'never'
   list = 'local'

--- a/common-content/en/module/induction/previous-versions/index.md
+++ b/common-content/en/module/induction/previous-versions/index.md
@@ -1,5 +1,5 @@
 +++
-title = 'Previous versions'
+title = 'Inspecting previous versions'
 objectives = ["Use a Git history to view previous versions of a project", "Find the commit that corresponds to a particular version of a project"]
 time ="20"
 facilitation = false

--- a/common-content/en/module/induction/viewing-files/index.md
+++ b/common-content/en/module/induction/viewing-files/index.md
@@ -1,5 +1,5 @@
 +++
-title = 'Viewing the files'
+title = 'Viewing files from a git clone'
 
 time ="20"
 facilitation = false

--- a/common-content/en/module/induction/wrapping-up/index.md
+++ b/common-content/en/module/induction/wrapping-up/index.md
@@ -4,6 +4,7 @@ title = 'Wrapping up Git'
 time ="20"
 facilitation = false
 emoji= '🎁'
+hide_from_overview = true
 [objectives]
     1='Commit changes to a local git branch'
 [build]

--- a/common-content/en/module/js1/assembly/index.md
+++ b/common-content/en/module/js1/assembly/index.md
@@ -4,6 +4,7 @@ title = '🏗️ Assembling the parts'
 time = 20
 facilitation = false
 emoji= '🧩'
+hide_from_overview = true
 [objectives]
     1='Explain how different concepts are combined to solve a goal'
 [build]

--- a/common-content/en/module/js1/clocks/index.md
+++ b/common-content/en/module/js1/clocks/index.md
@@ -4,6 +4,7 @@ title = '🕛 12 vs 24 hour clock'
 time = 10
 facilitation = false
 emoji= '🧩'
+hide_from_overview = true
 [objectives]
  1='Identify a pattern between a set of inputs and outputs produced by a given function'
 [build]

--- a/common-content/en/module/js1/strategy/index.md
+++ b/common-content/en/module/js1/strategy/index.md
@@ -4,6 +4,7 @@ title = '↙️ ↘️ Making a choice'
 time = 20
 facilitation = false
 emoji= '🧩'
+hide_from_overview = true
 [objectives]
     1='Propose a strategy for solving a problem'
 [build]

--- a/common-content/en/module/js2/plan/index.md
+++ b/common-content/en/module/js2/plan/index.md
@@ -1,5 +1,5 @@
 +++
-title = '🧭 Strategy'
+title = '🧭 Breaking down the strategy'
 
 time = 20
 facilitation = false

--- a/common-theme/layouts/_default/overview.html
+++ b/common-theme/layouts/_default/overview.html
@@ -60,10 +60,11 @@
          <ol class="c-overview__list">
             {{ range $prep.Params.blocks }}
               {{ $block := ($site.GetPage .src) }}
-              {{ if or $block.Params.hide_from_overview (strings.Contains .src "https:") }}
+              {{ if or $block.Params.hide_from_overview (and (not .title) (strings.Contains .src "https:")) }}
                 {{ continue }}
               {{ end }}
-              <li>{{ $block.Title }}</li>
+              {{ $title := or .title $block.Title }}
+              <li>{{ $title }}</li>
             {{ end }}
           </ol>
          {{end}}

--- a/org-cyf-itp/content/structuring-data/sprints/1/_index.md
+++ b/org-cyf-itp/content/structuring-data/sprints/1/_index.md
@@ -5,5 +5,5 @@ layout = 'sprint'
 emoji= '⏱️'
 menu_level = ['module']
 weight = 2
-theme = "Playing computer"
+theme = "Programming fundamentals"
 +++

--- a/org-cyf-itp/content/structuring-data/sprints/2/_index.md
+++ b/org-cyf-itp/content/structuring-data/sprints/2/_index.md
@@ -5,5 +5,5 @@ layout = 'sprint'
 emoji= '⏱️'
 menu_level = ['module']
 weight = 3
-theme = "Comparisons and assertions"
+theme = "Comparisons, assertions, and breaking down problems"
 +++

--- a/org-cyf-itp/content/user-data/sprints/1/_index.md
+++ b/org-cyf-itp/content/user-data/sprints/1/_index.md
@@ -5,7 +5,7 @@ layout = 'sprint'
 emoji= '⏱️'
 menu_level = ['module']
 weight = 2
-theme = 'Programming fundamentals'
+theme = 'Version control'
 +++
 
 

--- a/org-cyf-itp/content/user-data/sprints/2/_index.md
+++ b/org-cyf-itp/content/user-data/sprints/2/_index.md
@@ -5,7 +5,7 @@ layout = 'sprint'
 emoji= '⏱️'
 menu_level = ['module']
 weight = 3
-theme = "Breaking down problems with functions"
+theme = "Collecting and formatting data"
 +++
 
 

--- a/org-cyf-itp/content/user-data/sprints/2/prep/index.md
+++ b/org-cyf-itp/content/user-data/sprints/2/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 [[blocks]]
 name="Forms in 25 minutes"
+title="Form building"
 src="https://www.youtube.com/watch?v=fNcJuPIZ2WE"
 [[blocks]]
 name="Spaced Repetition"

--- a/org-cyf-itp/content/user-data/sprints/3/_index.md
+++ b/org-cyf-itp/content/user-data/sprints/3/_index.md
@@ -5,7 +5,7 @@ layout = 'sprint'
 emoji= '⏱️'
 menu_level = ['module']
 weight = 4
-theme = "Breaking down problems and testing"
+theme = "Querying data, considering presentation"
 +++
 
 

--- a/org-cyf-itp/content/user-data/sprints/3/prep/index.md
+++ b/org-cyf-itp/content/user-data/sprints/3/prep/index.md
@@ -6,6 +6,7 @@ menu_level = ['sprint']
 weight = 1
 [[blocks]]
 name="Record a Goose"
+title="Accessibility audit"
 src="https://github.com/CodeYourFuture/Project-Record-A-Goose/readme"
 time=180
 [[blocks]]


### PR DESCRIPTION
* Update themes to reflect actual content
* Make some titles more clear
* Hide a few "just process, not content" prep items from overview
* Allow specifying titles in the blocks list (e.g. for external blocks like YouTube videos), rather than requiring blocks specify them in their own frontmatter.