### PR TITLE
Use $URL not $DEPLOY_PRIME_URL

### DIFF
--- a/tooling/common-config/deploy-netlify.sh
+++ b/tooling/common-config/deploy-netlify.sh
@@ -4,5 +4,10 @@ set -euo pipefail
 
 npm install --legacy-peer-deps
 
+URL_TO_USE="${URL}"
+if [[ "${PULL_REQUEST}" == "true" ]]; then
+  URL_TO_USE="${DEPLOY_PRIME_URL}"
+fi
+
 # We set --baseURL on netlify so that any references to .Permalink end up pointing at deploy preview pages, rather than being hard-coded to point at the production URLs.
-hugo --minify --environment production --baseURL $DEPLOY_PRIME_URL && npx pagefind --site "public"
+hugo --minify --environment production --baseURL "${URL_TO_USE}" && npx pagefind --site "public"


### PR DESCRIPTION
$DEPLOY_PRIME_URL appears to point at a .netlify.app version of the site, rather than the URL it's actually getting deployed as.

This manifests as a bunch of CORS errors like:

> Access to manifest at 'https://main--cyf-programming.netlify.app/manifest.json' from origin 'https://programming.codeyourfuture.io' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.