### PR TITLE
Set CORS headers for dummy APIs

### DIFF
--- a/org-cyf-itp/netlify.toml
+++ b/org-cyf-itp/netlify.toml
@@ -12,3 +12,8 @@ to = "/.netlify/functions/:splat"
 status = 200
 [functions]
 external_node_modules = ["node-fetch"]
+
+[[headers]]
+  for = "/dummy-apis/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
Currently trying to fetch them fails due to CORS.