### PR TITLE
Rename self-study tracks to guided-study, mark AI as one

### DIFF
--- a/org-cyf-tracks/content/ai-essentials/_index.md
+++ b/org-cyf-tracks/content/ai-essentials/_index.md
@@ -3,6 +3,7 @@ title = 'AI Essentials'
 description = 'In teams, learn new efficient ways to work with data and AI in the workplace; apply these skills to recruitment and hiring processes.'
 layout = 'module'
 emoji="🤖"
-track_kinds = ["jobs-after-itp"]
+track_kinds = ["guided-study-after-itp"]
 menu="AI Essentials"
+weight = 1
 +++

--- a/org-cyf-tracks/content/react/_index.md
+++ b/org-cyf-tracks/content/react/_index.md
@@ -3,6 +3,6 @@ title = 'React'
 description = 'Explore frameworks, libraries, and declarative programming with React; Develop unit testing with Testing Library; Build a dynamic web application in an Agile team'
 layout = 'module'
 emoji= '🪄'
-track_kinds = ["self-study"]
+track_kinds = ["guided-study-after-itp"]
 weight='6'
 +++

--- a/org-cyf-tracks/content/track_kinds/guided-study-after-itp/_index.md
+++ b/org-cyf-tracks/content/track_kinds/guided-study-after-itp/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Guided study after ITP"
+weight = 1
+description = "These are course materials which train general skills without a particular job in mind."
+[[details]]
+name = "When"
+value = "When capacity exists to run the course."
+[[details]]
+name = "Who"
+value = "Each track has its own entry requirements, but most assume you have attempted ITP, and gotten submitted some number of steps."
++++

--- a/org-cyf-tracks/content/track_kinds/self-study/_index.md
+++ b/org-cyf-tracks/content/track_kinds/self-study/_index.md
@@ -1,8 +1,0 @@
-+++
-title = "Self-study"
-weight = 1
-description = "These are are course materials introducing topics which you can study on your own or in a group. They are not targeted at specific jobs, but can help broaden your knowledge."
-[[details]]
-name = "When"
-value = "You can study these tracks any time. They list what you need to know before starting."
-+++


### PR DESCRIPTION
## What does this change?

Realistically AI Essentials isn't a track which leads directly to a job (and which we only run when we have specific jobs) - it's more of a "build some skills which may help you in jobs" track. Let's be straight about this, to avoid diluting what we mean by jobs tracks.

And also pretend React is one for now. Sure, someone could run it as a track if they wanted.

### Org Content?

CYF Tracks