### PR TITLE
Fix dotted underline link issue for old Safari

### DIFF
--- a/common-theme/assets/styles/03-elements/links.scss
+++ b/common-theme/assets/styles/03-elements/links.scss
@@ -9,8 +9,10 @@ a:link:not([class]),
 a:visited:not([class]),
 .e-link {
   color: currentColor;
-  text-decoration: dotted underline;
-
+  text-decoration: underline;            /* fallback for old Safari */
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  
   @include on-event {
     text-decoration: underline;
     outline: none;


### PR DESCRIPTION
## What does this change?

Some ITD participants using Safari could not see the dotted underline on links in the ITD Curriculum page.
This change should fix the problem.

### Common Theme?

- [x] Yes

### Org Content?

- [x] I have run my code to check it works (with help from a ITD participant)


## Who needs to know about this?
@kfklein15 @illicitonion 

