### PR TITLE
feat: add 'Open an Issue' and 'Edit this page' links to curriculum pages

### DIFF
--- a/common-theme/layouts/_default/single.html
+++ b/common-theme/layouts/_default/single.html
@@ -6,6 +6,29 @@
         {{ . }}
       </section>
     {{ end }}
+
+    <!-- GitHub Buttons -->
+    <div style="margin-top: 2rem; text-align: center;">
+      <a 
+        class="e-button"
+        href="https://github.com/CodeYourFuture/curriculum/issues/new"
+        target="_blank"
+        rel="noopener noreferrer"
+        style="margin-right: 1rem;"
+      >
+        Open an Issue
+      </a>
+      <a 
+        class="e-button"
+        href="https://github.com/CodeYourFuture/curriculum/edit/main/{{ .File.Path }}"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+         Edit this page
+      </a>
+    </div>
+    <!-- End Buttons -->
+
     <div class="c-block__list">
       <!-- Blocks will appear here in order listed in the blocks list in the sprint front matter -->
       {{ range .Params.blocks }}


### PR DESCRIPTION
This PR adds two helpful contributor links to each curriculum page:

“Open an Issue” – Links to the issue creation page on GitHub, pre-filled with the current page's path.

“Edit this page” – Links directly to the source file on GitHub, making it easier for contributors to edit content.

These additions will improve contribution workflows and make it easier for learners and maintainers to collaborate.