### PR TITLE
Add in step 3 a link to the "Scrimba FAQ"

### DIFF
--- a/org-cyf-itd/content/blocks/step-3/instructions/index.md
+++ b/org-cyf-itd/content/blocks/step-3/instructions/index.md
@@ -12,7 +12,7 @@ time= 300
 This course teaches you HTML and CSS by helping you make five great projects. You'll also get to do over 75 coding tasks. You don't need to know anything about coding to start - it's good for complete beginners.
 
 1. Create an [account on Scrimba](https://v2.scrimba.com/home)
-1. Find out [what to do and what to avoid when taking the Scrimba course](https://docs.google.com/presentation/d/1Z10grrFWQcKeEb2iD84ljhq9vzLMPWL5ny6oaotpb8E/edit?usp=sharing)
+1. Learn [what to do and what to avoid when taking the Scrimba course](https://docs.google.com/presentation/d/1Z10grrFWQcKeEb2iD84ljhq9vzLMPWL5ny6oaotpb8E/edit?usp=sharing)
 1. Go to the course: [Learn HTML and CSS](https://v2.scrimba.com/learn-html-and-css-c0p) on Scrimba
 1. Follow along and build the first five projects
 1. Make a public Google doc to collect the links to all your deployed projects on Netlify

--- a/org-cyf-itd/content/blocks/step-3/instructions/index.md
+++ b/org-cyf-itd/content/blocks/step-3/instructions/index.md
@@ -12,6 +12,7 @@ time= 300
 This course teaches you HTML and CSS by helping you make five great projects. You'll also get to do over 75 coding tasks. You don't need to know anything about coding to start - it's good for complete beginners.
 
 1. Create an [account on Scrimba](https://v2.scrimba.com/home)
+1. Find out [what to do and what to avoid when taking the Scrimba course](https://docs.google.com/presentation/d/1Z10grrFWQcKeEb2iD84ljhq9vzLMPWL5ny6oaotpb8E/edit?usp=sharing)
 1. Go to the course: [Learn HTML and CSS](https://v2.scrimba.com/learn-html-and-css-c0p) on Scrimba
 1. Follow along and build the first five projects
 1. Make a public Google doc to collect the links to all your deployed projects on Netlify


### PR DESCRIPTION
## What does this change?

Add an item in step 3 (under "What to do") to direct the participant to study "What to do and what to avoid when taking Scrimba Course" (aka the "Scrimba FAQ").

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

@SallyMcGrath 
