### PR TITLE
Fix: Center horizontal rules (---) in backlog pages

### DIFF
--- a/common-theme/layouts/partials/head.html
+++ b/common-theme/layouts/partials/head.html
@@ -72,4 +72,6 @@
   <link rel="shortcut icon" href="{{ .Site.BaseURL }}favicon.ico" />
   <meta name="theme-color" content="#e3ddeef2" />
   <link rel="manifest" href="{{ .Site.BaseURL }}manifest.json" />
+  <link rel="stylesheet" href="/css/custom.css" /> 
+
 </head>

--- a/common-theme/static/css/custom.css
+++ b/common-theme/static/css/custom.css
@@ -1,0 +1,5 @@
+hr {
+  margin-left: auto;
+  margin-right: auto;
+  width: 80%;
+}


### PR DESCRIPTION
This pull request fixes the issue where horizontal rules (`<hr>` tags rendered from `---` in markdown) were not centered on backlog pages.

✅ What I did:
- Created a new CSS file (`custom.css`) under `static/css/`
- Added a rule to center all `<hr>` elements and set their width to 80%
- Linked this CSS file from the `head.html` partial in the `common-theme` so it's applied globally

📌 This resolves Issue #1061.

The visual alignment now looks more consistent and readable across backlog pages. No other content or logic is affected.

