### PR TITLE
Fix: prevent arrow key nav conflict inside textareas

### DIFF
--- a/common-theme/assets/scripts/solo-view.js
+++ b/common-theme/assets/scripts/solo-view.js
@@ -12,13 +12,14 @@ class SoloView extends HTMLElement {
       fragment: null,
       touchStartX: 0,
       touchEndX: 0,
-    };
-    // Adding window and doc event listeners
+    };    // Adding window and doc event listeners
     window.addEventListener(
       "hashchange",
-      { passive: true },
-      this.handleFragment.bind(this)
+      this.handleFragment.bind(this),
+      { passive: true }
     );
+    // Note: We're keeping document keydown listener for wider page coverage
+    // but the handler will now check for editable elements
     document.addEventListener("keydown", this.handleKeydown.bind(this));
   }
 
@@ -78,7 +79,11 @@ class SoloView extends HTMLElement {
       { passive: true }
     );
 
-    this.addEventListener("keydown", this.handleKeydown, { passive: true });
+    this.addEventListener(
+      "keydown",
+      this.handleKeydown,
+      { passive: false } // Changed from true to false so we can call preventDefault when appropriate
+    );
   }
 
   // Update current block index
@@ -118,11 +123,20 @@ class SoloView extends HTMLElement {
       this.navigateNext(new Event("swipe"));
     }
   };
-
   handleKeydown = (event) => {
+    // Don't intercept arrow keys if they occurred in a form control that uses arrow keys
+    const target = event.target;
+    if (target.tagName === 'TEXTAREA' || 
+        target.tagName === 'INPUT' || 
+        target.tagName === 'SELECT' || 
+        target.isContentEditable) {
+      return; // Allow default behavior for arrow keys in editable elements
+    }
+
     if (event.key === "ArrowLeft") {
       this.navigateBack(event);
     }
+
     if (event.key === "ArrowRight") {
       this.navigateNext(event);
     }


### PR DESCRIPTION
## What does this change?
This PR fixes a bug where pressing the left or right arrow keys inside a textarea would trigger navigation to a different prep section instead of moving the cursor within the textarea. 

The fix ensures that arrow key navigation handlers ignore key events when the focused element is an input or textarea.
<!-- Add a description of what your PR changes here -->

### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #1072 

### Org Content?
A function fixed
<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Module | Sprint | Page Type | Block Type

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
