### PR TITLE
Error if a README couldn't be found

### DIFF
--- a/common-theme/layouts/partials/block/block.html
+++ b/common-theme/layouts/partials/block/block.html
@@ -21,5 +21,5 @@
 {{ else if eq $blockData.type "link" }}
   {{ partial "block/link.html" . }}
 {{ else }}
-  <p>Error: {{ $blockData.type }} Unrecognized block type</p>
+  {{ errorf "Unrecognized block type %s" $blockData.type }}
 {{ end }}

--- a/common-theme/layouts/partials/block/readme.html
+++ b/common-theme/layouts/partials/block/readme.html
@@ -1,6 +1,14 @@
 {{ $blockData := .Page.Scratch.Get "blockData" }}
+
 {{ $pageContext := . }}
-{{ with resources.GetRemote $blockData.api $blockData.headers }}
+{{ $response := resources.GetRemote $blockData.api $blockData.headers }}
+
+{{/* 404s lead to GetRemote returning nil rather than an error. */}}
+{{ if eq $response nil }}
+  {{ errorf "Couldn't find readme at %s" $blockData.api }}
+{{ end }}
+
+{{ with $response }}
   {{ with .Err }}
     {{ errorf "Failed %s on %s. Error: %s" $blockData.api .Page.Title .Err }}
   {{ end }}


### PR DESCRIPTION
GetRemote returns nil not an error in this case


Also, fail the build on unrecognised block types.