### PR TITLE
Soften requirements to from "enroll to be a trainee" to "apply to be a trainee"

### DIFF
--- a/common-content/en/module/onboarding/goals/index.md
+++ b/common-content/en/module/onboarding/goals/index.md
@@ -16,7 +16,9 @@ objectives = [
 
 You have joined us as a Learner. Your overall goal for this module is to understand how to succeed at the ITP course.
 
-To demonstrate you know how to succeed at the course, you should enroll as a Trainee within the next three weeks. To do this, you will need to do show up every week, learn, get work done, and get your work reviewed.
+To demonstrate you know how to succeed at the course, you should apply to enroll as a Trainee within the next three weeks. To do this, you will need to do show up every week, learn, get work done, and get your work reviewed.
+
+If eligible, you should enroll as a Trainee within the next three weeks.
 
 > 🎯 Complete onboarding and enroll as a Trainee
 

--- a/org-cyf-itp/content/onboarding/success/index.md
+++ b/org-cyf-itp/content/onboarding/success/index.md
@@ -10,7 +10,7 @@ weight = 11
 2="Link to your PR for [Form Controls](https://github.com/CodeYourFuture/Module-User-Focused-Data/issues/88)"
 +++
 
-> 🎯 Complete onboarding and [enroll as a Trainee](https://forms.gle/vRuofa7aeL5DsbhGA)
+> 🎯 Complete onboarding and [apply to enroll as a Trainee](https://forms.gle/vRuofa7aeL5DsbhGA)
 
 ### 🎯 You've achieved your learning objectives if you can:
 
@@ -34,5 +34,6 @@ weight = 11
 1. Make a new issue on your own Coursework Planner.
 1. Link to the two Pull Requests on your issue. You don't have to wait for your PRs to be reviewed, but you must have made them.
 1. Submit the issue link to step 1 of ITP on [CYF Course Portal](https://application-process.codeyourfuture.io/)
-1. [Enroll as a Trainee](https://forms.gle/vRuofa7aeL5DsbhGA)
-1. Here are those PRs again:
+1. [Apply to enroll as a Trainee](https://forms.gle/vRuofa7aeL5DsbhGA).
+
+Here are those PRs again:


### PR DESCRIPTION
We do not require that everyone participating in ITP is eligible to enroll as a trainee. But we do require that to have completed the Onboarding module you must have applied.

Frame success as _applying_ to enroll as a trainee, rather than framing success as contingent on being positively enrolled as a trainee.

We want everyone to apply. It's ok if not everyone is eligible. But we're trying to anchor people to a path of applying.