### PR TITLE
add an audit option

### DIFF
--- a/common-docs/package.json
+++ b/common-docs/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:dev": "dotenv -e ../.env -- hugo server --disableFastRender --environment development",
-    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development"
+    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development",
+    "build:audit": "HUGO_MINIFY_TDEWOLFF_HTML_KEEPCOMMENTS=true HUGO_ENABLEMISSINGTRANSLATIONPLACEHOLDERS=true hugo mod vendor && dotenv -e ../.env  -- hugo --environment production && grep -inorE '<\\!-- raw HTML omitted -->|ZgotmplZ|\\[i18n\\]|\\(<nil>\\)|(&lt;nil&gt;)|hahahugo' public/"
   },
   "keywords": [],
   "author": "",

--- a/common-theme/package.json
+++ b/common-theme/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start:dev": "dotenv -- hugo server -p 3000 -D"
+    "start:dev": "dotenv -- hugo server -p 3000 -D",
+    "build:audit": "HUGO_MINIFY_TDEWOLFF_HTML_KEEPCOMMENTS=true HUGO_ENABLEMISSINGTRANSLATIONPLACEHOLDERS=true hugo mod vendor && dotenv -e ../.env  -- hugo --environment production && grep -inorE '<\\!-- raw HTML omitted -->|ZgotmplZ|\\[i18n\\]|\\(<nil>\\)|(&lt;nil&gt;)|hahahugo' public/"
   },
   "repository": {
     "type": "git",

--- a/org-cyf-itd/package.json
+++ b/org-cyf-itd/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:dev": "dotenv -e ../.env -- hugo server --environment development",
-    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development"
+    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development",
+    "build:audit": "HUGO_MINIFY_TDEWOLFF_HTML_KEEPCOMMENTS=true HUGO_ENABLEMISSINGTRANSLATIONPLACEHOLDERS=true hugo mod vendor && dotenv -e ../.env  -- hugo --environment production && grep -inorE '<\\!-- raw HTML omitted -->|ZgotmplZ|\\[i18n\\]|\\(<nil>\\)|(&lt;nil&gt;)|hahahugo' public/"
   },
   "keywords": [],
   "author": "",

--- a/org-cyf-itp/package.json
+++ b/org-cyf-itp/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:dev": "dotenv -e ../.env -- hugo server --environment development",
-    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development"
+    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development",
+    "build:audit": "HUGO_MINIFY_TDEWOLFF_HTML_KEEPCOMMENTS=true HUGO_ENABLEMISSINGTRANSLATIONPLACEHOLDERS=true hugo mod vendor && dotenv -e ../.env  -- hugo --environment production && grep -inorE '<\\!-- raw HTML omitted -->|ZgotmplZ|\\[i18n\\]|\\(<nil>\\)|(&lt;nil&gt;)|hahahugo' public/"
   },
   "keywords": [],
   "author": "",

--- a/org-cyf-piscine/package.json
+++ b/org-cyf-piscine/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:dev": "dotenv -e ../.env -- hugo server --environment development",
-    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development"
+    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development",
+    "build:audit": "HUGO_MINIFY_TDEWOLFF_HTML_KEEPCOMMENTS=true HUGO_ENABLEMISSINGTRANSLATIONPLACEHOLDERS=true hugo mod vendor && dotenv -e ../.env  -- hugo --environment production && grep -inorE '<\\!-- raw HTML omitted -->|ZgotmplZ|\\[i18n\\]|\\(<nil>\\)|(&lt;nil&gt;)|hahahugo' public/"
   },
   "keywords": [],
   "author": "",

--- a/org-cyf-sdc/package.json
+++ b/org-cyf-sdc/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:dev": "dotenv -e ../.env -- hugo server --environment development",
-    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development"
+    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development",
+    "build:audit": "HUGO_MINIFY_TDEWOLFF_HTML_KEEPCOMMENTS=true HUGO_ENABLEMISSINGTRANSLATIONPLACEHOLDERS=true hugo mod vendor && dotenv -e ../.env  -- hugo --environment production && grep -inorE '<\\!-- raw HTML omitted -->|ZgotmplZ|\\[i18n\\]|\\(<nil>\\)|(&lt;nil&gt;)|hahahugo' public/"
   },
   "keywords": [],
   "author": "",

--- a/org-cyf-tracks/package.json
+++ b/org-cyf-tracks/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:dev": "dotenv -e ../.env -- hugo server --environment development",
-    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development"
+    "build:dev": "hugo mod vendor && dotenv -e ../.env  -- hugo --environment development",
+    "build:audit": "HUGO_MINIFY_TDEWOLFF_HTML_KEEPCOMMENTS=true HUGO_ENABLEMISSINGTRANSLATIONPLACEHOLDERS=true hugo mod vendor && dotenv -e ../.env  -- hugo --environment production && grep -inorE '<\\!-- raw HTML omitted -->|ZgotmplZ|\\[i18n\\]|\\(<nil>\\)|(&lt;nil&gt;)|hahahugo' public/"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
https://gohugo.io/troubleshooting/audit/

This exists now, so maybe we should use it. 

I've stored it in package.json but may wish to extend this or build it in elsewhere like as an action on PR.  Have at it.

Would catch things like #1271 
