### PR TITLE
1168 in support of Assign an energiser to the day plans in ITP

### DIFF
--- a/common-content/en/energisers/popcorn-screen-share/index.md
+++ b/common-content/en/energisers/popcorn-screen-share/index.md
@@ -13,7 +13,7 @@ publishResources = false
 
 A playful way to practice screen sharing while sharing something personal.
 
-Facilitator, please begin by sharing your screen. talk through what you are doing and show your favorite website, digital photo, or bookmark. Explain why it's meaningful to you. On gallery view, choose the person "next" to you to share next.
+Facilitator, please begin by sharing your screen. Talk through what you are doing and show your favorite website, digital photo, or bookmark. Explain why it's meaningful to you. On gallery view, choose the person "next" to you to share next.
 
 Each participant will have {{<timer>}}1{{</timer>}} minute to:
 

--- a/common-content/en/energisers/popcorn-screen-share/index.md
+++ b/common-content/en/energisers/popcorn-screen-share/index.md
@@ -1,0 +1,36 @@
++++
+title="Screen Safari"
+emoji="🖥️"
+time=15
+[objectives]
+1="Practice screen sharing functionality"
+2="Build comfort with sharing digital workspace"
+[build]
+render = 'never'
+list = 'local'
+publishResources = false
++++
+
+A playful way to practice screen sharing while sharing something personal.
+
+Facilitator, please begin by sharing your screen. talk through what you are doing and show your favorite website, digital photo, or bookmark. Explain why it's meaningful to you. On gallery view, choose the person "next" to you to share next.
+
+Each participant will have {{<timer>}}1{{</timer>}} minute to:
+
+1. Share their screen
+1. Show their favorite website, digital photo, or bookmark
+1. Explain why it's meaningful to them
+
+Practice stopping screen share before the next person begins!
+
+Go around the group until everyone has shared.
+
+#### Facilitator Check in questions
+
+<details><summary>Guide participants on technical comfort</summary>
+
+- What was challenging about the screen sharing process?
+- What would make you feel more confident sharing your screen?
+- What did you learn about your colleagues through their shares?
+
+</details>

--- a/common-content/en/energisers/popcorn/index.md
+++ b/common-content/en/energisers/popcorn/index.md
@@ -1,0 +1,24 @@
++++
+title="Popcorn Show and Tell"
+emoji="🍿"
+time=10
+[objectives]
+1="Practice popcorning participation in meetings"
+2="Share quick personal insights"
+[build]
+render = 'never'
+list = 'local'
+publishResources = false
++++
+
+A quick introduction to popcorning where participants spontaneously "pop up" to share.
+
+**Facilitator** grab something close to you and show it to the group. What is interesting about this object? What does it mean to you?
+
+1. After sharing, say "popcorn to..." and choose someone else.
+1. That person shares their response, then popcorns to another participant.
+
+Continue until everyone has shared once or you run out of time.
+
+> ![!TIP]
+> If everyone puts their hand up and then put it down after speaking, it's easier to see who hasn't shared yet.

--- a/common-content/en/energisers/slack-libs/index.md
+++ b/common-content/en/energisers/slack-libs/index.md
@@ -1,0 +1,39 @@
++++
+title="Slack Stack"
+emoji="💬"
+time=10
+[tasks]
+1="Familiarise participants with Slack features"
+2="Create engaging team communication"
+[build]
+render = 'never'
+list = 'local'
+publishResources = false
++++
+
+A creative way to practice Slack communication through collaborative storytelling.
+
+1. **Facilitator**: Create a dedicated thread in your team's Slack channel.
+2. Start with a simple prompt, eg:
+
+- "Time travelers from 2030 visit to study our cohort as the pioneers of the tech industry. What made us so revolutionary?"
+- "Scientists accidentally merged all our pets/favorite animals into one super-creature. Describe this majestic beast and its day at the office."
+- "Breaking news: Our entire team just discovered we have superpowers! What powers did each person get and how did we first discover them?"
+
+Now, each person will add **one sentence** to the story using:
+
+1. 😁 At least one emoji
+1. One Slack formatting feature (**bold**, _italic_, bullet point)
+1. One @mention of another team member, inviting them to continue the story.
+
+Continue for {{<timer>}}10{{</timer>}} minutes or until everyone has contributed.
+
+<details><summary>Key Slack features to try</summary>
+
+- How to start/find threads
+- Basic text formatting (\*/`~)
+- Emoji reactions
+- @mentions and notifications
+- How to edit/delete messages
+
+</details>

--- a/common-content/en/energisers/slack-libs/index.md
+++ b/common-content/en/energisers/slack-libs/index.md
@@ -1,5 +1,5 @@
 +++
-title="Slack Stack"
+title="Slack Libs"
 emoji="💬"
 time=10
 [tasks]

--- a/common-content/en/energisers/word-chain/index.md
+++ b/common-content/en/energisers/word-chain/index.md
@@ -1,0 +1,28 @@
++++
+title="Word Chain"
+emoji="🔤"
+time=15
+[tasks]
+1="Think quickly and associate words in English"
+2="Build active listening skills"
+[build]
+render = 'never'
+list = 'local'
+publishResources = false
++++
+
+A fast-paced word association game that works for both in-person and online groups of any size. If you are playing online, write the order of players in the chat to keep track of who is next. Set a timer for {{<timer>}}10{{</timer>}}
+
+1. The first player says any word.
+1. The next player must say a word that begins with the last letter of the previous word.
+1. Continue around the circle. For example: cat → tree → elephant → tower
+1. If a player takes longer than 5 seconds or repeats a word, they're out.
+1. Last player standing wins.
+
+<details><summary>Variations</summary>
+
+- Restrict words to specific categories (animals, countries, food)
+- Words must be exactly 4 letters long
+- Words must be related to the previous word in meaning
+
+</details>


### PR DESCRIPTION
## What does this change?

These were hanging around from before my break. Some early course energisers, suitable for Intro Module.

### Common Content?

<!-- Does this PR add content to the common-content module? -->

Yep, all energisers, none assigned to a day plan yet  - this is just supporting material #1168 

@CarolineFrank35 FYI  - I knocked these up before my break and just found them hanging out in this branch. 

