### PR TITLE
Tweaks to welcome sprint

### DIFF
--- a/common-content/en/module/fundamentals/next-steps/index.md
+++ b/common-content/en/module/fundamentals/next-steps/index.md
@@ -27,12 +27,10 @@ Pair up with a new person. In pairs, complete the following tasks:
 > If you're unsure about the answer to any of the questions below, start a thread in Slack to clarify the answer (unless there is already a thread discussing this matter).
 
 1. Starting from the home page of this website, locate the success page for the next module. Have you already achieved any of the learning objectives?
-1. Starting from the home page of this website, locate the prep page for the next module, and the prep page for sprint 1 of the next module.
-1. List the things you need to install (if anything) for the upcoming module.
+1. Starting from the home page of this website, locate the prep page for sprint 1 of the next module.
+1. List the things you need to install (if anything) for sprint 1 of the upcoming module.
 1. Check you can find the backlog page for the next sprint.
-1. Double check you've copied all the issues from the backlog over to your Course Planner (There are instructions for setting up your Course Planner in the prep).
 1. When should you start the prep work for the upcoming module?
-1. Experiment with your project planner: can you filter by Size, Sprint, or other fields?
 
 ## For volunteers
 

--- a/common-content/en/module/induction/accounts/index.md
+++ b/common-content/en/module/induction/accounts/index.md
@@ -69,7 +69,7 @@ Your cohort is your first network, and this is one of the most valuable things y
 [Slack](https://slack.com/intl/en-gb) is our community space and how we communicate with each other. Download and install it now. If you are not using your own computer, log in to the web version instead.
 
 - [ ] I have downloaded the [Slack](https://slack.com/intl/en-gb) app on my computer and phone.
-- [ ] I have logged in to the {{<our-name>}} workspace.
+- [ ] I have logged in to the {{<our-name>}} ITP workspace.
 - [ ] I have found and joined my class channels.
 - [ ] I have updated my profile with my picture, my professional email address, my GitHub username, my Linkedin profile and my class.
 - [ ] I have introduced myself on Slack.

--- a/common-content/en/module/onboarding/goals/index.md
+++ b/common-content/en/module/onboarding/goals/index.md
@@ -14,11 +14,11 @@ objectives = [
   publishResources = false
 +++
 
-You have joined us as a Learner. Your overall goal for this module is to understand how to succeed at the ITP course.
+You have joined us as a trainee. Your overall goal for this module is to understand how to succeed at the ITP course.
 
-To demonstrate you know how to succeed at the course, you should apply to enroll as a Trainee within the next three weeks. To do this, you will need to do show up every week, learn, get work done, and get your work reviewed.
+To demonstrate you know how to succeed at the course, you should apply to enrol as a Trainee within the next three weeks. To do this, you will need to do show up every week, learn, get work done, and get your work reviewed.
 
-If eligible, you should enrol as a Trainee within the next three weeks. _If you do not enrol as a trainee by week 6 of this course, you will be removed from it. You can request to restart in the next ITP course._
+You should enrol as a Trainee within the next three weeks. _If you do not enrol as a trainee by week 6 of this course, you will be removed from it. You can request to restart in the next ITP course._
 
 > 🎯 Complete onboarding and enrol as a Trainee
 
@@ -30,7 +30,7 @@ This formal structure might be new to you. **It is a way to help you evaluate fo
 
 As we are just meeting this idea, let's go over them here too. The skills you'll learn in this module are based around these themes: version control, requirements and testing, code review, data, and scientific method. Write each of these themes down in your notebook.
 
-To complete the module, you will need to demonstrate you have learnt these skills, and apply to enroll as a Trainee.
+To complete the module, you will need to demonstrate you have learnt these skills, and apply to enrol as a Trainee.
 
 #### Version control
 
@@ -52,6 +52,6 @@ _By the end of this module_ you will have manipulated data with HTML, Git, and G
 
 _By the end of this module_ you will have written and asked well-structured developer questions. Your goal is to build a strategy to methodically solve problems.
 
-#### Enrollment
+#### Enrolment
 
 _By the end of this module_ you will have enrolled as a Trainee. Your goal is to complete the onboarding process and enrol as a Trainee.

--- a/common-content/en/module/onboarding/notes/index.md
+++ b/common-content/en/module/onboarding/notes/index.md
@@ -1,0 +1,16 @@
++++
+title = "Notes"
+time = 5
+[build]
+  render = "never"
+  list = "local"
+  publishResources = false
++++
+
+Writing information down helps you learn.
+
+Writing helps you process what you're reading more than just reading it. Keeping notes also gives you a reference you can check. It can also help you plan, and remember to come back to things.
+
+The curriculum will often tell you to write something in your notebook. You can do this however you want - on paper in a physical notebook, in a Google Doc, in a specialised application like [Obsidian](https://obsidian.md/), or however works for you.
+
+We recommend you keep notes as you go through the course and learn.

--- a/org-cyf-itp/content/welcome/day-plan/index.md
+++ b/org-cyf-itp/content/welcome/day-plan/index.md
@@ -1,5 +1,5 @@
 +++
-title = 'day plan'
+title = 'Day Plan'
 layout = 'day-plan'
 description='The agenda and activities for our first day together'
 emoji= '🧑🏾‍🤝‍🧑🏾'

--- a/org-cyf-itp/content/welcome/prep/index.md
+++ b/org-cyf-itp/content/welcome/prep/index.md
@@ -10,6 +10,9 @@ weight = 1
 name="Application"
 src="module/onboarding/application"
 [[blocks]]
+name="Notes"
+src="module/onboarding/notes"
+[[blocks]]
 name="Goals"
 src="module/onboarding/goals"
 [[blocks]]

--- a/org-cyf-itp/content/welcome/success/index.md
+++ b/org-cyf-itp/content/welcome/success/index.md
@@ -1,5 +1,5 @@
 +++
-title = 'success'
+title = 'Success'
 description = 'How do we know if we have completed day one successfully?'
 layout = 'success'
 emoji= '✅'
@@ -9,7 +9,7 @@ objectives = [[
   "Come to class.",
   "Name 5 people in your class.",
   "Have a plan for how to make progress, and how to get help.",
-  "Find and begin your prep for the Onboarding Module (both the module prep, and the first sprint prep).",
+  "Find and begin your prep for the first sprint of the Onboarding Module.",
 ]]
 +++
 


### PR DESCRIPTION
* Remove references to module prep, it's gone
* Add an introduction to the idea of taking notes, and what "write this in your notebook" later in the course will mean.
* Remove the course-planner related tasks from the welcome sprint - setting this up is part of Onboarding not Welcome.
* Minor wording tweaks