### PR TITLE
feat: add GitHub edit and issue buttons to curriculum pages (#552)

### DIFF
--- a/common-theme/layouts/_default/baseof.html
+++ b/common-theme/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]>      <html class="no-js"> <!<![endif]-->
+<!--[if gt IE 8]>      <html class="no-js"> <![endif]-->
 <html lang="en" class="p-{{ (.Layout | default .Kind ) | urlize | lower }}">
   {{- partial "head.html" . -}}
   <body>
@@ -15,7 +15,18 @@
         class="l-layout__main l-main"
         tabindex="0"
         data-pagefind-body>
+        
         {{ block "main" . }}{{ end }}
+
+        <!-- 📝 GitHub Edit & Issue Links -->
+        <div style="margin-top: 2rem; text-align: right; font-size: 0.95em;">
+          <a href="https://github.com/CodeYourFuture/curriculum/edit/main/{{ .File.Path }}" target="_blank" style="margin-right: 1em;">
+            📝 Edit this page on GitHub
+          </a>
+          <a href="https://github.com/CodeYourFuture/curriculum/issues/new?title=Issue%20with%20{{ .File.Path }}&body=Describe%20the%20problem..." target="_blank">
+            🐛 Open an issue for this page
+          </a>
+        </div>
 
         {{ partial "page-footer.html" . }}
       </main>


### PR DESCRIPTION
Fixes #552

Added two helpful links at the bottom of each curriculum page:
1)"Edit this page on GitHub"
2)"Open an issue for this page"

This makes it easier for contributors to propose changes or report problems.
