### PR TITLE
Bring tooltips further forward

### DIFF
--- a/common-theme/assets/styles/04-components/tooltip.scss
+++ b/common-theme/assets/styles/04-components/tooltip.scss
@@ -3,7 +3,7 @@ tool-tip-container {
   display: inline-block;
   cursor: help;
   text-decoration: 1px var(--theme-color--brand) wavy underline;
-  z-index: 2;
+  z-index: 3;
 }
 
 .tooltip {


### PR DESCRIPTION
Tab titles are already at 2.

I'm sorry Sally.

Fixes #1106