### PR TITLE
~Final tweaks to Piscine

### DIFF
--- a/common-content/en/module/piscine/kickoff/index.md
+++ b/common-content/en/module/piscine/kickoff/index.md
@@ -16,7 +16,7 @@ It's important that software works and the people can use it
 
 ## 🎯 Goal:
 
-You will be split randomly into groups of 3-4.
+You will be split randomly into groups of 2-4.
 
 {{<note type="activity" title="Kickoff">}}
 

--- a/common-content/en/module/piscine/practice-break-down/index.md
+++ b/common-content/en/module/piscine/practice-break-down/index.md
@@ -1,0 +1,24 @@
++++
+title = "Practice breaking down a requirement"
+time = 60
+objectives = [
+  "Break down a requirement into approachable tasks.",
+  "Coordinate multiple team members in executing tasks in parallel.",
+]
+[build]
+  render = "never"
+  list = "local"
+  publishResources = false
++++
+
+In team projects, it's important that we break large tasks down into small tasks.
+
+It's also important that we can coordinate across our team. This requires having shared understanding of who will do what, and how the work we do will interact.
+
+We will practice this together on the first two requirements of the project.
+
+{{/*
+  TODO: The Piscine is meant to be pure evaluation with no teaching.
+  Ideally ITP would provide this experience so we wouldn't need to teach it in the Piscine.
+  But right now ITP doesn't teach these skills, so we fill that gap so we're not testing people on things they don't know.
+*/}}

--- a/org-cyf-piscine/content/sprints/1/day-plan/index.md
+++ b/org-cyf-piscine/content/sprints/1/day-plan/index.md
@@ -12,20 +12,23 @@ time=15
 name="Energiser"
 src="energisers/zip-zap-boing"
 [[blocks]]
-name="Morning break"
-src="blocks/morning-break"
-[[blocks]]
 name="Kickoff"
 src="module/piscine/kickoff"
 time=20
 [[blocks]]
+name="Morning break"
+src="blocks/morning-break"
+[[blocks]]
 name="Group Project: Spaced Repetition Tracker"
 src="https://github.com/CodeYourFuture/The-Piscine/tree/main/Project-Spaced-Repetition-Tracker"
-time=50
+time=30
+[[blocks]]
+name="Practice breaking down a requirement"
+src="module/piscine/practice-break-down"
 [[blocks]]
 name="Development"
 src="module/piscine/development"
-time="60"
+time="20"
 [[blocks]]
 name="lunch"
 src="blocks/lunch"

--- a/org-cyf-piscine/content/sprints/2/day-plan/index.md
+++ b/org-cyf-piscine/content/sprints/2/day-plan/index.md
@@ -11,12 +11,12 @@ src="energisers/blockers"
 name="Demo"
 src="module/piscine/demo"
 [[blocks]]
-name="Morning break"
-src="blocks/morning-break"
-[[blocks]]
 name="Kickoff"
 src="module/piscine/kickoff"
 time=20
+[[blocks]]
+name="Morning break"
+src="blocks/morning-break"
 [[blocks]]
 name="Group Project: Days Calendar"
 src="https://github.com/CodeYourFuture/The-Piscine/tree/main/Project-Days-Calendar"


### PR DESCRIPTION
* Note that groups may be 2 people.
* Add temporary block for talking through breaking down requirements. We hope to remove this in the future, but we would like our day plans to be accurate for the course we're delivering.
* Move team-selection to happen before morning break.