### PR TITLE
Update register module name for Welcome module

### DIFF
--- a/common-theme/layouts/_default/day-plan.html
+++ b/common-theme/layouts/_default/day-plan.html
@@ -24,7 +24,11 @@
           {{ range seq $parentsToTraverseToModule }}
             {{ $moduleSection = $moduleSection.Parent }}
           {{ end }}
-          {{ partial "register-attendance.html" (dict "course" site.Title "module" $moduleSection.Title "day" $.Page.CurrentSection.Title) }}
+          {{ $module := $moduleSection.Title }}
+          {{ with $moduleSection.Params.moduleForRegister }}
+            {{ $module = . }}
+          {{ end }}
+          {{ partial "register-attendance.html" (dict "course" site.Title "module" $module "day" $.Page.CurrentSection.Title) }}
         {{ end }}
         {{ range $index, $block := .Params.blocks }}
 

--- a/org-cyf-itp/content/welcome/_index.md
+++ b/org-cyf-itp/content/welcome/_index.md
@@ -6,4 +6,5 @@ emoji= '🫶🏽'
 menu = ['syllabus', 'course schedule']
 weight='1'
 parentsToTraverseToModule = 0
+moduleForRegister = "Welcome"
 +++


### PR DESCRIPTION
We want to use consistent names across different systems - calling this Welcome not "Welcome to Code Your Future" is useful for this.