### PR TITLE
Add backlog to Welcome sprint

### DIFF
--- a/org-cyf-itp/content/welcome/backlog/index.md
+++ b/org-cyf-itp/content/welcome/backlog/index.md
@@ -1,0 +1,10 @@
++++
+title = "Backlog"
+description = "Tasks to attempt before coming to class"
+layout = "backlog"
+emoji= "🏷️"
+menu_level = ["module"]
+weight = 2
+backlog = "Module-Welcome"
+backlog_filter = "📅 Sprint 1"
++++


### PR DESCRIPTION
We try to use the Welcome sprint as an example of how all sprints work.

But not having a backlog makes it unusual, and means it's a bad example.

Add a backlog with a couple of useful tasks to do before the welcome day.