### PR TITLE
1113 Register must include location and made available to local leaders

### DIFF
--- a/common-theme/layouts/_default/day-plan.html
+++ b/common-theme/layouts/_default/day-plan.html
@@ -15,7 +15,16 @@
     <time-stamper start-time="{{$startTime}}">
       <div class="c-block__series c-block__series--timeline">
         {{ if ne .Params.noRegister true }}
-          {{ partial "register-attendance.html" (dict "course" site.Title "module" $.Page.CurrentSection.Parent.Title "day" $.Page.CurrentSection.Title) }}
+          {{ $moduleSection := $.Page.CurrentSection }}
+          {{/* Most of our modules have two levels of hierarchy - course > module > sprint. But some go straight course > sprint or module > sprint - allow opting into this with a param. */}}
+          {{ $parentsToTraverseToModule := $moduleSection.Params.parentsToTraverseToModule }}
+          {{ if eq $parentsToTraverseToModule nil }}
+            {{ $parentsToTraverseToModule = 1 }}
+          {{ end }}
+          {{ range seq $parentsToTraverseToModule }}
+            {{ $moduleSection = $moduleSection.Parent }}
+          {{ end }}
+          {{ partial "register-attendance.html" (dict "course" site.Title "module" $moduleSection.Title "day" $.Page.CurrentSection.Title) }}
         {{ end }}
         {{ range $index, $block := .Params.blocks }}
 

--- a/common-theme/layouts/partials/register-attendance.html
+++ b/common-theme/layouts/partials/register-attendance.html
@@ -12,9 +12,9 @@
 {{ $course := .course | anchorize }}
 {{ $module := .module }}
 {{ $day := .day | urlize}}
-{{ $orgData := $.Site.Data.courses "code" $course }}
-{{ $orgData}} YO {{ $course}}
-{{ $locations := $orgData.locations}} Loca {{$locations}}
+
+{{ $orgData := index site.Data.courses $course }}
+ {{$locations := $orgData.locations}}
 
 {{/* if any of these params are null, error */}}
 {{ if or (not $course) (not $module) (not $day) }}
@@ -40,11 +40,8 @@
   <input type="hidden" name="module" value="{{ $module }}">
   <input type="hidden" name="day" value="{{ $day }}">
   <input type="hidden" name="buildTime" value="{{ now.Format "2006-01-02T15:04:05" }}">
-  <div><label for="givenName" class="is-invisible">Given Name</label>
-  <input type="text" name="givenName" id="givenName" autocomplete="given-name" placeholder="Given Name" required>
-  </div>
-  <div><label for="familyName" class="is-invisible">Family Name</label>
-  <input type="text" name="familyName" id="familyName" autocomplete="family-name" placeholder="Family Name" required>
+  <div><label for="givenName" class="is-invisible">Name</label>
+  <input type="text" name="givenName" id="givenName" autocomplete="given-name" placeholder="Name" required>
   </div>
   <div><label for="email" class="is-invisible">Email</label>
   <input type="email" name="email" id="email" autocomplete="email" placeholder="Email" required>

--- a/common-theme/layouts/partials/register-attendance.html
+++ b/common-theme/layouts/partials/register-attendance.html
@@ -41,7 +41,7 @@
   <input type="hidden" name="day" value="{{ $day }}">
   <input type="hidden" name="buildTime" value="{{ now.Format "2006-01-02T15:04:05" }}">
   <div><label for="givenName" class="is-invisible">Name</label>
-  <input type="text" name="givenName" id="givenName" autocomplete="given-name" placeholder="Name" required>
+  <input type="text" name="givenName" id="givenName" autocomplete="name" placeholder="Name" required>
   </div>
   <div><label for="email" class="is-invisible">Email</label>
   <input type="email" name="email" id="email" autocomplete="email" placeholder="Email" required>

--- a/common-theme/layouts/partials/register-attendance.html
+++ b/common-theme/layouts/partials/register-attendance.html
@@ -12,6 +12,9 @@
 {{ $course := .course | anchorize }}
 {{ $module := .module }}
 {{ $day := .day | urlize}}
+{{ $orgData := $.Site.Data.courses "code" $course }}
+{{ $orgData}} YO {{ $course}}
+{{ $locations := $orgData.locations}} Loca {{$locations}}
 
 {{/* if any of these params are null, error */}}
 {{ if or (not $course) (not $module) (not $day) }}
@@ -46,6 +49,14 @@
   <div><label for="email" class="is-invisible">Email</label>
   <input type="email" name="email" id="email" autocomplete="email" placeholder="Email" required>
   </div>
+  {{ with $locations }}
+  <div><label for="location" class="is-invisible">Location</label>
+  <input list="locations" name="location" id="location" autocomplete="location" placeholder="Location" required>
+  <datalist id="locations">
+    {{ range . }}<option value="{{.}}"></option>{{ end }}
+  </datalist>
+  </div>
+  {{ end }}
   <button class="e-button">Register</button>
 </form>
 </section>

--- a/common-theme/layouts/partials/register-attendance.html
+++ b/common-theme/layouts/partials/register-attendance.html
@@ -14,7 +14,7 @@
 {{ $day := .day | urlize}}
 
 {{ $orgData := index site.Data.courses $course }}
- {{$locations := $orgData.locations}}
+{{ $locations := $orgData.locations }}
 
 {{/* if any of these params are null, error */}}
 {{ if or (not $course) (not $module) (not $day) }}
@@ -40,8 +40,8 @@
   <input type="hidden" name="module" value="{{ $module }}">
   <input type="hidden" name="day" value="{{ $day }}">
   <input type="hidden" name="buildTime" value="{{ now.Format "2006-01-02T15:04:05" }}">
-  <div><label for="givenName" class="is-invisible">Name</label>
-  <input type="text" name="givenName" id="givenName" autocomplete="name" placeholder="Name" required>
+  <div><label for="name" class="is-invisible">Name</label>
+  <input type="text" name="name" id="name" autocomplete="name" placeholder="Name" required>
   </div>
   <div><label for="email" class="is-invisible">Email</label>
   <input type="email" name="email" id="email" autocomplete="email" placeholder="Email" required>

--- a/org-cyf-itp/content/welcome/_index.md
+++ b/org-cyf-itp/content/welcome/_index.md
@@ -5,4 +5,5 @@ layout = 'module'
 emoji= '🫶🏽'
 menu = ['syllabus', 'course schedule']
 weight='1'
+parentsToTraverseToModule = 0
 +++

--- a/org-cyf-itp/hugo.toml
+++ b/org-cyf-itp/hugo.toml
@@ -1,4 +1,4 @@
-title = "CYF ITP"
+title = "ITP"
 baseURL = "https://programming.codeyourfuture.io/"
 
 [module]

--- a/org-cyf-itp/tooling/netlify/functions/submission-created.js
+++ b/org-cyf-itp/tooling/netlify/functions/submission-created.js
@@ -16,6 +16,7 @@ import {Auth, google} from "googleapis";
 // Each spreadsheet must also give write access to the email listed below in CREDENTIALS.
 const COURSE_TO_SPREADSHEET_ID = {
   "cyf-itp": "1YHKPCCN55PJD-o1jg4wbVKI3kbhB-ULiwB5hhG17DcA",
+  "cyf-piscine": "1XabWuYqvOUiY7HpUra0Vdic4pSxmXmNRZHMR72I1bjk",
 };
 
 const CREDENTIALS = {
@@ -47,7 +48,7 @@ const handler = async (event, context) => {
   }
   const request = body.payload.data;
 
-  for (const requiredField of ["course", "module", "givenName", "familyName", "email", "day", "buildTime"]) {
+  for (const requiredField of ["course", "module", "name", "email", "day", "location", "buildTime"]) {
     if (!(requiredField in request)) {
       const error = `Request missing field ${requiredField}`;
       console.error(error, request);
@@ -83,7 +84,7 @@ const handler = async (event, context) => {
       insertDataOption: "INSERT_ROWS",
       resource: {
         values: [
-          [request.givenName, request.familyName, request.email, new Date().toISOString(), request.course, request.module, request.day, request.buildTime],
+          [request.name, request.email, new Date().toISOString(), request.course, request.module, request.day, request.location, request.buildTime],
         ],
       },
     });

--- a/org-cyf-piscine/content/sprints/_index.md
+++ b/org-cyf-piscine/content/sprints/_index.md
@@ -1,0 +1,12 @@
++++
+title = 'Piscine'
+description = 'In teams and on your own, build working software with tests. Explain your work to others.'
+layout = 'module'
+emoji= '🐠'
+menu = ['syllabus', 'next steps']
+menus_to_map=['entry', 'sprints', 'assessment']
+[build]
+  render = "never"
+  list = "local"
+  publishResources = false
++++

--- a/org-cyf-theme/data/courses/cyf-piscine.toml
+++ b/org-cyf-theme/data/courses/cyf-piscine.toml
@@ -7,5 +7,5 @@ menu="selection"
 url="https://piscine.codeyourfuture.io/"
 days="22"
 commitment="part time"
-frequency=4
-locations=["Online"]
+frequency=3
+locations=["Birmingham", "Capetown", "Glasgow", "London", "Manchester", "Online", "Sheffield"]

--- a/org-cyf-theme/data/courses/itd.toml
+++ b/org-cyf-theme/data/courses/itd.toml
@@ -8,3 +8,4 @@ description="Meet the world of tech: write a CV with AI; evaluate data in spread
 days=30
 commitment="part time"
 frequency=6
+locations=["Birmingham", "Capetown", "Glasgow", "London", "Manchester", "Online", "Sheffield"]

--- a/org-cyf-theme/data/courses/itp.toml
+++ b/org-cyf-theme/data/courses/itp.toml
@@ -1,5 +1,5 @@
 name="Intro to Programming"
-code="cyf-itp"
+code="itp"
 weight=2
 menu="start here"
 url="https://programming.codeyourfuture.io"

--- a/org-cyf-theme/data/courses/itp.toml
+++ b/org-cyf-theme/data/courses/itp.toml
@@ -7,5 +7,5 @@ description="Programming with JavaScript, Python, and SQL; collaborate to delive
 emoji="🐣"
 days=84
 commitment="part time"
-frequency=4
+frequency=3
 locations=["Birmingham", "Capetown", "Glasgow", "London", "Manchester", "Online", "Sheffield"]

--- a/org-cyf-theme/data/courses/itp.toml
+++ b/org-cyf-theme/data/courses/itp.toml
@@ -1,5 +1,5 @@
 name="Intro to Programming"
-code="itp"
+code="cyf-itp"
 weight=2
 menu="start here"
 url="https://programming.codeyourfuture.io"
@@ -8,3 +8,4 @@ emoji="🐣"
 days=84
 commitment="part time"
 frequency=4
+locations=["Birmingham", "Capetown", "Glasgow", "London", "Manchester", "Online", "Sheffield"]

--- a/org-cyf-theme/data/courses/launch.toml
+++ b/org-cyf-theme/data/courses/launch.toml
@@ -8,3 +8,4 @@ emoji="🚀"
 commitment="part time"
 days=35
 frequency=4
+locations=["Online"]

--- a/org-cyf-theme/data/courses/piscine.toml
+++ b/org-cyf-theme/data/courses/piscine.toml
@@ -8,3 +8,4 @@ url="https://piscine.codeyourfuture.io/"
 days="22"
 commitment="part time"
 frequency=4
+locations=["Online"]

--- a/org-cyf-theme/data/courses/sdc.toml
+++ b/org-cyf-theme/data/courses/sdc.toml
@@ -8,3 +8,4 @@ description="A secure grounding in software: binary, logic, systems, and problem
 days="84"
 commitment="part time"
 frequency=3
+locations=["Birmingham", "Capetown", "Glasgow", "London", "Manchester", "Online", "Sheffield"]

--- a/org-cyf-theme/data/courses/systems.toml
+++ b/org-cyf-theme/data/courses/systems.toml
@@ -6,3 +6,4 @@ url="https://systems.codeyourfuture.io/"
 menu="fellowships"
 days=260
 commitment="full time"
+locations=["Online"]


### PR DESCRIPTION
## What does this change?

pulls location data from course data files stored in org-cyf-theme
removes family name because it's too many fields

### Common Content?

courses data files

### Common Theme?

Fixes #1113 

Register includes locations


## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
