### PR TITLE
fix typo in LSOF

### DIFF
--- a/common-content/en/module/tools/process-spelunking/index.md
+++ b/common-content/en/module/tools/process-spelunking/index.md
@@ -275,7 +275,7 @@ Use what you learned in the previous exercise, to find the *PID* of this program
 Now run `lsof -p 1234` (replace 1234 with the *PID* of the program).
 The `-p` flag tells `lsof` that we're only interested in the files opened by that process; without that option `lsof` will show everything that it can show.
 
-Can you find the FD of the `exercise_2.py` file?
+Can you find the FD of the `exercise_2_file.txt` file?
 
 ===[[Answer]]===
 If I run `lsof` on the program, I see this.
@@ -306,6 +306,8 @@ python3 65262 ariane    3r   REG  253,0        0  262147 /home/ariane/programmin
 The *FD* column says `3r`.
 This means the file is on *FD* 3.
 (The `r` suffix, means it is opened for reading.)
+
+Note that the file `exercise_2.py` does not appear in the list because, by the time lsof is executed, Python has already read its contents into memory and no longer holds an open file descriptor.
 {{</tabs>}}
 
 ### Standard Input, Output, and Error


### PR DESCRIPTION
## What does this change?

The content of the tutorial on LSOF
### Org Content?

Module | Sprint | Page Type
Tools | Sprint 3 | Index
<img width="856" height="266" alt="Screenshot 2025-07-26 at 11 08 51" src="https://github.com/user-attachments/assets/8b098bd2-71e4-407a-8d3b-9e5ceca86896" />

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

spotted by @OracPrime 
