### PR TITLE
Link to the public view of the calendar

### DIFF
--- a/org-cyf/content/_index.md
+++ b/org-cyf/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title="Our Courses"
 menus_to_map=["start here", "selection", "trainees", "fellowships"]
-description="Free training for good jobs in tech [📅 2024/25](https://docs.google.com/spreadsheets/d/1qNxf44_vbNKU1KeFozGX7Kt1QxmTtU6Bf9tOh1sTUuc/edit?gid=1346767713#gid=1346767713)"
+description="Free training for good jobs in tech [📅 2025](https://docs.google.com/spreadsheets/d/1yI0msIwe8qYn2Nv9WPLwFMTM_Td0TtPvlv17u3B8sS8/edit)"
 emoji= "🧑🏿‍🏫👨🏽‍🎓"
 +++


### PR DESCRIPTION
Previously we were linking to the sheet the public view is a proxy for, which means it didn't get updated when we updated the proxy.

Also, remove 2024 from the link text, we're in 2025 now.