### PR TITLE
Clarify access to How Computers Really Work

### DIFF
--- a/org-cyf-sdc/content/blocks/get-how-computers-really-work/index.md
+++ b/org-cyf-sdc/content/blocks/get-how-computers-really-work/index.md
@@ -1,0 +1,20 @@
++++
+title = "Get a copy of How Computers Really Work"
+emoji = "📚"
+time = 5
+hide_from_overview = true
+[build]
+  render = "never"
+  list = "local"
+  publishResources = false
++++
+
+Throughout this course, we will reference the book [How Computers Really Work](https://www.howcomputersreallywork.com/) by Matthew Justice.
+
+You will need a copy.
+
+The author, Matthew Justice, has kindly donated a pdf of this book for use by CodeYourFuture trainees. If you would like a copy of this PDF, you can find access details in the [#software-development-course slack channel](https://codeyourfuture.slack.com/archives/C0884D7GLS3).
+
+If you buy your own copy [from e.g. Amazon](https://www.amazon.co.uk/How-Computers-Work-Hands-Workings/dp/1718500661), {{<our-name>}} cannot pay for this.
+
+Huge thanks to Matthew Justice and the folks at No Starch Press for their kind donation of this excellent book!


### PR DESCRIPTION
Matthew Justice has very kindly donated a PDF of the book to CYF for use by our trainees, which means we have a much better answer for "how do you get this book if you can't afford it?" now!

This block overrides the common-content version of this block, because it's a CYF-specific donation.