### PR TITLE
Use site not $.Site

### DIFF
--- a/common-theme/layouts/_default/day-plan.html
+++ b/common-theme/layouts/_default/day-plan.html
@@ -16,11 +16,11 @@
     <time-stamper>
       <div class="c-block__series c-block__series--timeline">
         {{ if ne .Params.noRegister true }}
-          {{ partial "register-attendance.html" (dict "course" $.Site.Title "module" $.Page.CurrentSection.Parent.Title "day" $.Page.CurrentSection.Title) }}
+          {{ partial "register-attendance.html" (dict "course" site.Title "module" $.Page.CurrentSection.Parent.Title "day" $.Page.CurrentSection.Title) }}
         {{ end }}
         {{ range $index, $block := .Params.blocks }}
 
-          {{ partial "block/block.html" (dict "block" $block "Page" $.Page "Site" $.Site) }}
+          {{ partial "block/block.html" (dict "block" $block "Page" $.Page "Site" site) }}
 
         {{ end }}
       </div>

--- a/common-theme/layouts/_default/prep.html
+++ b/common-theme/layouts/_default/prep.html
@@ -14,7 +14,7 @@
         <!-- Blocks will appear here in order listed in the blocks list in the sprint front matter -->
         {{ range .Params.blocks }}
           {{ partial "block/block.html" (dict "block" . "Page"
-            $.Page "Site" $.Site )
+            $.Page "Site" site )
           }}
         {{ end }}
       </div>

--- a/common-theme/layouts/_default/single.html
+++ b/common-theme/layouts/_default/single.html
@@ -10,7 +10,7 @@
       <!-- Blocks will appear here in order listed in the blocks list in the sprint front matter -->
       {{ range .Params.blocks }}
         {{ partial "block/block.html" (dict "block" . "Page"
-          $.Page "Site" $.Site)
+          $.Page "Site" site)
         }}
       {{ end }}
     </div>

--- a/common-theme/layouts/partials/block/local.html
+++ b/common-theme/layouts/partials/block/local.html
@@ -33,7 +33,7 @@
         <h3>🗂️ Options</h3>
         {{ range . }}
           {{ range $block := . }}
-            {{ $blockDict := dict "block" $block "Page" $.Page "Site" $.Site }}
+            {{ $blockDict := dict "block" $block "Page" $.Page "Site" site }}
             {{ partial "block/nested.html"  $blockDict }}
           {{ end }}
         {{ end }}

--- a/common-theme/layouts/partials/block/pd.html
+++ b/common-theme/layouts/partials/block/pd.html
@@ -1,7 +1,7 @@
 {{ $blockData := .Page.Scratch.Get "blockData" }}
 {{ $pageContext := . }}
 {{ $tab_set_id := $blockData.name | anchorize }}
-{{ $issueForm := print $.Site.Params.org "/" $.Site.Params.pdrepo "/issues/new?assignees=&labels=Feedback&template=feedback_template.yml&title=Feedback+on+" ($blockData.name | urlize) }}
+{{ $issueForm := print site.Params.org "/" site.Params.pdrepo "/issues/new?assignees=&labels=Feedback&template=feedback_template.yml&title=Feedback+on+" ($blockData.name | urlize) }}
 
 {{ with .Page.Site.GetPage $blockData.api }}
   <section

--- a/common-theme/layouts/partials/block/readme.html
+++ b/common-theme/layouts/partials/block/readme.html
@@ -46,7 +46,7 @@
         <h3>🗂️ Related</h3>
         {{ range . }}
           {{ range $block := . }}
-            {{ $blockDict := dict "block" $block "Page" $.Page "Site" $.Site }}
+            {{ $blockDict := dict "block" $block "Page" $.Page "Site" site }}
             {{ partial "block/nested.html"  $blockDict }}
           {{ end }}
         {{ end }}

--- a/common-theme/layouts/partials/foot.html
+++ b/common-theme/layouts/partials/foot.html
@@ -1,15 +1,15 @@
 <footer class="l-layout__footer l-footer">
   <a
     class="l-footer__github e-button e-button--icon"
-    href="{{ $.Site.Params.repo }}">
+    href="{{ site.Params.repo }}">
     {{ partial "github-icon.html" . }}
     <span class="is-invisible">Find us on GitHub</span>
   </a>
   <p class="l-footer__impressum e-heading__6">
     This
-    <a href="{{ $.Site.Params.repo }}">free and open source programme</a>
+    <a href="{{ site.Params.repo }}">free and open source programme</a>
     is a project of
-    <a href="{{$.Site.Params.main_website}}">{{ $.Site.Params.main_org_name }}</a>
+    <a href="{{site.Params.main_website}}">{{ site.Params.main_org_name }}</a>
     <br />
     Creative Commons Attribution-ShareAlike 4.0
   </p>

--- a/common-theme/layouts/partials/header.html
+++ b/common-theme/layouts/partials/header.html
@@ -3,7 +3,7 @@
     <h1 class="l-header__heading e-heading__6" data-pagefind-ignore>
       <a class="l-header__home" href="/"
         ><span class="is-invisible"
-          >{{ .Section }} {{ .Title }} {{ $.Site.Title }}</span
+          >{{ .Section }} {{ .Title }} {{ site.Title }}</span
         >
         {{ $logos := resources.Match "custom-images/site-logo/*.svg" }}
         {{ range $logos }}{{ .Content | safeHTML }}{{ end }}

--- a/common-theme/layouts/partials/issues.html
+++ b/common-theme/layouts/partials/issues.html
@@ -1,6 +1,6 @@
 {{/* This is a page, basically, not a block, so we don't go via blockData for now */}}
 {{ $repo := .Params.backlog }}
-{{ $issuesUrl := print $.Site.Params.orgapi $repo "/issues?per_page=100&state=open&direction=asc" }}
+{{ $issuesUrl := print site.Params.orgapi $repo "/issues?per_page=100&state=open&direction=asc" }}
 {{ $filter := .Params.backlog_filter }}
 {{ $currentPath := .Page.RelPermalink }}
 {{ $headers := partial "github-auth.html" }}

--- a/common-theme/layouts/partials/module-tabs.html
+++ b/common-theme/layouts/partials/module-tabs.html
@@ -39,7 +39,7 @@
       <!-- Blocks will appear here in order listed in the blocks list in the front matter -->
       {{ range .Params.blocks }}
         {{ partial "block/block.html" (dict "block" . "Page"
-          $.Page "Site" $.Site)
+          $.Page "Site" site)
         }}
       {{ end }}
     </div>

--- a/common-theme/layouts/shortcodes/logos.html
+++ b/common-theme/layouts/shortcodes/logos.html
@@ -4,7 +4,7 @@
 */}}
 {{ $filter := slice (.Get 0) }}
 
-{{ with and $filter $.Site.Data.funding }}
+{{ with and $filter site.Data.funding }}
   <ul class="c-logos">
     {{ range . }}
       {{ if intersect .support_type $filter }}

--- a/common-theme/layouts/shortcodes/our-name.html
+++ b/common-theme/layouts/shortcodes/our-name.html
@@ -1,1 +1,1 @@
-<span class="c-our-name">{{ $.Site.Params.our_name |default "CYF"}}</span>
+<span class="c-our-name">{{ site.Params.our_name |default "CYF"}}</span>

--- a/org-cyf/layouts/partials/map.html
+++ b/org-cyf/layouts/partials/map.html
@@ -10,12 +10,12 @@
         <ol class="c-map__timeline">
           {{/* Range over the courses stored in /data/courses */}}
           {{ $counter := 0 }}
-          {{ range $index, $course:= (sort $.Site.Data.courses "weight" "asc") }}
+          {{ range $index, $course:= (sort site.Data.courses "weight" "asc") }}
             {{ $counter =  add $counter 1 }}
             {{ if eq $course.menu $menu }}
               <li
                 class="c-map__stop"
-                style="--layer:{{ sub (len $.Site.Data.courses) $counter }}">
+                style="--layer:{{ sub (len site.Data.courses) $counter }}">
                 <a class="c-card" href="{{ $course.url }}">
                   <h3 class="c-card__title">{{ $course.name }}</h3>
                   <span class="c-card__meta"


### PR DESCRIPTION
## What does this change?

Use `site` not `$.Site`

These are equivalent when they happen to be called in a context that has `.Site`, but `$.Site` breaks if the current context doesn't have a `.Site`.

Because `site` _always_ works, and when they both work they're exactly equivalent, prefer to use it. This makes future refactorings less brittle.