### PR TITLE
Use textContent not innerText

### DIFF
--- a/common-content/en/module/js2/update/index.md
+++ b/common-content/en/module/js2/update/index.md
@@ -5,7 +5,7 @@ time = 45
 facilitation = false
 emoji= '🧩'
 [objectives]
-    1='Access and modify the innerText of a html element'
+    1='Access and modify the textContent of a html element'
 [build]
   render = 'never'
   list = 'local'
@@ -17,7 +17,7 @@ We can calculate the remaining characters available every time a user's key is r
 
 > Step 5: Update the interface with the number of characters left
 
-To achieve this goal, we'll need to access the `p` element with id `"character-limit-info"` and then update the inner text. As before, we can use `document.querySelector` to access an element in the DOM using an appropriate CSS selector:
+To achieve this goal, we'll need to access the `p` element with id `"character-limit-info"` and then update its text content. As before, we can use `document.querySelector` to access an element in the DOM using an appropriate CSS selector:
 
 ```js {linenos=table,linenostart=1, hl_lines=["8-9"] }
 const characterLimit = 200;
@@ -28,7 +28,7 @@ function updateCharacterLimit() {
   console.log(`${charactersLeft} characters remaining`);
 
   const charactersLeftP = document.querySelector("#character-limit-info");
-  charactersLeftP.innerText = `You have ${charactersLeft} characters remaining`;
+  charactersLeftP.textContent = `You have ${charactersLeft} characters remaining`;
 }
 
 textarea.addEventListener("keyup", updateCharacterLimit);

--- a/common-theme/assets/scripts/word-limit.js
+++ b/common-theme/assets/scripts/word-limit.js
@@ -22,7 +22,7 @@ class WordLimit extends HTMLElement {
   updateCharacterLimitInfo() {
     const characterCount = this.getCharacterCount();
     this.charactersLeft = CHARACTER_LIMIT - characterCount;
-    this.message.innerText = `You have ${this.charactersLeft} characters remaining`;
+    this.message.textContent = `You have ${this.charactersLeft} characters remaining`;
   }
 
   getCharacterCount() {


### PR DESCRIPTION
## What does this change?

textContent is a better default as it doesn't force reflows.

We can introduce innerText as/when it's needed.

### Common Content?

- `common-content/en/module/js2/update/index.md`

### Common Theme?

- `common-theme/assets/scripts/word-limit.js`

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)