### PR TITLE
Re-fill overview page, and error if it's empty

### DIFF
--- a/common-theme/layouts/_default/overview.html
+++ b/common-theme/layouts/_default/overview.html
@@ -8,7 +8,10 @@
   {{ if not $overviewMenu }}
     {{ errorf "You must define a menu in your overview_menu front matter param" }}
   {{ end }}
- 
+  {{ if not (index .Site.Menus $overviewMenu) }}
+    {{ errorf "Overview page tried to generate overview for menu %s which is empty" $overviewMenu }}
+  {{ end }}
+
   {{ range index .Site.Menus $overviewMenu }}
     <section class="c-overview">
       {{/* ===========================

--- a/org-cyf-itp/content/overview/_index.md
+++ b/org-cyf-itp/content/overview/_index.md
@@ -1,7 +1,7 @@
 +++
 title="Course overview"
 layout="overview"
-overview_menu="programming"
+overview_menu="course schedule"
 menu=["start here", "syllabus"]
 description="4 modules of 3 sprints delivered over 12-16 weeks"
 weight=2

--- a/org-cyf-itp/content/welcome/prep/index.md
+++ b/org-cyf-itp/content/welcome/prep/index.md
@@ -3,6 +3,7 @@ title = 'Prep'
 description = 'What to do before you come to class'
 layout = 'prep'
 emoji= '🧑🏾‍💻'
+theme = "Getting to know how the course works"
 menu_level = ['module']
 weight = 1
 [[blocks]]


### PR DESCRIPTION
@SallyMcGrath it looks like in https://github.com/CodeYourFuture/curriculum/pull/1241 you removed all of the modules from the `programming` menu... Was this intentional? The overview page is currently being driven by that - can we either change what menu the overview page is driven from, or re-add the `programming` menu?