### PR TITLE
Port CV checklist over from the portfolio module

### DIFF
--- a/org-cyf-guides/content/employability/cvs/checklist/index.md
+++ b/org-cyf-guides/content/employability/cvs/checklist/index.md
@@ -1,0 +1,34 @@
+---
+title: Checklist
+description: Things to check before sending a CV
+emoji: 📝
+weight: 4
+---
+
+Things to check in your CV before sending it to an employer:
+
+* [ ] There are no spelling or grammar errors (confirm this using[ Grammarly](https://www.grammarly.com/grammar-check) or any other AI grammar tool).
+* [ ] It is at most 2 pages long.
+* [ ] There is only one column of text throughout.
+* [ ] There are no pictures.
+* [ ] Includes contact details: mobile number, e-mail address, LinkedIn.
+* [ ] It avoids personal pronouns (e.g. I, me, my).
+* [ ] Written in relevant tenses (i.e. past tense for past experiences, present tense for any project/role they are still working on).
+* [ ] The summary does not contain any clichés or buzzwords without a supporting statement:
+  * [ ] For example, do not accept "good team worker" by itself.
+  * [ ] But you may accept "good team worker with experience of …", "good team worker as shown by …", etc.
+* [ ] Includes a project in the experience section.
+  * [ ] Includes a technical description of what was developed / what they did.
+  * [ ] Includes the goal/benefit of that project.
+* [ ] Includes at least 12 bullet points in total in the experience section such that:
+  * [ ] For example, if they mentioned 3 different projects/roles, 4 bullet points for each would be acceptable because it totals to 12.
+    * Each bullet point is in the past tense, unless it refers to an ongoing role or project.
+    * Each bullet point begins with an active verb.
+    * Benefits of each bullet point (or at least the first bullet point) are quantified, so include numbers of cost reduction, number of users, etc.
+  * [ ] Clearly details experiences from education (what they learned, covered that is relevant to the role).
+  * [ ] Is tailored to the role:
+    * [ ] Mentions actions that are relevant to at least one of the main responsibilities.
+    * [ ] Mention the key technologies of the job description on every opportunity.
+    * [ ] Focus on the essential skills of the role.
+* Is consistently formatted:
+  * e.g. Uses the same fonts, font sizes, spacings between words, spacings between sections, etc.


### PR DESCRIPTION
In #cyf-profile-review there's currently a "temporary" link to the portfolio module. Pull this into the core shared guide.

(Taken from
https://module-graduates.codeyourfuture.io/further-activities/cv-and-job-prep/cv and lightly edited)