### PR TITLE
Content: STAD day plans update

### DIFF
--- a/common-content/en/blocks/standup/index.md
+++ b/common-content/en/blocks/standup/index.md
@@ -1,0 +1,19 @@
++++
+title="Standup"
+time=15
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+It's time to [stand up](https://www.atlassian.com/agile/scrum/standups). Split into groups of no more than 6 people.
+
+Stand in a circle and share for no more than 60 seconds each:
+
+- 📛 your name
+- 💪🏽 What you worked on yesterday
+- 🛟 What issues are blocking you / What problems you encountered
+- 👷🏾 What you will work on today
+
+After everyone has given an update, reflect on next steps together. Can you team up on shared blockers? Is someone working on something interesting that you want to know more about?

--- a/common-content/en/energisers/introduce-yourself/index.md
+++ b/common-content/en/energisers/introduce-yourself/index.md
@@ -17,19 +17,29 @@ Today we will be going around the room and introducing ourselves! `
 
 Facilitator(s) start by sharing your elevator pitch and then popcorn around the room.
 
-Some tips:
+<details>
+<summary>
 
-- Your response should be around 30 seconds.
-- Have a list of items ready but tailor what you say to your audience. For example, at a technical conference focus on your technical interests rather than your love of making cupcakes, but on the first day of a new job introducing yourself to your new team feel free to add 1-2 personal details.
-- Try to structure your response,
-  - Who are you? Where are you from? Where have you worked? Have you studied somewhere and what subjects?
-  - What do you do? What are your skills, passions, or hobbies? What motivates you?
+#### Some tips:
+
+</summary>
+
+- Your response should be around 30 seconds. Think: What do you do? What are your skills, passions, or hobbies? What motivates you?
+- Have a list of items ready but tailor what you say to your audience. For example, at a technical conference focus on your technical interests rather than your love of making cupcakes, but on the first day of a new job introducing yourself to your new team, add 1-2 personal details.
+- Structure your response: Who are you? Where are you from? Where have you worked? Have you studied somewhere and what subjects?
 - Try to be enthusiastic, let your personality and confidence shine
 - Allow space for follow-up questions
 - It will feel awkward and nerve-wracking the first couple of times, practice-practice-practice to feel confident
+</details>
+<details>
+<summary>
 
 #### Facilitator Check-in questions
+
+</summary>
 
 - How did you feel about public speaking?
 - What are some strategies to feel more confident when public speaking?
 - What activities could you share to create a connection? Ex. Sports, Hobbies
+
+</details>

--- a/common-content/en/energisers/time-traveller/index.md
+++ b/common-content/en/energisers/time-traveller/index.md
@@ -13,6 +13,13 @@ time=30
 
 #### Meet the time traveller
 
-In this motivational session, you will hear from an alumni who has been through the course and is now working in the tech industry. They will share their experience of training with {{<our-name>}} and how it has helped them in their career.
+In this insight session, you will hear from an alumni who has been through the course and is now working in the tech industry. They will share their experience of training with {{<our-name>}} and how it has helped them in their career.
 
 You will have the opportunity to ask questions and learn from their experience. If you could ask your future self anything about today, what would it be?
+
+<details><summary>Facilitator tips</summary>
+Put a call out on main Slack for alumni to volunteer to be a time traveller. They should be prepared to share their experience of the course and answer questions from the class.
+
+Please do this a couple of weeks beforehand to give them time to prepare.
+
+</details>

--- a/common-content/en/energisers/word-chain/index.md
+++ b/common-content/en/energisers/word-chain/index.md
@@ -11,11 +11,13 @@ list = 'local'
 publishResources = false
 +++
 
-A fast-paced word association game that works for both in-person and online groups of any size. If you are playing online, write the order of players in the chat to keep track of who is next. Set a timer for {{<timer>}}10{{</timer>}}
+A fast-paced word association game that works for both in-person and online groups of any size. If you are playing online, write the order of players in the chat to keep track of who is next.
+
+Set a timer for {{<timer>}}10{{</timer>}}
 
 1. The first player says any word.
-1. The next player must say a word that begins with the last letter of the previous word.
-1. Continue around the circle. For example: cat → tree → elephant → tower
+1. The next player must say a word that begins with the last letter of the previous word. For example: cat → tree → elephant → tower
+1. Continue around the circle or moving clockwise on Zoom gallery.
 1. If a player takes longer than 5 seconds or repeats a word, they're out.
 1. Last player standing wins.
 

--- a/org-cyf-itp/content/structuring-data/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/structuring-data/sprints/1/day-plan/index.md
@@ -5,35 +5,40 @@ emoji= '🧑🏾‍🤝‍🧑🏾'
 menu_level = ['sprint']
 weight = 3
 [[blocks]]
-name="Energiser"
-src="blocks/energiser"
-[[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
-time=15
+time=10
 [[blocks]]
-name="Workshop"
-src="blocks/workshop"
-time="140"
-  [[blocks.nested.blocks]]
-    name="Reporting Bugs [PD] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/reporting-bugs"
-    time="0"
-  [[blocks.nested.blocks]]
-    name="Playing Computer [Tech] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/playing-computer"
-    time="0"
-  [[blocks.nested.blocks]]
-    name="Javascript Test Your Understanding [Tech] (30 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/js1-wk1-eval"
-    time="0"
+name="Energiser: Popcorn"
+src="energisers/popcorn-screen-share"
+[[blocks]]
+name="Javascript Test Your Understanding"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/js1-wk1-eval"
+time=65
+[[blocks]]
+name="Morning break"
+src="blocks/morning-break"
+[[blocks]]
+name="Another Asking Questions Workshop"
+src="https://cyf-pd.netlify.app/blocks/asking-good-technical-questions"
+time=70
 [[blocks]]
 name="lunch"
 src="blocks/lunch"
 [[blocks]]
+name="Blockers! Getting Unstuck"
+src="module/onboarding/blockers"
+time=15
+[[blocks]]
 name="Study Group"
-src="blocks/study-group"
-time="90"
+src="module/onboarding/development"
+time=60
+[[blocks.nested.blocks]]
+name="Optional structured activity: Pair Programming"
+src="module/onboarding/pairing"
+[[blocks.nested.blocks]]
+name="Optional structured activity: Code Review"
+src="blocks/mentored-code-review"
 [[blocks]]
 name="Code Review"
 src="https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/pulls"
@@ -43,8 +48,11 @@ name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
 name="Study Group"
-src="blocks/study-group"
-time="75"
+src="module/onboarding/development"
+time=60
+[[blocks.nested.blocks]]
+name="Optional structured activity: Know Your Computer"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/know-your-computer"
 [[blocks]]
 name="Retro"
 src="blocks/retro"

--- a/org-cyf-itp/content/structuring-data/sprints/2/day-plan/index.md
+++ b/org-cyf-itp/content/structuring-data/sprints/2/day-plan/index.md
@@ -5,35 +5,38 @@ emoji= '🧑🏾‍🤝‍🧑🏾'
 menu_level = ['sprint']
 weight = 3
 [[blocks]]
-name="Energiser"
-src="blocks/energiser"
+name="Energiser: Word Chain"
+src="energisers/word-chain"
+time=20
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
 time=15
 [[blocks]]
-name="Workshop"
-src="blocks/workshop"
-time=140
-  [[blocks.nested.blocks]]
-    name="Questions and Reviews [PD] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/questions-and-reviews"
-    time=0
-  [[blocks.nested.blocks]]
-    name="Debugging [Tech] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/debugging"
-    time=0
-  [[blocks.nested.blocks]]
-    name="Javascript Test Your Understanding Level 2 [Tech] (30 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/js1-week-2"
-    time=0
+name="Questions and Review Workshop"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/questions-and-reviews"
+time=60
+[[blocks]]
+name="Morning break"
+src="blocks/morning-break"
+[[blocks]]
+name="Time Traveller"
+src="energisers/time-traveller"
+time=65
 [[blocks]]
 name="lunch"
 src="blocks/lunch"
 [[blocks]]
+name="Stand Up"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/stand-up"
+time=30
+[[blocks]]
 name="Study Group"
-src="blocks/study-group"
-time="90"
+src="module/onboarding/development"
+time=30
+[[blocks.nested.blocks]]
+name="Optional structured activity: Code Review"
+src="blocks/mentored-code-review"
 [[blocks]]
 name="Code Review"
 src="https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/pulls"
@@ -43,8 +46,15 @@ name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
 name="Study Group"
-src="blocks/study-group"
-time="75"
+src="module/onboarding/development"
+time=75
+[[blocks.nested.blocks]]
+name="Optional structured activity: Pair Programming"
+src="module/onboarding/pairing"
+[[blocks.nested.blocks]]
+name="Optional structured activity: Predict Explain exercises"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/js1-week-2/"
+time=0
 [[blocks]]
 name="Retro"
 src="blocks/retro"

--- a/org-cyf-itp/content/structuring-data/sprints/3/day-plan/index.md
+++ b/org-cyf-itp/content/structuring-data/sprints/3/day-plan/index.md
@@ -5,35 +5,34 @@ emoji= '🧑🏾‍🤝‍🧑🏾'
 menu_level = ['sprint']
 weight = 3
 [[blocks]]
-name="Energiser"
-src="blocks/energiser"
-[[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
 time=15
 [[blocks]]
-name="Workshop"
-src="blocks/workshop"
-time="140"
-  [[blocks.nested.blocks]]
-    name="Planning Estimation Game [PD] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/paint-the-room"
-    time="0"
-  [[blocks.nested.blocks]]
-    name="CRUD [Tech] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/crud"
-    time="0"
-  [[blocks.nested.blocks]]
-    name="Components 2 [Tech] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/components-2"
-    time="0"
+name="Energiser: Introduce Yourself"
+src="energisers/introduce-yourself"
+time=20
+[[blocks]]
+name="Workshop:Playing Computer"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/playing-computer"
+time=140
 [[blocks]]
 name="lunch"
 src="blocks/lunch"
 [[blocks]]
+name="Stand Up"
+src="blocks/standup"
+time=15
+[[blocks]]
 name="Study Group"
-src="blocks/study-group"
-time="90"
+src="module/onboarding/development"
+time=60
+[[blocks.nested.blocks]]
+name="Optional structured activity: Pair Programming"
+src="module/onboarding/pairing"
+[[blocks.nested.blocks]]
+name="Optional structured activity: Code Review"
+src="blocks/mentored-code-review"
 [[blocks]]
 name="Code Review"
 src="https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/pulls"
@@ -43,8 +42,14 @@ name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
 name="Study Group"
-src="blocks/study-group"
-time="75"
+src="module/onboarding/development"
+time="60"
+[[blocks.nested.blocks]]
+name="Optional structured activity: Pomodoro"
+src="module/onboarding/pomodoro"
+[[blocks.nested.blocks]]
+name="Optional structured activity: Kata"
+src="blocks/kata"
 [[blocks]]
 name="Retro"
 src="blocks/retro"


### PR DESCRIPTION
## What does this change?

- slowly fade onboarding "blockers" and "wrap"  into standups and retros
- assign workshops they have context for
- add structured activities to introduce coursework tasks

Fixes #1182
Fixes #1168 
### Common Content?

- standup block
- tweaked some energisers

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

STAD | 123 | Day Plans 

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
