### PR TITLE
Tweaks to SDC front page

### DIFF
--- a/org-cyf-sdc/content/_index.md
+++ b/org-cyf-sdc/content/_index.md
@@ -1,7 +1,7 @@
 +++
 title="Software Development Course"
-menus_to_map=["start here", "SDC", "tracks"]
-description="Course began [📅 March 2025](https://curriculum.codeyourfuture.io)."
+menus_to_map=["start here", "SDC"]
+description="Practical, employment-focused training in foundational software concepts."
 emoji= "🧑🏾‍🔧" 
 +++
 

--- a/org-cyf-sdc/content/overview/_index.md
+++ b/org-cyf-sdc/content/overview/_index.md
@@ -2,6 +2,7 @@
 title="Course overview"
 layout="overview"
 overview_menu='SDC'
+menus = ["start here"]
 +++
 
 ## Objective


### PR DESCRIPTION
* Hide tracks menu, it's empty and not useful.
* Add a meaningful sub-title to the course page.
* Link to the Overview on the front page.