### PR TITLE
Removed lowercase rule from TOC

### DIFF
--- a/common-theme/assets/styles/04-components/toc.scss
+++ b/common-theme/assets/styles/04-components/toc.scss
@@ -22,7 +22,7 @@
   // so instead of writing all that I'm resetting the counter and running them together that way
   // feel free to tackle if you have spare time
   ol > li {
-    text-transform: lowercase;
+    
     font-family: var(--theme-font--display);
     font-weight: 300;
     &:before {


### PR DESCRIPTION
I removed the text-transform: lowercase; rule from the Table of Contents (TOC) because it was making the text all lowercase. This change allows the TOC text to stay as it is.