### PR TITLE
Extend temp Piscine workshop with exercises to breaking down project requirements

### DIFF
--- a/common-content/en/module/piscine/practice-break-down/index.md
+++ b/common-content/en/module/piscine/practice-break-down/index.md
@@ -25,7 +25,7 @@ We will practice this together on the two of the requirements of the project:
 To complete these requirements we'd need to build most of the project! So we'll focus on simplified versions of these requirements:
 
 - When the page loads, display one revision date for one topic from in User 1's stored agenda
-- When clicking a button, store _hard-coded_ data for User 1's agenda
+- When clicking a button, store {{<tooltip title="hard-coded">}}Hard-coding refers to when developers directly write values or data into code, often replacing variables or user input with static values.{{</tooltip>}} data for User 1's agenda
 
 To complete the full requirements, you can build on the tasks we decide on today.
 

--- a/common-content/en/module/piscine/practice-break-down/index.md
+++ b/common-content/en/module/piscine/practice-break-down/index.md
@@ -38,13 +38,14 @@ To complete the full requirements, you can build on the tasks we decide on today
 
 {{</note>}}
 
-Some of these tasks _block_ other tasks: one task must be completed before the other can start.
+Looking ahead to your coursework for the next week, one of your tasks will be to [Refine a ticket](https://github.com/CodeYourFuture/The-Piscine/issues/6).
 
-{{<note type="exercise" title="Identify blockers">}}
+{{<note type="exercise" title="Refining tickets">}}
 
-1. In groups of 2, discuss of the tasks on the whiteboard are blocking other tasks?
-2. As a group, discuss which tasks are blockers.
-3. Again as a group, discuss what actions you could take to avoid being blocked by these tasks?
+1. Everyone read the [Refine a ticket coursework task](https://github.com/CodeYourFuture/The-Piscine/issues/6), for {{<timer>}}3{{</timer>}} minutes.
+2. Get into pairs. Each pair should then pick 2 of the tasks from the whiteboard (it doesn't matter if multiple pairs do the same task). Spend {{<timer>}}10{{</timer>}} minutes refining your tickets in your pairs. Make sure you work through **all** of the workflow points.
+3. Go around each pair in the group. The pair should pick 1 of their tasks and say what they think the priority, estimate, schedule and type of work the task is, and if there is anything they would need to know before starting the ticket. (Hint: the last point is **important**! Don't skip it!)
+4. As a group, pick a task (or two, depending on time) that needs more information. Spend {{<timer>}}10{{</timer>}} minutes discussing what actions you could take to ensure everyone has what they need to complete this task?
 
 {{</note>}}
 

--- a/common-content/en/module/piscine/practice-break-down/index.md
+++ b/common-content/en/module/piscine/practice-break-down/index.md
@@ -15,7 +15,38 @@ In team projects, it's important that we break large tasks down into small tasks
 
 It's also important that we can coordinate across our team. This requires having shared understanding of who will do what, and how the work we do will interact.
 
-We will practice this together on the first two requirements of the project.
+Finally, it's important that we arrange tasks so your team isn't blocking yourselves, so you'll want to find ways of working on tasks in parallel.
+
+We will practice this together on the two of the requirements of the project:
+
+- Selecting a user must display the agenda for the relevant user (see manual testing below)
+- Submitting the form adds a new topic to revise for the relevant user only
+
+To complete these requirements we'd need to build most of the project! So we'll focus on simplified versions of these requirements:
+
+- When the page loads, display one revision date for one topic from in User 1's stored agenda
+- When clicking a button, store _hard-coded_ data for User 1's agenda
+
+To complete the full requirements, you can build on the tasks we decide on today.
+
+{{<note type="exercise" title="Breaking down tasks">}}
+
+1. Set a timer for {{<timer>}}5{{</timer>}}
+2. Individually, write down all the tasks that would be needed to complete the simplified requirements above
+3. After the timer is up, go around the group and discuss the tasks you came up with. One of the volunteers should write the tasks on a whiteboard
+4. Volunteers, discuss any that you think might be missing or that might need breaking down further
+
+{{</note>}}
+
+Some of these tasks _block_ other tasks: one task must be completed before the other can start.
+
+{{<note type="exercise" title="Identify blockers">}}
+
+1. In groups of 2, discuss of the tasks on the whiteboard are blocking other tasks?
+2. As a group, discuss which tasks are blockers.
+3. Again as a group, discuss what actions you could take to avoid being blocked by these tasks?
+
+{{</note>}}
 
 {{/*
   TODO: The Piscine is meant to be pure evaluation with no teaching.


### PR DESCRIPTION
## What does this change?

Extends the temporary workshop added in https://github.com/CodeYourFuture/curriculum/pull/1325 with exercises to break down a couple of requirements from the first Piscine project (spaced repetition tracker).

This is something of a strawman - please feel free to tear it apart!

I've chosen not to explicitly write out the tickets that I was thinking of, but they were something like:

- Add form submit button
- On submit, store some hard-coded data (user 1, today's date, any topic)

- Read the data (hard coded to user 1 for now) from storage
- Display the first date from the data

I also chose not to include exercises on writing up tickets - I wasn't sure how to frame that as an exercise and I wanted to get something in soon. But will try to think about that this week.

### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: N/A

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Module

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->

@CodeYourFuture/global-syllabus 