### PR TITLE
Create a placeholder 404 file with the correct permissions

### DIFF
--- a/common-theme/static/404.html
+++ b/common-theme/static/404.html
@@ -1,0 +1,11 @@
+This is a placeholder file which will be replaced by hugo.
+
+If this file doesn't exist, hugo will for some reason create a placeholder file with the wrong permissions, and won't be able to overwrite it with the rendered file.
+
+You should never see this file served by a hugo site.
+
+We wish we understood why hugo was creating a placeholder with permissions 0444 instead of 0644, but we can't work it out.
+
+Oh, by the way, it only does so for some sites (specifically, common-docs, but not any others).
+
+See https://github.com/CodeYourFuture/curriculum/issues/992


### PR DESCRIPTION
Hugo will correctly replace this with the actual rendered 404 page. But if this file doesn't already exist with the correct permissions, hugo will for some reason which we can't debug create a placeholder file with permissions 0444 instead of 0644, and then won't be able to overwrite it with the correctly rendered file.

Fixes #992 somehow, even if we don't really know how.