### PR TITLE
ITP: Link to Piscine instead of mounting it

### DIFF
--- a/common-theme/layouts/partials/card.html
+++ b/common-theme/layouts/partials/card.html
@@ -1,5 +1,9 @@
-{{ $BaseURL := .Page.Parent.Permalink }}
-<a class="c-card" href="{{ relURL .Page.RelPermalink }}">
+{{ $url := relURL .Page.RelPermalink }}
+{{ if .Page.Params.external_url }}
+{{ $url = .Page.Params.external_url }}
+{{ end }}
+
+<a class="c-card" href="{{ $url }}">
   <h3 class="c-card__title">{{ .Name }}</h3>
   {{ with .Page.Description }}
     <p class="c-card__description">{{ . }}</p>

--- a/org-cyf-itp/content/piscine/index.md
+++ b/org-cyf-itp/content/piscine/index.md
@@ -1,0 +1,7 @@
++++
+title = 'Piscine'
+description = 'In teams and on your own, build working software with tests. Explain your work to others.'
+emoji= '🐠'
+menu = ['next steps']
+external_url = "https://piscine.codeyourfuture.io"
++++

--- a/org-cyf-itp/hugo.toml
+++ b/org-cyf-itp/hugo.toml
@@ -5,11 +5,6 @@ baseURL = "https://programming.codeyourfuture.io/"
   [[module.imports]]
     path = "github.com/CodeYourFuture/curriculum/org-cyf-theme"
   [[module.imports]]
-    path = "github.com/CodeYourFuture/curriculum/org-cyf-piscine"
-    [[module.imports.mounts]]
-      source = "content"
-      target="content/piscine"
-  [[module.imports]]
     path = "github.com/CodeYourFuture/curriculum/org-cyf-guides" 
     [[module.imports.mounts]]
       source = "content"


### PR DESCRIPTION
Currently the mounting means that site-specific overrides (e.g. the application form) don't get overridden.

We really just want a link here.