### PR TITLE
Switch sample day-plan PRs to less interesting repo

### DIFF
--- a/common-docs/content/common-theme/pages/day-plan.md
+++ b/common-docs/content/common-theme/pages/day-plan.md
@@ -22,7 +22,7 @@ src="common-content/blocks/study-group"
 time="90"
 [[blocks]]
 name="Code Review"
-src="https://github.com/CodeYourFuture/curriculum/pulls"
+src="https://github.com/CodeYourFuture/Module-Template/pulls"
 time="0"
 [[blocks]]
 name="Afternoon break"


### PR DESCRIPTION
The build is currently failing because we have some complicated PRs in curriculum which include unknown shortcodes in their descriptions.

Ideally this wouldn't cause problems for the site, but it does, so... Let's switch to a repo which is less likely to trigger this problem.