### PR TITLE
Pull down list-with-class stylings

### DIFF
--- a/common-theme/assets/scripts/label-items.js
+++ b/common-theme/assets/scripts/label-items.js
@@ -20,9 +20,6 @@ class LabelItems extends HTMLElement {
 
   render() {
     this.shadowRoot.innerHTML = `
-    <style>
-    .c-quiz { display: grid;gap: var(--theme-spacing--gutter)}
-    </style>
       <section class="c-quiz">
         <slot name="labels"></slot>
         <slot name="heading"></slot>

--- a/common-theme/assets/styles/03-elements/lists.scss
+++ b/common-theme/assets/styles/03-elements/lists.scss
@@ -1,6 +1,4 @@
-ul[class],
-ol[class],
-li[class] {
+%list-without-list-formatting {
   padding: 0;
   margin: 0;
   list-style: none;
@@ -8,6 +6,8 @@ li[class] {
 
 ul.e-list,
 ol.e-list {
+  padding: 0;
+  list-style: none;
   margin: revert;
   line-height: 1.5;
 }

--- a/common-theme/assets/styles/04-components/block.scss
+++ b/common-theme/assets/styles/04-components/block.scss
@@ -1,3 +1,7 @@
+ul.c-block, ol.c-block, li.c-block {
+  @extend %list-without-list-formatting;
+}
+
 .c-block {
   scroll-snap-align: start;
   background-color: var(--theme-color--paper-fade);

--- a/common-theme/assets/styles/04-components/breadcrumbs.scss
+++ b/common-theme/assets/styles/04-components/breadcrumbs.scss
@@ -1,5 +1,6 @@
 .c-breadcrumbs {
   &__list {
+    @extend %list-without-list-formatting;
     display: flex;
     align-items: center;
     gap: var(--theme-spacing--1);
@@ -34,5 +35,9 @@
   &__icon {
     height: 1em;
     min-width: 6px;
+  }
+
+  &__item {
+    @extend %list-without-list-formatting;
   }
 }

--- a/common-theme/assets/styles/04-components/chip.scss
+++ b/common-theme/assets/styles/04-components/chip.scss
@@ -18,6 +18,9 @@
       clip: circle();
     }
   }
+  &__list {
+    @extend %list-without-list-formatting;
+  }
   @include on-event() {
     .c-chip__title {
       text-decoration: underline;

--- a/common-theme/assets/styles/04-components/columns.scss
+++ b/common-theme/assets/styles/04-components/columns.scss
@@ -1,5 +1,9 @@
 // put anything side by side
 
+ol.c-columns {
+  @extend %list-without-list-formatting;
+}
+
 .c-columns {
   display: grid;
   gap: var(--theme-spacing--gutter);

--- a/common-theme/assets/styles/04-components/contributor.scss
+++ b/common-theme/assets/styles/04-components/contributor.scss
@@ -1,5 +1,6 @@
 .c-contributors,
 ol.c-contributors {
+  @extend %list-without-list-formatting;
   display: flex;
   flex-flow: row wrap;
   gap: var(--theme-spacing--3) var(--theme-spacing--2);
@@ -7,6 +8,7 @@ ol.c-contributors {
   max-width: none;
 }
 .c-contributor {
+  @extend %list-without-list-formatting;
   flex: 0 1 auto;
   display: grid;
   @include grid-assign(avatar, name, commits);

--- a/common-theme/assets/styles/04-components/issue.scss
+++ b/common-theme/assets/styles/04-components/issue.scss
@@ -18,12 +18,14 @@
   }
 
   &__labels {
+    @extend %list-without-list-formatting;
     display: flex;
     flex-flow: row wrap;
     gap: var(--theme-spacing--1);
   }
   &__label,
   &__button {
+    @extend %list-without-list-formatting;
     background: var(--github);
     font: 600 var(--theme-type-size--6) system-ui;
     border: 1px solid;

--- a/common-theme/assets/styles/04-components/label.scss
+++ b/common-theme/assets/styles/04-components/label.scss
@@ -1,5 +1,6 @@
 //styled after github labels
 .c-label {
+  @extend %list-without-list-formatting;
   background: var(--color);
   font: 600 var(--theme-type-size--6) system-ui;
   border: 1px solid;
@@ -22,6 +23,7 @@
     }
   }
   &__list {
+    @extend %list-without-list-formatting;
     display: flex;
     flex-flow: row wrap;
     gap: var(--theme-spacing--1);

--- a/common-theme/assets/styles/04-components/list.scss
+++ b/common-theme/assets/styles/04-components/list.scss
@@ -1,0 +1,3 @@
+.c-list__item {
+    @extend %list-without-list-formatting;
+}

--- a/common-theme/assets/styles/04-components/logos.scss
+++ b/common-theme/assets/styles/04-components/logos.scss
@@ -1,5 +1,6 @@
 .c-logos,
 ul.c-logos {
+  @extend %list-without-list-formatting;
   padding: var(--theme-spacing--4) 0 var(--theme-spacing--6);
   display: flex;
   flex-flow: row wrap;
@@ -9,6 +10,7 @@ ul.c-logos {
   max-width: none;
 
   &__item {
+    @extend %list-without-list-formatting;
     max-width: 200px;
     flex: 1 1 auto;
   }

--- a/common-theme/assets/styles/04-components/map.scss
+++ b/common-theme/assets/styles/04-components/map.scss
@@ -18,12 +18,17 @@
   }
 
   &__timeline {
+    @extend %list-without-list-formatting;
     display: grid;
     gap: var(--theme-spacing--gutter);
   }
   &__start {
     position: absolute;
     left: 0;
+  }
+
+  &__stop {
+    @extend %list-without-list-formatting;
   }
 
   &__stop,

--- a/common-theme/assets/styles/04-components/objectives.scss
+++ b/common-theme/assets/styles/04-components/objectives.scss
@@ -5,6 +5,12 @@
   &__title {
     margin-bottom: 0;
   }
+  &__item {
+    @extend %list-without-list-formatting;
+  }
+  &__list {
+    @extend %list-without-list-formatting;
+  }
 }
 
 // markdown checklist we are trying to hijack from gfm

--- a/common-theme/assets/styles/04-components/overview.scss
+++ b/common-theme/assets/styles/04-components/overview.scss
@@ -6,6 +6,10 @@
   padding: var(--gap) var(--gap) var(--gap) 0;
   max-width: var(--theme-spacing--linelength);
 
+  &__list {
+    @extend %list-without-list-formatting;
+  }
+
   &__module {
     font-weight: 600;
     color: var(--theme-color--ink);

--- a/common-theme/assets/styles/04-components/quiz.scss
+++ b/common-theme/assets/styles/04-components/quiz.scss
@@ -1,0 +1,8 @@
+.c-quiz {
+    display: grid;
+    gap: var(--theme-spacing--gutter);
+
+    &__answer, &__list {
+        @extend %list-without-list-formatting;
+    }
+}

--- a/common-theme/assets/styles/04-components/timeline.scss
+++ b/common-theme/assets/styles/04-components/timeline.scss
@@ -1,5 +1,6 @@
 .c-timeline,
 [class="c-timeline"] {
+  @extend %list-without-list-formatting;
   --box: var(--theme-spacing--gutter);
   position: relative;
   transform: translateX(var(--box));
@@ -8,6 +9,7 @@
 
   &__entry,
   [class="c-timeline__entry"] {
+    @extend %list-without-list-formatting;
     display: flex;
     align-items: center;
     border-left: var(--theme-border--thick);

--- a/common-theme/assets/styles/layout/menu.scss
+++ b/common-theme/assets/styles/layout/menu.scss
@@ -53,6 +53,10 @@
     min-width: fit-content;
   }
 
+  &__item {
+    @extend %list-without-list-formatting;
+  }
+
   &__link {
     @include on-event {
       text-decoration: underline dotted var(--theme-color--accent);
@@ -71,12 +75,14 @@
   }
 
   &__primary {
+    @extend %list-without-list-formatting;
     display: grid;
     align-self: stretch;
     place-content: center;
   }
 
   &__secondary {
+    @extend %list-without-list-formatting;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-evenly;


### PR DESCRIPTION
Previously we were applying reset styles to all lists or list items which set any class name.

This was quite forceful, and also `ul[class]` was more specific than places (notably, `ul[class]` is more specific than `.foo`) which means it was sometimes hard to override this where different styling was desired.

Instead, pull down the reset stylings to all of the classes this happens to apply to. I tested this with lots of searching for elements and classes across the whole HTML. I am reasonably confident I got them all.

This also pulls some quiz styling out from inline JS into scss so we can do the extending rather than hard-coding an inlining.