### PR TITLE
Update Success Criteria for ITP Structuring-Data module

### DIFF
--- a/org-cyf-itp/content/structuring-data/success/index.md
+++ b/org-cyf-itp/content/structuring-data/success/index.md
@@ -6,9 +6,11 @@ emoji= '✅'
 menu_level = ['module']
 weight = 11
 [[objectives]]
-1="Complete the [Intro to Python course](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/21)"
-2="Link to your exercises for the [Coursework Exercises](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/6) - they must have been reviewed and must be labelled Complete by a volunteer"
-3="Link to your [Written Email for an Internship](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/20)"
+1="Screenshot showing you finished the **Intro to Python** section of the [Code In Place course](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/21)"
+2="Link to your PR for your [Sprint 1 Coursework](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/35)"
+3="Link to your PR for your [Sprint 2 Coursework](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/7)"
+4="Link to your PR for your [Sprint 3 Coursework](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/6)"
+5="Link to your [Written Email for an Internship](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/449)"
 +++
 
 ### 🎯 You've achieved your learning objectives if you can:
@@ -35,4 +37,6 @@ weight = 11
 
 ## ✅ To complete _this_ module, you must:
 
-Submit the following items to complete this module on the CYF Dashboard:
+Note: Any PRs you're submitting must have been reviewed and labelled "Complete" by a volunteer.
+
+In your Coursework Planner repo, create an issue with the following, and submit the link to Step 2 of ITP on the [CYF Course Platform](https://application-process.codeyourfuture.io/):


### PR DESCRIPTION
## What does this change?

The Success criteria for module "Structuring and Testing Data".
1. Include Sprint 1 and Sprint 2 Coursework Exercises (before the Coursework Exercises only link to Sprint 3's Coursework)
2. State clearly what to submit as evidence when they finished the "Intro to Python" section of the CIP course.

### Org Content?

ITP | Module Structuring and Testing Data | Content | Success 
`org-cyf-itp/content/structuring-data/success`

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?
@CodeYourFuture/curriculum
