### PR TITLE
Name specific site logos

### DIFF
--- a/common-theme/layouts/partials/header.html
+++ b/common-theme/layouts/partials/header.html
@@ -5,8 +5,12 @@
         ><span class="is-invisible"
           >{{ .Section }} {{ .Title }} {{ site.Title }}</span
         >
-        {{ $logos := resources.Match "custom-images/site-logo/*.svg" }}
-        {{ (index $logos 0).Content | safeHTML }}
+        <span class="is-none--lt-container">
+          {{ (resources.Get "custom-images/site-logo/site-logo.svg").Content | safeHTML }}
+        </span>
+        <span class="is-none--gt-container">
+          {{ (resources.Get "custom-images/site-logo/site-logo-small.svg").Content | safeHTML }}
+        </span>
       </a>
     </h1>
     {{ partial "search.html" }}

--- a/org-cyf-theme/assets/custom-images/site-logo/site-logo-small.svg
+++ b/org-cyf-theme/assets/custom-images/site-logo/site-logo-small.svg
@@ -1,4 +1,4 @@
-<svg class="is-none--gt-container"
+<svg
           xmlns="http://www.w3.org/2000/svg"
           version="1.0"
           viewBox="0 0 512 512"

--- a/org-cyf-theme/assets/custom-images/site-logo/site-logo.svg
+++ b/org-cyf-theme/assets/custom-images/site-logo/site-logo.svg
@@ -1,7 +1,6 @@
 <svg
           xmlns="http://www.w3.org/2000/svg"
           title="Code Your Future."
-          class="is-none--lt-container"
           viewBox="0 0 621.64 155.81"
           width="140px"
           focusable="false"


### PR DESCRIPTION
Before c7f101d53e11df76248752d000678d988518eb71 we always showed all logos. This was problematic if an inheriting site tried to supply logos, as we would show both.

c7f101d53e11df76248752d000678d988518eb71 tried to fix this by just showing one, but that breaks the fact that we have two that are shown differently based on media-query. The SVGs were self-styling with class attributes.

Instead, we always show exactly two, in a container with the relevant class attribute. This means the inheriting site must also supply two logos, and makes that contract explicit.