### PR TITLE
Fix multiple choice click capturing

### DIFF
--- a/common-theme/layouts/partials/multiple-choice.html
+++ b/common-theme/layouts/partials/multiple-choice.html
@@ -35,7 +35,6 @@
           <li class="c-quiz__answer">
             <label
               class="c-quiz__label"
-              for="answer-{{ $index }}"
               ><input
               class="c-quiz__input"
               type="radio"

--- a/common-theme/layouts/partials/multiple-choice.html
+++ b/common-theme/layouts/partials/multiple-choice.html
@@ -38,7 +38,6 @@
               ><input
               class="c-quiz__input"
               type="radio"
-              id="answer-{{ $index }}"
               name="answer"
               value="{{ $index }}" />
             {{ $answer | markdownify}}</label


### PR DESCRIPTION
## What does this change?

Different quizzes in the same page apparently share the same ID space for labels, even though they're in separate shadow roots.

Fortunately, the `<input>` tags are nested inside the `<label>` tags, so the `for` attribute isn't necessary, they implicitly bind to their contained tag.

So removing the `for` attribute here preserves the desired behaviour, while removing the confusion of which element is being targeted.

### Common Theme?

- [x] `common-theme/layouts/partials/multiple-choice.html`

Fixes #1410