### PR TITLE
note shortcode: Use title as title when specified

### DIFF
--- a/common-content/en/module/js1/interpreting-errors/index.md
+++ b/common-content/en/module/js1/interpreting-errors/index.md
@@ -56,11 +56,11 @@ Your output was probably different. But it will have the same parts. Some text, 
 
 {{<note type="exercise" title="Exercise">}}
 
-Work out what the parts of this line mean.
+1. Work out what the parts of this line mean.
 
-Why are they different on my computer than yours?
+2. Why are they different on my computer than yours?
 
-How can we use both pieces of information?
+3. How can we use both pieces of information?
 
 {{</note>}}
 
@@ -92,9 +92,7 @@ Node.js v22.4.1
 
 {{<note type="exercise" title="Exercise">}}
 
-What does this line mean?
-
-Why might it be useful to know this information?
+What does this line mean? Why might it be useful to know this information?
 
 Add your answer to your spaced repetition calendar. Your understanding of this will grow over time. Answer the question again in the future, and compare it to your previous answer.
 

--- a/common-theme/layouts/shortcodes/note.html
+++ b/common-theme/layouts/shortcodes/note.html
@@ -14,13 +14,13 @@ so look in render-blockquote.html for the new syntax.
   "tip" ":bulb:"
   "warning" ":warning:"
 }}
-{{$title := .Get "title" | default "Note"}}
+{{$title := .Get "title" | default (.Get "type") | default "Note"}}
 {{$noteType := .Get "type" | default "note"}}
 
 <section class="c-note c-note--{{$noteType}}">
   <h4 class="c-note__title e-heading__4">
     {{ transform.Emojify (index $emojis $noteType) }}
-      {{ or (i18n $noteType) ($noteType) }}</span>
+      {{ or (i18n $noteType) ($title) }}</span>
   </h4>
   <div class="c-note__text ">{{ printf "%s" .Inner | markdownify }}</div>
 </section>


### PR DESCRIPTION
## What does this change?

I think this was accidentally changed in
7287ff7c75f944eb4a79f871e40425ec3d4ba3d7?

This isn't a pure revert - it sets up a fallback chain of title > type > Note rather than just title > Note

### Common Content?

Trivially, sets up some example titles (as requested in #1033).

### Common Theme?

Yes - changes the note shortcode.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)