### PR TITLE
Fix broken guides links in 2 README files sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Each org or team configures its own Hugo site that mounts the common theme and c
 - https://projects.codeyourfuture.io/
 - https://workshops.codeyourfuture.io/
 - https://programming.codeyourfuture.io/
+- https://curriculum.codeyourfuture.io/guides/
 - https://launch.codeyourfuture.io/
 - https://piscine.codeyourfuture.io/
 - https://sdc.codeyourfuture.io/

--- a/org-cyf-guides/README.md
+++ b/org-cyf-guides/README.md
@@ -1,6 +1,7 @@
 # Code Your Future Curriculum GUIDES MODULE
 
-https://guides.codeyourfuture.io/
+<!-- https://guides.codeyourfuture.io/ -->
+https://curriculum.codeyourfuture.io/guides/
 
 This is a Hugo Module. You can mount this module in your Hugo site by adding it to your `config.toml` file:
 


### PR DESCRIPTION
## What does this change?

<!-- Add a description of what your PR changes here -->
This PR changes a block on the 2 README pages :

- Added guides link `https://guides.codeyourfuture.io/` in the Examples section
- Fixed broken link `https://guides.codeyourfuture.io/` with working link `https://curriculum.codeyourfuture.io/guides/` in `org-cyf-guides` folder

Fixes #1319


### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #1319 

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Block Type

## Checklist

- [X] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [X] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [X] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [X] I have run my code to check it works
- [X] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
@mbadrawy1 @chinar-amrutkar 
