### PR TITLE
Centralise env vars into a config file

### DIFF
--- a/tooling/common-config/netlify.toml
+++ b/tooling/common-config/netlify.toml
@@ -2,14 +2,24 @@
 ignore = "exit 1" #always build on PR even if you can't detect changes in this folder
 publish = "public"
 command = "./deploy-netlify.sh"
+
+[build.environment]
+  GO_VERSION = "1.21.3"
+  HUGO_VERSION = "0.136.3"
+  NODE_VERSION = "20"
+  NPM_FLAGS = "--legacy-peer-deps"
+
+
 [dev]
 framework = "hugo"
 targetPort = 3000
 command = "hugo server -p 3000"
+
 [[redirects]]
 from = "/api/*"
 to = "/.netlify/functions/:splat"
 status = 200
+
 [functions]
 external_node_modules = ["node-fetch"]
 


### PR DESCRIPTION
Currently these are manually configured in each site in netlify, which is fiddly to maintain.