### PR TITLE
Only show one logo

### DIFF
--- a/common-theme/layouts/partials/header.html
+++ b/common-theme/layouts/partials/header.html
@@ -6,7 +6,7 @@
           >{{ .Section }} {{ .Title }} {{ site.Title }}</span
         >
         {{ $logos := resources.Match "custom-images/site-logo/*.svg" }}
-        {{ range $logos }}{{ .Content | safeHTML }}{{ end }}
+        {{ (index $logos 0).Content | safeHTML }}
       </a>
     </h1>
     {{ partial "search.html" }}


### PR DESCRIPTION
Previously we were iterating across all logos, which mean that if someone inherited from the common-theme with their own logo, we would awkwardly show them all.

Logos should replace, not combine!