### PR TITLE
1211 details tags don't show up inside note

### DIFF
--- a/org-cyf-tracks/hugo.toml
+++ b/org-cyf-tracks/hugo.toml
@@ -21,5 +21,19 @@ baseURL = "https://tracks.codeyourfuture.io/"
       source = "content"
       target = "content/how-this-works"
 
+[markup]
+# I've configured markdown so you don't have to
+  [markup.tableOfContents]
+    endLevel = 2
+    ordered = true
+    startLevel = 2
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true # Enable HTML codeblocks, e.g. for <details> blocks
+    [markup.goldmark.parser]
+      [markup.goldmark.parser.attribute]
+        block = true
+        title = true
+
 [taxonomies]
   track_kind = "track_kinds"


### PR DESCRIPTION
## What does this change?

adds goldmark config to tracks  because this cannot be inherited from theme 

without configuring goldmark anything which does complex mixes of md and html goes wrong. You can tell it's goldmark, or a markdown rendering problem mixing in HTML, because in the rendered view it says `<!--raw HTML omitted -->`

Fixes #1211 

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Tracks | hugo.toml

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
