### PR TITLE
Bugfix: trainee PR showing up in backlog : filter out PRs

### DIFF
--- a/common-theme/layouts/partials/issues.html
+++ b/common-theme/layouts/partials/issues.html
@@ -30,6 +30,10 @@
             {{ end }}
           {{ end }}
         {{ end }}
+
+        {{ if (isset . "pull_request") }}
+          {{ $showIssue = false }}
+        {{ end }}
         <!-- now show the issue -->
         {{ if $showIssue }}
           {{ if strings.Contains .body "_No response_" }}


### PR DESCRIPTION
I always forget this API won't let you do it up top - have to do it after pulling them through, hence the need for Daniel's cache

I've filtered out PRs so they won't show up even if a trainee labels their PR with a sprint label, which I guess sometimes someone might do!

See https://codeyourfuture.slack.com/archives/C076K3V76CA/p1729175848173849 for more context

with filter
<img width="1390" alt="Screenshot 2024-10-17 at 16 11 01" src="https://github.com/user-attachments/assets/dfb0facb-0511-4f48-882c-b216764aa515">


without
<img width="1453" alt="Screenshot 2024-10-17 at 16 11 58" src="https://github.com/user-attachments/assets/0f6c70de-ac0d-4c3c-bf3b-62f66e8c1b4e">
