### PR TITLE
1105 suppress step view

### DIFF
--- a/common-theme/layouts/partials/breadcrumbs.html
+++ b/common-theme/layouts/partials/breadcrumbs.html
@@ -26,16 +26,18 @@
           </a>
         </li>
       {{- end }}
-      <li class="c-breadcrumbs__item">
-        <a
-          class="c-breadcrumbs__link"
-          href="{{ .RelPermalink }}"
-          {{- if in .Title "Sprint" -}}
-            data-pagefind-filter="sprint"
-          {{- end -}}
-          >{{ .Title }}</a
-        >
-      </li>
+      {{ if ne .Params.Build.render "never" }}
+        <li class="c-breadcrumbs__item">
+          <a
+            class="c-breadcrumbs__link"
+            href="{{ .RelPermalink }}"
+            {{- if in .Title "Sprint" -}}
+              data-pagefind-filter="sprint"
+            {{- end -}}
+            >{{ .Title }}</a
+          >
+        </li>
+      {{ end }}
     </ol>
   </nav>
   {{/* Here's a tiny drop of structured data for google's hungry maw

--- a/org-cyf-itd/content/steps/_index.md
+++ b/org-cyf-itd/content/steps/_index.md
@@ -3,5 +3,6 @@ title = 'Steps'
 description = 'The steps to complete the Intro to Digital programme'
 layout = 'module'
 emoji= '📚'
-menu = ['syllabus']
+[build]
+render = 'never'
 +++


### PR DESCRIPTION
Part 3 of #1105 

Other parts #1130  #1131 

1. suppress step index view as it's just the same info as the home page
2. skip this inaccessible page in breadcrumbs