### PR TITLE
Give tabs horizontal scrolling

### DIFF
--- a/common-theme/assets/styles/04-components/tabs.scss
+++ b/common-theme/assets/styles/04-components/tabs.scss
@@ -44,6 +44,7 @@
     border-radius: var(--theme-border-radius);
     border-top-left-radius: 0;
     opacity: 0;
+    overflow-x: scroll;
 
     &.is-active {
       opacity: 1;


### PR DESCRIPTION
Currently if a tab overflows it makes the page (potentially very much) wider. In-tab scrolling seems more friendly.