### PR TITLE
Require Codewars username in Step 1

### DIFF
--- a/org-cyf-itp/content/onboarding/success/index.md
+++ b/org-cyf-itp/content/onboarding/success/index.md
@@ -40,6 +40,7 @@ weight = 11
 1. On the issue, add:
    - A link to your _completed_ pull request for "[Wireframe to Web Code](https://github.com/CodeYourFuture/Module-Onboarding/issues/17)".
    - A link to your _completed_ pull request for "[Form Controls](https://github.com/CodeYourFuture/Module-Onboarding/issues/19)".
+   - Your Codewars username which you created when you [joined Codewars](https://github.com/CodeYourFuture/Module-Onboarding/issues/39).
 1. Submit the issue link to step 1 of ITP on [CYF Course Portal](https://application-process.codeyourfuture.io/).
 1. **[Apply to enroll as a Trainee](https://forms.gle/vRuofa7aeL5DsbhGA)**.
 


### PR DESCRIPTION
Trainees are meant to sign up to Codewars in the Onbaording module, and start doing it in Structuring and Testing Data.

In my experience, trainees who are behind often have never signed up to Codewars.

Require that they sign up for step 1. We will probably also start requiring that they have done a certain number of kata as part of subsequent steps.

I have already edited the backlog ticket for Step 1 to indicate this.