### PR TITLE
1001 Bug: readme links not being cleaned

### DIFF
--- a/common-theme/layouts/partials/block/data.html
+++ b/common-theme/layouts/partials/block/data.html
@@ -56,11 +56,7 @@
       {{ $newSrc = print $newSrc "?per_page=5&state=open" }}
       {{ .Scratch.SetInMap "blockData" "type" "pullreq" }}
     {{ else }}
-      {{/* For repositories and individual README files, use readme API endpoint
-        https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-a-repository-readme-for-a-directory
-      */}}
-      {{ $newSrc = replace $newSrc "/tree/main" "/readme" }}
-      {{ $newSrc = replace $newSrc "/blob/main/README.md" "/readme" }}
+      {{ $newSrc = partial "strings/readme-paths" (dict "src" $newSrc) }}
       {{ .Scratch.SetInMap "blockData" "type" "readme" }}
     {{ end }}
 

--- a/common-theme/layouts/partials/strings/readme-paths.html
+++ b/common-theme/layouts/partials/strings/readme-paths.html
@@ -17,6 +17,9 @@
 
 {{ $newSrc := .src }}
 
+{{/* Remove trailing slash if present */}}
+{{ $newSrc = replaceRE "/$" "" $newSrc }}
+
 {{/* Handle /blob/main/path/readme.md format */}}
 {{ $newSrc = replaceRE "/blob/main/(.+?)/(?i:readme\\.md)$" "/readme/$1" $newSrc }}
 

--- a/common-theme/layouts/partials/strings/readme-paths.html
+++ b/common-theme/layouts/partials/strings/readme-paths.html
@@ -1,0 +1,31 @@
+{{/* For repositories and individual README files, use readme API endpoint
+  https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-a-repository-readme-for-a-directory
+
+  /repos/{owner}/{repo}/readme/{dir}
+
+  $newSrc comes in as api links from data.html, but TODO you might want to also transform directly from github.com links
+  https://api.github.com/repos/CodeYourFuture/CYF-Workshops
+  change to => https://api.github.com/repos/CodeYourFuture/CYF-Workshops/readme/
+  https://api.github.com/repos/CodeYourFuture/CYF-Workshops/tree/main/template
+  change to => https://api.github.com/repos/CodeYourFuture/CYF-Workshops/readme/template
+  https://api.github.com/repos/CodeYourFuture/CYF-Workshops/blob/main/template/readme.md
+  change to => https://api.github.com/repos/CodeYourFuture/CYF-Workshops/readme/template
+
+  https://api.github.com/repos/{owner}/{repo}
+  https://api.github.com/repos/{owner}/{repo}/{dir}
+*/}}
+
+{{ $newSrc := .src }}
+
+{{/* Handle /blob/main/path/readme.md format */}}
+{{ $newSrc = replaceRE "/blob/main/(.+?)/(?i:readme\\.md)$" "/readme/$1" $newSrc }}
+
+{{/* Handle /tree/main/path format */}}
+{{ $newSrc = replaceRE "/tree/main/(.+)$" "/readme/$1" $newSrc }}
+
+{{/* Add /readme if it's not already present */}}
+{{ if not (findRE "/readme" $newSrc) }}
+  {{ $newSrc = print $newSrc "/readme" }}
+{{ end }}
+
+{{ return $newSrc }}

--- a/org-cyf-itp/content/user-data/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/user-data/sprints/1/day-plan/index.md
@@ -17,7 +17,7 @@ src="blocks/workshop"
 time="140"
   [[blocks.nested.blocks]]
     name="Stand-up [PD] (30 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/stand-up"
+    src="https://github.com/CodeYourFuture/CYF-Workshops/blob/main/stand-up/readme.md"
     time=0
   [[blocks.nested.blocks]]
     name="Git Day 1 [Tech] (60 Mins)"


### PR DESCRIPTION
## What does this change?

As per #1001, adds a new strings util to transform github readme api paths. 

I've changed the format of a link on ITP> UFD > 1 > Dayplan  to show this. This is how it worked before we broke it at some point, but I've done it in a more robust way now - I've hived it off into a separate, well commented partial that the data partial can call. 

It is probably desirable to do this with most of the string transforms over time.


### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

 Fixes #1001 readme regex

<!--Please reference the ticket you are addressing -->

Issue number: #issue-number

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

UFD | 1 | Dayplan | Workshop

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
