### PR TITLE
Add file path argument to count-containing-words program and update i…

### DIFF
--- a/common-content/en/module/tools/comparing-javascript-and-python/index.md
+++ b/common-content/en/module/tools/comparing-javascript-and-python/index.md
@@ -28,7 +28,8 @@ import process from "node:process";
 program
     .name("count-containing-words")
     .description("Counts words in a file that contain a particular character")
-    .option("-c, --char <char>", "The character to search for", "e");
+    .option("-c, --char <char>", "The character to search for", "e")
+    .argument("<path>", "The file path to process");
 
 program.parse();
 

--- a/common-content/en/module/tools/converting-javascript-to-python/index.md
+++ b/common-content/en/module/tools/converting-javascript-to-python/index.md
@@ -64,7 +64,7 @@ There are some differences here.
 * With commander we were calling functions on a global `program`, whereas with argparse we construct a new `ArgumentParser` which we use.
 * `add_argument` takes separate parameters for the short (`-c`) and long (`--char`) forms of the option - `commander` expected them in one string.
 * The Python version uses a lot of named arguments (e.g. `add_argument(...)` took `help=`, `default=`), whereas the JavaScript version (`option(...)`) used a lot of positional ones.
-* The Python version handles positional arguments itself as arguments with names (`path`), whereas the JavaScript version just gives us an array of positional arguments and leaves us to understand them.
+* The Python version handles positional arguments itself as arguments with names (`path`), whereas the JavaScript version defines them explicitly using `.argument("<path>", "The file path to process")`, where `<path>` is a placeholder and the second argument is a description.
 
 ### Validating command line flags
 

--- a/common-content/en/module/tools/converting-javascript-to-python/index.md
+++ b/common-content/en/module/tools/converting-javascript-to-python/index.md
@@ -19,7 +19,8 @@ import { program } from "commander";
 program
     .name("count-containing-words")
     .description("Counts words in a file that contain a particular character")
-    .option("-c, --char <char>", "The character to search for", "e");
+    .option("-c, --char <char>", "The character to search for", "e")
+    .argument("<path>", "The file path to process");
 
 program.parse();
 

--- a/common-content/en/module/tools/installing-npm-dependencies/index.md
+++ b/common-content/en/module/tools/installing-npm-dependencies/index.md
@@ -47,7 +47,8 @@ import process from "node:process";
 program
     .name("count-containing-words")
     .description("Counts words in a file that contain a particular character")
-    .option("-c, --char <char>", "The character to search for", "e");
+    .option("-c, --char <char>", "The character to search for", "e")
+    .argument("<path>", "The file path to process");
 
 program.parse();
 
@@ -87,10 +88,11 @@ Let's run through what we changed:
 program
     .name("count-containing-words")
     .description("Counts words in a file that contain a particular character")
-    .option("-c, --char <char>", "The character to search for", "e");
+    .option("-c, --char <char>", "The character to search for", "e")
+    .argument("<path>", "The file path to process");
 ```
 
-We told `commander` information about our program. We gave it a name, a description, and told it that it should allow a user to pass a flag name `-c` (or equivalently `--char`), and use a default value of `-` for that flag if it's not specified.
+We told `commander` information about our program. We gave it a name, a description, and told it that it should allow a user to pass a flag name `-c` (or equivalently `--char`), and use a default value of `-` for that flag if it's not specified, and also told it that it should allow a user to pass the path to process as an argument.
 
 ```js
 program.parse();


### PR DESCRIPTION
…ts description.

## What does this change?

<!-- Add a description of what your PR changes here -->

### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #issue-number

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Module | Sprint | Page Type | Block Type

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
@illicitonion ,  the program was not explicitly defining the file path as an argument which was causing it to thrown the following error: 
```bash
error: too many arguments. Expected 0 arguments but got 1.
```
And that is because by default, `commander` expects no arguments unless you explicitly define them. To fix this, I have defined the file path as a required argument using `.argument()`.

