### PR TITLE
itp: js1: install node: adjust nvm instructions for mac os

### DIFF
--- a/common-content/en/module/js1/install-node/index.md
+++ b/common-content/en/module/js1/install-node/index.md
@@ -66,7 +66,7 @@ xcode-select --install
 
 These may already be installed, in which case you will see "xcode-select: note: Command line tools are already installed." and can continue to the next step.
 
-2. Create a (Non-Login Interactive) Shell Configuration File
+2. Create a (Non-Login Interactive) Shell Configuration File:
 
 ```terminal
 touch ~/.zshrc

--- a/common-content/en/module/js1/install-node/index.md
+++ b/common-content/en/module/js1/install-node/index.md
@@ -58,7 +58,7 @@ You should see a version number like `10.9.0`.
 
 ##  On Mac
 
-1. Install the the Xcode Command Line Developer Tools
+1. Install the the Xcode Command Line Developer Tools by running the following command in your terminal:
 
 ```terminal
 xcode-select --install
@@ -72,7 +72,7 @@ These may already be installed, in which case you will see "xcode-select: note: 
 touch ~/.zshrc
 ```
 
-3. Install nvm by running the following command in your terminal:
+3. Install nvm:
 
 ```terminal
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash

--- a/common-content/en/module/js1/install-node/index.md
+++ b/common-content/en/module/js1/install-node/index.md
@@ -25,7 +25,7 @@ Check if you already have NodeJS installed by running `node -v` in a terminal. T
 1. Install nvm by running the following commands in your terminal:
 
 ```terminal
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 ```
 
 2. After the installation is complete, you'll need to source the nvm script by running:
@@ -46,7 +46,7 @@ nvm install --lts
 node -v
 ```
 
-You should see a version number like `v20.16.0`.
+You should see a version number like `v22.11.0`.
 
 5. Check that you have successfully installed npm by running:
 
@@ -54,43 +54,57 @@ You should see a version number like `v20.16.0`.
 npm -v
 ```
 
-You should see a version number like `10.5.0`.
+You should see a version number like `10.9.0`.
 
 ##  On Mac
 
-1. Install nvm by running the following command in your terminal:
+1. Install the the Xcode Command Line Developer Tools
 
 ```terminal
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+xcode-select --install
 ```
 
-2. After the installation is complete, you'll need to source the nvm script by running:
+These may already be installed, in which case you will see "xcode-select: note: Command line tools are already installed." and can continue to the next step.
+
+2. Create a (Non-Login Interactive) Shell Configuration File
+
+```terminal
+touch ~/.zshrc
+```
+
+3. Install nvm by running the following command in your terminal:
+
+```terminal
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+```
+
+4. After the installation is complete, you'll need to source the nvm script by running:
 
 ```terminal
 source ~/.zshrc
 ```
 
-3. Install the latest LTS version of Node.js by running:
+5. Install the latest LTS version of Node.js by running:
 
 ```terminal
 nvm install --lts
 ```
 
-4. Check that you have successfully installed Node.js by running:
+6. Check that you have successfully installed Node.js by running:
 
 ```terminal
 node -v
 ```
 
-You should see a version number like `v20.16.0`.
+You should see a version number like `v22.11.0`.
 
-5. Check that you have successfully installed npm by running:
+7. Check that you have successfully installed npm by running:
 
 ```terminal
 npm -v
 ```
 
-You should see a version number like `10.5.0`.
+You should see a version number like `10.9.0`.
 
 {{<note type="tip" title="Protip">}}
 Using nvm allows you to easily install and manage multiple versions of Node.js on your system. This will help you access projects that use older versions of Node.js.


### PR DESCRIPTION
## What does this change?

- Issue was reported here: https://codeyourfuture.slack.com/archives/C076K3V76CA/p1730546048389919
- Adjusts the Node Setup instructions to work seamlessly for Mac OS
- Instructions tested on a fresh install Mac OS (virtual machine)

```sh
baz@bazs-Virtual-Machine ~ % xcode-select --install
xcode-select: note: install requested for command line developer tools
baz@bazs-Virtual-Machine ~ % touch ~/.zshrc
baz@bazs-Virtual-Machine ~ % curl -0- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | 
...
=> Appending nvm source string to /Users/baz/.zshrc
=> Appending bash_completion source string to /Users/baz/.zshrc
...
baz@bazs-Virtual-Machine ~ % source ~/.zshrc
baz@bazs-Virtual-Machine ~ % nvm install --lts
...
baz@bazs-Virtual-Machine ~ % node -v 
v22.11.0
baz@bazs-Virtual-Machine ~ % npm -v
10.9.0
baz@bazs-Virtual-Machine ~ % 
```

Note: if the `.zshrc` file already exists `touch` will not overwrite it, and so it is safe to proceed.

### Common Content?

- No

### Common Theme?

- No

### Org Content?

- No

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

ITP Team(?)
Sally/Daniel(?)

