### PR TITLE
Tweak logic day-plan timings

### DIFF
--- a/org-cyf-sdc/content/logic/sprints/1/day-plan/index.md
+++ b/org-cyf-sdc/content/logic/sprints/1/day-plan/index.md
@@ -11,28 +11,28 @@ src="blocks/morning-orientation"
 name="Energiser"
 src="energisers/binary"
 [[blocks]]
-name="Workshop: Binary Search"
-src="blocks/workshop"
-time="120"
+name="Workshop: Bits and Rats"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/bits-and-rats"
+time="90"
 [[blocks]]
 name="Games, rules, logic and strategy"
 src="blocks/games"
-time="20"
+time="50"
 [[blocks]]
 name="lunch"
 src="blocks/lunch"
 [[blocks]]
 name="demo"
 src="module/logic/demo"
-time="60"
+time="75"
 [[blocks]]
 name="Afternoon break"
 src="blocks/afternoon-break"
 [[blocks]]
-name="Workshop: Bits and Rats"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/bits-and-rats"
-time="90"
+name="demo"
+src="blocks/demo"
+time="60"
 [[blocks]]
-name="Wrap"
-src="blocks/wrap"
+name="Retro"
+src="blocks/retro"
 +++


### PR DESCRIPTION
* Move rats to morning
* Give more time for games - it's games week!
* Give more time for logic teaching
* Add in a regular demos slot - demos _every_ week!
* Switch back to retro - we're doing retros rather than wraps for most of SDC.