### PR TITLE
Allow specifying a custom delimiter for multiple choice quizzes

### DIFF
--- a/common-docs/content/common-theme/shortcodes/multiple-choice.md
+++ b/common-docs/content/common-theme/shortcodes/multiple-choice.md
@@ -7,6 +7,8 @@ menu=["shortcodes"]
 
 This is a simple "check understanding" block that allows you to create a multiple choice question with options and feedback. Short assessments like this are a pedagogically sound strategy to boost retention and understanding.
 
+If you need to use `|` characters in your answers/feedback, you can specify the `delimiter` key to use a different delimiter between them.
+
 ### Invoke
 
 ```go

--- a/common-theme/layouts/shortcodes/multiple-choice.html
+++ b/common-theme/layouts/shortcodes/multiple-choice.html
@@ -7,9 +7,11 @@
 >}}
 
 */}}
+
+{{ $delimiter := .Get "delimiter" | default "|" }}
 {{ $question := .Get "question" }}
-{{ $answers := split (.Get "answers")  "|" }}
-{{ $feedback := split (.Get "feedback" | default "") "|" }}
+{{ $answers := split (.Get "answers") $delimiter }}
+{{ $feedback := split (.Get "feedback" | default "") $delimiter }}
 {{ $correct := (.Get "correct") }}
 
 {{ partial "multiple-choice" (dict "question" $question "answers" $answers "feedback" $feedback "correct" $correct) }}


### PR DESCRIPTION
## What does this change?

Allow specifying a custom delimiter for multiple choice quizzes

I'm writing quizzes on shell pipelines, and I need to include |s in my answers.

### Common Theme?

- [x] Adds a backward-compatible feature to multiple-choice.