### PR TITLE
Fix typo in Sprint 2 prep table (duplicate "Column 1")

### DIFF
--- a/common-content/en/module/databases/databases-with-sheets/index.md
+++ b/common-content/en/module/databases/databases-with-sheets/index.md
@@ -28,7 +28,7 @@ What else you do on your computer and phone? What information is there? And wher
 
 Most databases arrange data into **columns** and **rows**.
 
-| column 1 | column 1 |
+| column 1 | column 2 |
 | -------- | -------- |
 | row 1    | row 1    |
 | row 2    | row 2    |


### PR DESCRIPTION
## What does this change?

This PR fixes a typo in the Sprint 2 prep page. The table diagram had "Column 1" listed twice. I corrected the second "Column 1" to "Column 2" to reflect the intended structure.

### Common Content?

- [ ] Block/s

### Common Theme?

- [ ] Yes

Issue number: N/A

### Org Content?

Module | Sprint | Page Type | Block Type
onboarding | 2 | prep | text

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

@CodeYourFuture/dashboard-developers 
<img width="1425" alt="Screenshot 2025-05-21 at 23 57 20" src="https://github.com/user-attachments/assets/0facf3f8-8171-4094-8d3a-614b29820dbd" />
