### PR TITLE
Add /calendar redirect

### DIFF
--- a/org-cyf/content/_index.md
+++ b/org-cyf/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title="Our Courses"
 menus_to_map=["start here", "selection", "trainees", "fellowships"]
-description="Free training for good jobs in tech [📅 2025](https://docs.google.com/spreadsheets/d/1yI0msIwe8qYn2Nv9WPLwFMTM_Td0TtPvlv17u3B8sS8/edit)"
+description="Free training for good jobs in tech [📅 2025](/calendar)"
 emoji= "🧑🏿‍🏫👨🏽‍🎓"
 +++

--- a/tooling/common-config/netlify.toml
+++ b/tooling/common-config/netlify.toml
@@ -20,6 +20,11 @@ from = "/api/*"
 to = "/.netlify/functions/:splat"
 status = 200
 
+[[redirects]]
+from = "/calendar"
+to = "https://docs.google.com/spreadsheets/d/1yI0msIwe8qYn2Nv9WPLwFMTM_Td0TtPvlv17u3B8sS8/edit?gid=0#gid=0"
+status = 302
+
 [functions]
 directory = "tooling/netlify/functions"
 external_node_modules = ["node-fetch"]


### PR DESCRIPTION
Rather than needing to know a Google Doc link, this allows going to https://curriculum.codeyourfuture.io/calendar