### PR TITLE
Rejig Data Groups workshops

### DIFF
--- a/common-content/en/blocks/morning-break/index.md
+++ b/common-content/en/blocks/morning-break/index.md
@@ -10,4 +10,4 @@ hide_from_overview=true
 
 +++
 
-A quick break of fifteen minutes so we can all concentrate on the next piece of work.
+A quick break so we can all concentrate on the next piece of work.

--- a/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/1/day-plan/index.md
@@ -12,13 +12,17 @@ name="Morning orientation"
 src="blocks/morning-orientation"
 time=15
 [[blocks]]
-name="Workshop"
-src="blocks/workshop"
-time="140"
-[[blocks.nested.blocks]]
-    name="Giving Feedback [PD] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/feedback"
-    time=0
+name="Giving Feedback"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/feedback"
+time=60
+[[blocks]]
+name="Morning break"
+src="blocks/morning-break"
+time=20
+[[blocks]]
+name="Arrays"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/feedback"
+time=60
 [[blocks]]
 name="lunch"
 src="blocks/lunch"

--- a/org-cyf-itp/content/data-groups/sprints/2/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/2/day-plan/index.md
@@ -12,17 +12,17 @@ name="Morning orientation"
 src="blocks/morning-orientation"
 time=15
 [[blocks]]
-name="Workshop"
-src="blocks/workshop"
-time="140"
-  [[blocks.nested.blocks]]
-    name="Objects [Tech] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/objects"
-    time=0
-  [[blocks.nested.blocks]]
-    name="Debugging 2 [Tech] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/debugging-2"
-    time=0
+name="Objects"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/objects"
+time=60
+[[blocks]]
+name="Morning break"
+src="blocks/morning-break"
+time=20
+[[blocks]]
+name="Debugging"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/debugging"
+time=60
 [[blocks]]
 name="lunch"
 src="blocks/lunch"

--- a/org-cyf-itp/content/data-groups/sprints/3/day-plan/index.md
+++ b/org-cyf-itp/content/data-groups/sprints/3/day-plan/index.md
@@ -12,17 +12,17 @@ name="Morning orientation"
 src="blocks/morning-orientation"
 time=15
 [[blocks]]
-name="Workshop"
-src="blocks/workshop"
-time="140"
-  [[blocks.nested.blocks]]
-    name="DOM merge conflict [Tech] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/dom-merge-conflict"
-    time=0
-    [[blocks.nested.blocks]]
-    name="Interviewing practice [PD] (60 Mins)"
-    src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/interviewing"
-    time=0
+name="DOM merge conflict"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/dom-merge-conflict"
+time=60
+[[blocks]]
+name="Morning break"
+src="blocks/morning-break"
+time=20
+[[blocks]]
+name="Interviewing practice"
+src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/interviewing"
+time=60
 [[blocks]]
 name="lunch"
 src="blocks/lunch"


### PR DESCRIPTION
* Have two 60-minute workshops, rather than a 140 minute section with two 60-minute options. We know people won't necessarily get through them all - it may be better to just choose one and give it two hours, but right now "Spend 60 minutes but have a block for 140" is confusing.
* Pull Arrays workshop into the Arrays sprint.
* Use non-DOM debugging workshop in the sprint when the DOM hasn't yet been covered.

I've adjusted the prep to include the prereq reading where appropriate.