### PR TITLE
Rephrase pages to hide "block" as a UI term

### DIFF
--- a/common-content/en/module/how-our-curriculum-works/day-plan/index.md
+++ b/common-content/en/module/how-our-curriculum-works/day-plan/index.md
@@ -4,7 +4,7 @@ emoji="📅"
 time=5
 [objectives]
     1="Describe how the day plan works"
-    2="Identify some frequently used blocks in a module"
+    2="Identify some frequently used activities in a day plan"
 [build]
   render = 'never'
   list = 'local'

--- a/common-content/en/module/how-our-curriculum-works/morning-orientation-block/index.md
+++ b/common-content/en/module/how-our-curriculum-works/morning-orientation-block/index.md
@@ -3,8 +3,8 @@ title="Morning orientation"
 emoji='🎡'
 time=10
 [objectives]
-    1="Locate a morning orientation block"
-    2="Check learning objectives for morning orientation block"
+    1="Locate the morning orientation activity in a day plan"
+    2="Check learning objectives for morning orientation activity"
 [build]
   render = 'never'
   list = 'local'
@@ -12,10 +12,12 @@ time=10
 
 +++
 
-We use the morning orientation block to gather the community together. We nominate a time-keeper and a facilitator (if they weren't already nominated during the week). The objectives of the morning orientation block are clear:
+Early in most day plans, we use the morning orientation activity to gather the community together. We nominate a time-keeper and a facilitator (if they weren't already nominated during the week).
+
+Most activities have written down objectives. It's useful to know _why_ we're doing something, before we start doing it.
 
 ### Steps 👣
 
-1. Find a day plan view where the morning orientation is used
-1. Check the learning objectives on the morning orientation block
-1. Volunteer to be the facilitator or timekeeper
+1. Find a day plan view where the morning orientation activity is used
+1. Check the learning objectives on the morning orientation activity
+1. Volunteer to be the facilitator or timekeeper (you don't need to do this every week!)

--- a/common-content/en/module/how-our-curriculum-works/study-groups/index.md
+++ b/common-content/en/module/how-our-curriculum-works/study-groups/index.md
@@ -3,7 +3,7 @@ title="Study groups"
 emoji='🫱🏾‍🫲🏿'
 time=10
 [objectives]
-    1="Locate a study group block"
+    1="Locate a study group activity in a day plan"
     2="Explain the importance of study groups"
 [build]
   render = 'never'
@@ -17,6 +17,6 @@ In a flipped classroom, we spend our time in class focused on active learning: w
 ### Steps 👣
 
 1. Search for **study group** on the curriculum website
-1. Find a day plan that uses the **study group** block
-1. Read the instructions on the block
-1. Check the learning objectives for the study group block
+1. Find a day plan that uses the **study group** activity
+1. Read the instructions for the activity
+1. Check the learning objectives for the study group activity


### PR DESCRIPTION
## What does this change?

Rephrase pages to hide "block" as a UI term

Blocks are an internal implementation detail of the curriculum platform. We shouldn't typically refer to them when talking to users of the platform.

Instead, refer to "activities in a day plan" and similar.

### Common Content?

Yes, in How Our Curriculum Works.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)