### PR TITLE
fix that annoying time bug on day plan

### DIFF
--- a/common-theme/assets/scripts/time-stamper.js
+++ b/common-theme/assets/scripts/time-stamper.js
@@ -2,15 +2,12 @@ class TimeStamper extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
-    this.shadowRoot.innerHTML = `
-            <style>
-                /* You can include any component-specific styles here */
-            </style>
-            <slot></slot>
-        `;
+    this.shadowRoot.innerHTML = `<slot></slot>`;
 
-    this.timelineEntries = this.querySelectorAll(".c-block");
-    this.startTime = this.getAttribute('start-time');
+    this.timelineEntries = this.querySelectorAll(
+      ".c-block:not(.is-nested .c-block)"
+    );
+    this.startTime = this.getAttribute("start-time");
   }
 
   connectedCallback() {


### PR DESCRIPTION
## What does this change?

On the day plan, if you nest blocks as options, the time stamp accumulates them and the times go wrong.

I've excluded nested blocks from the timestamper.
### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes see above

<!--Please reference the ticket you are addressing -->

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
