### PR TITLE
Fix incorrect repo names for Piscine

### DIFF
--- a/org-cyf-piscine/content/sprints/1/backlog/index.md
+++ b/org-cyf-piscine/content/sprints/1/backlog/index.md
@@ -4,6 +4,6 @@ layout = 'backlog'
 emoji= '🏷️'
 menu_level = ['sprint']
 weight = 2
-backlog= 'Module-Piscine'
+backlog= 'The-Piscine'
 backlog_filter='📅 Sprint 1'
 +++

--- a/org-cyf-piscine/content/sprints/2/backlog/index.md
+++ b/org-cyf-piscine/content/sprints/2/backlog/index.md
@@ -4,6 +4,6 @@ layout = 'backlog'
 emoji= '🏷️'
 menu_level = ['sprint']
 weight = 2
-backlog= 'Module-Piscine'
+backlog= 'The-Piscine'
 backlog_filter='📅 Sprint 2'
 +++

--- a/org-cyf-piscine/content/sprints/3/backlog/index.md
+++ b/org-cyf-piscine/content/sprints/3/backlog/index.md
@@ -4,6 +4,6 @@ layout = 'backlog'
 emoji= '🏷️'
 menu_level = ['sprint']
 weight = 2
-backlog= 'Module-Piscine'
+backlog= 'The-Piscine'
 backlog_filter='📅 Sprint 3'
 +++


### PR DESCRIPTION
## What does this change?

<!-- Add a description of what your PR changes here -->

Fixes incorrect repo names used in the Backlog for the Piscine - it seems we renamed the coursework repo from `Module-Piscine` to `The-Piscine` at some point.

While it continues to work (because Github maintains redirects for renamed modules), it seems to make the most sense to fix the names to be correct.

### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: N/A, just noticed while reviewing the Piscine content

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Module

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
@CodeYourFuture/global-syllabus 