### PR TITLE
fix double word in sdc tools sprint3 prep

### DIFF
--- a/common-content/en/module/tools/nodejs/index.md
+++ b/common-content/en/module/tools/nodejs/index.md
@@ -9,7 +9,7 @@ objectives = [
 ]
 +++
 
-We know that that JavaScript is an interpreted language. Running it needs some interpreter to read our lines of code and execute them.
+We know that JavaScript is an interpreted language. Running it needs some interpreter to read our lines of code and execute them.
 
 We've already seen that web browsers can run JavaScript. Web browsers provide a runtime environment for JavaScript. 
 


### PR DESCRIPTION
## What does this change?

Duplicate word in prep text

### Common Content?

- [x] Block/s

### Common Theme?

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: no issue number, this is technically a typo

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Module | Sprint | Page Type | Block Type
SDC | sprint 3 | module index page (index.md) | N/A

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

