### PR TITLE
add regex to catch case

### DIFF
--- a/common-theme/layouts/partials/strings/readme-paths.html
+++ b/common-theme/layouts/partials/strings/readme-paths.html
@@ -26,8 +26,11 @@
 {{/* Handle /tree/main/path format */}}
 {{ $newSrc = replaceRE "/tree/main/(.+)$" "/readme/$1" $newSrc }}
 
-{{/* Add /readme if it's not already present */}}
-{{ if not (findRE "/readme" $newSrc) }}
+{{/* Handle root of repo with /tree/main */}}
+{{ $newSrc = replaceRE "/tree/main$" "/readme" $newSrc }}
+
+{{/* Make sure that /readme is present, avoiding duplicates */}}
+{{ if not (findRE "/readme(/.*)?$" $newSrc) }}
   {{ $newSrc = print $newSrc "/readme" }}
 {{ end }}
 


### PR DESCRIPTION
## What does this change?

This adds in a catch for the case where it's the root of the repo readme but /tree/main is on the path.

This is fine but the real question is why isn't the error caught in readme.html


### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes read me paths
