### PR TITLE
Replace toBe with toEqual

### DIFF
--- a/common-content/en/module/js1/anonymous-functions/index.md
+++ b/common-content/en/module/js1/anonymous-functions/index.md
@@ -25,9 +25,9 @@ In our Jest test, we wrote a function differently:
 
 ```js
 function() {
-  expect(getOrdinalNumber(1)).toBe("1st");
-  expect(getOrdinalNumber(11)).toBe("11th");
-  expect(getOrdinalNumber(21)).toBe("21st");
+  expect(getOrdinalNumber(1)).toEqual("1st");
+  expect(getOrdinalNumber(11)).toEqual("11th");
+  expect(getOrdinalNumber(21)).toEqual("21st");
 }
 ```
 

--- a/common-content/en/module/js1/arrow-functions/index.md
+++ b/common-content/en/module/js1/arrow-functions/index.md
@@ -51,9 +51,9 @@ Applying all of these techniques, we can rewrite our Jest test with fewer words:
 
 ```js
 test("works for any number ending in 1", () => {
-  expect(getOrdinalNumber(1)).toBe("1st");
-  expect(getOrdinalNumber(11)).toBe("11th");
-  expect(getOrdinalNumber(21)).toBe("21st");
+  expect(getOrdinalNumber(1)).toEqual("1st");
+  expect(getOrdinalNumber(11)).toEqual("11th");
+  expect(getOrdinalNumber(21)).toEqual("21st");
 });
 ```
 

--- a/common-content/en/module/js1/generalise/index.md
+++ b/common-content/en/module/js1/generalise/index.md
@@ -34,9 +34,9 @@ function getOrdinalNumber() {
 }
 
 test("works for any number ending in 1", function() {
-  expect(getOrdinalNumber(1)).toBe("1st");
-  expect(getOrdinalNumber(11)).toBe("11th");
-  expect(getOrdinalNumber(21)).toBe("21st");
+  expect(getOrdinalNumber(1)).toEqual("1st");
+  expect(getOrdinalNumber(11)).toEqual("11th");
+  expect(getOrdinalNumber(21)).toEqual("21st");
 });
 ```
 

--- a/common-content/en/module/js1/outliers/index.md
+++ b/common-content/en/module/js1/outliers/index.md
@@ -44,9 +44,9 @@ function getOrdinalNumber(num) {
 }
 
 test("works for any number ending in 1", function () {
-  expect(getOrdinalNumber(1)).toBe("1st");
-  expect(getOrdinalNumber(11)).toBe("11th");
-  expect(getOrdinalNumber(21)).toBe("21st");
+  expect(getOrdinalNumber(1)).toEqual("1st");
+  expect(getOrdinalNumber(11)).toEqual("11th");
+  expect(getOrdinalNumber(21)).toEqual("21st");
 });
 ```
 
@@ -68,13 +68,13 @@ function getOrdinalNumber(num) {
 }
 
 test("works for any number ending in 1", function () {
-  expect(getOrdinalNumber(1)).toBe("1st");
-  expect(getOrdinalNumber(11)).toBe("11th");
-  expect(getOrdinalNumber(21)).toBe("21st");
+  expect(getOrdinalNumber(1)).toEqual("1st");
+  expect(getOrdinalNumber(11)).toEqual("11th");
+  expect(getOrdinalNumber(21)).toEqual("21st");
 });
 
 test("converts 2 to an ordinal number", function () {
-  expect(getOrdinalNumber(2)).toBe("2nd");
+  expect(getOrdinalNumber(2)).toEqual("2nd");
 });
 ```
 

--- a/common-content/en/module/js2/mean/index.md
+++ b/common-content/en/module/js2/mean/index.md
@@ -28,7 +28,7 @@ test("calculates the mean of a list of numbers", () => {
   const currentOutput = calculateMean(list);
   const targetOutput = 20;
 
-  expect(currentOutput).toBe(targetOutput); // 20 is (3 + 50 + 7) / 3
+  expect(currentOutput).toEqual(targetOutput); // 20 is (3 + 50 + 7) / 3
 });
 ```
 

--- a/common-content/en/module/js2/median/index.md
+++ b/common-content/en/module/js2/median/index.md
@@ -32,7 +32,7 @@ test("calculates the median of a list of odd length", () => {
   const currentOutput = calculateMedian(list);
   const targetOutput = 30;
 
-  expect(currentOutput).toBe(targetOutput);
+  expect(currentOutput).toEqual(targetOutput);
 });
 ```
 

--- a/org-cyf-guides/content/testing/intro/index.md
+++ b/org-cyf-guides/content/testing/intro/index.md
@@ -76,7 +76,7 @@ For example, we could write a test to check that `countWords` behaves in a parti
 
 ```js
 test("one word string gives a count of 1", function () {
-  expect(countWords("hello")).toBe(1);
+  expect(countWords("hello")).toEqual(1);
 });
 ```
 
@@ -95,7 +95,7 @@ We use a function in Jest called `test` to write a test description - `"will cou
 #### 2. Assertion
 
 ```js
-expect(countWords("hello")).toBe(1);
+expect(countWords("hello")).toEqual(1);
 ```
 
 The assertion is the part of the test code that actually checks to see if something is true or not. In this example, we are claiming that the following is true:
@@ -104,7 +104,7 @@ The assertion is the part of the test code that actually checks to see if someth
 
 Notice that the statement above is very similar to the syntax used in the test code.
 
-The function [`toBe`](https://jestjs.io/docs/expect#tobevalue) ( which is part of the Jest framework ) is used to check that the return value of `countWords("hello")` and `1` are equal to each other. There are [many other functions](https://jestjs.io/docs/using-matchers) like `toEqual` which we can use to make different assertions.
+The function [`toEqual`](https://jestjs.io/docs/expect#toequalvalue) ( which is part of the Jest framework ) is used to check that the return value of `countWords("hello")` and `1` are equal to each other. There are [many other functions](https://jestjs.io/docs/using-matchers) like `toHaveLength`, `toBeCloseTo`, and `toBe` which we can use to make different assertions.
 
 ### Pass ✅ or Fail ❌
 


### PR DESCRIPTION
## What does this change?

Replace `toBe` with `toEqual`

These were meant to be changed before, but apparently I missed a few.

toEqual is a good default, and toBe is something that generally only makes sense in more limited use-cases.

### Common Content?

Yes, but only trivially