### PR TITLE
Moving the setup planner section after the planner-related videos

### DIFF
--- a/org-cyf-itp/content/user-data/prep/index.md
+++ b/org-cyf-itp/content/user-data/prep/index.md
@@ -22,13 +22,13 @@ name="Fork your Planner"
 src="https://www.youtube.com/watch?v=cnx0RuAu2tc"
 time=5
 [[blocks]]
-name="Set up Planner"
-src="https://github.com/CodeYourFuture/Coursework-Planner/tree/main"
-time=30
-[[blocks]]
 name="Make your Planning Board"
 src="https://www.youtube.com/watch?v=Hbtfil-G0h0"
 time=15
+[[blocks]]
+name="Set up Planner"
+src="https://github.com/CodeYourFuture/Coursework-Planner/tree/main"
+time=30
 [[blocks]]
 name="Spaced Repetition"
 src="blocks/spaced-repetition"


### PR DESCRIPTION
## What does this change?

We've now updated the "Set up Planner" to cover the full step-by-step process and included screenshots. Moving this after the videos, as participants can first watch the videos before attempting to set up the planner themselves.

### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #1018 

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

@CodeYourFuture/itp-syllabus-team 
