### PR TITLE
Remove obsolete prereqs from Piscine

### DIFF
--- a/common-content/en/module/piscine/programming-prereqs/index.md
+++ b/common-content/en/module/piscine/programming-prereqs/index.md
@@ -25,7 +25,7 @@ _Before_ you join the Piscine, you should have a secure understanding of a _limi
 - [ ] Navigating Objects: `Object.entries`, `Object.fromEntries`, `Object.keys`, `Object.values`
 - [ ] Navigating Arrays: `Array.includes`, `Array.slice`
 - [ ] Operators: `=`, `==`, `===`, `!=`, `!==`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`, `%`, `+`, `-`, `*`, `/`
-- [ ] Control structures: `if`, `else`, `else if`, `switch`, `case`, `break`, `continue`, `return`
+- [ ] Control structures: `if`, `else`, `else if`, `return`
 - [ ] Functions: `function`, `=>`, scope, callbacks, and extracting a function
 - [ ] Loops: `for`, `for of`
 - [ ] Higher order functions that take callbacks: `Array.map`, `Array.filter`, `Array.find`, `Array.findIndex`
@@ -38,8 +38,7 @@ _Before_ you join the Piscine, you should have a secure understanding of a _limi
 
 ### JavaScript Testing
 
-- [ ] Assertions in Jest: `describe`, `it`, `expect`, `to`, `toEqual`, `toBe`, `not`
-- [ ] Error handling: `try`, `catch`, `throw`
+- [ ] Assertions in Jest: `test`, `expect`, `toEqual`, `not`
 
 ### Git
 


### PR DESCRIPTION
## What does this change?

See discussion from https://codeyourfuture.slack.com/archives/C012UUW69S8/p1729604686501789?thread_ts=1729514033.295269&cid=C012UUW69S8

We will re-add error handling when we've re-added this to ITP.

The Jest updates are reflecting what we actually teach in ITP - the other things aren't super necessary they're Just More APIs.

Switch isn't needed and can be picked up as needed through Google.

### Common Content?

Yes, but this is maybe actually super CYF specific and maybe all the Piscine stuff should get moved into the Piscine module.