### PR TITLE
Add Codewars to success criteria of last two ITP modules

### DIFF
--- a/org-cyf-itp/content/data-flows/success/index.md
+++ b/org-cyf-itp/content/data-flows/success/index.md
@@ -33,6 +33,7 @@ weight = 11
 1. Make a new issue on your own Coursework Planner.
    - Follow this template for naming your issue: `<COHORT_NAME> | Data flows | <YOUR_NAME>`
 1. On the issue, add:
+    - Evidence that you have completed **at least 6 katas** in the [Data Flow collection](https://github.com/CodeYourFuture/Module-Data-Flows/issues/35) and **at least 6 katas** in the Array and Object Methods collection.
     - A link to your GitHub repo and deployed Netlify site for the "[TV Show Project](https://github.com/CodeYourFuture/Project-TV-Show)".
     - A link to your level 400 and level 500 pull requests for the "[TV Show Project](https://github.com/CodeYourFuture/Project-TV-Show)", to show both you and your partner contributed.
     - A link to your _completed_ pull request for "[Book Library Project](https://github.com/CodeYourFuture/Module-Data-Flows/issues/31)", where you have responded to review feedback.

--- a/org-cyf-itp/content/data-flows/success/index.md
+++ b/org-cyf-itp/content/data-flows/success/index.md
@@ -33,7 +33,7 @@ weight = 11
 1. Make a new issue on your own Coursework Planner.
    - Follow this template for naming your issue: `<COHORT_NAME> | Data flows | <YOUR_NAME>`
 1. On the issue, add:
-    - Evidence that you have completed **at least 6 katas** in the [Data Flow collection](https://github.com/CodeYourFuture/Module-Data-Flows/issues/35) and **at least 6 katas** in the Array and Object Methods collection.
+    - Evidence that you have completed **at least 6 katas** in the [Data Flows collection](https://github.com/CodeYourFuture/Module-Data-Flows/issues/35) and **at least 6 katas** in the Array and Object Methods collection.
     - A link to your GitHub repo and deployed Netlify site for the "[TV Show Project](https://github.com/CodeYourFuture/Project-TV-Show)".
     - A link to your level 400 and level 500 pull requests for the "[TV Show Project](https://github.com/CodeYourFuture/Project-TV-Show)", to show both you and your partner contributed.
     - A link to your _completed_ pull request for "[Book Library Project](https://github.com/CodeYourFuture/Module-Data-Flows/issues/31)", where you have responded to review feedback.

--- a/org-cyf-itp/content/data-groups/success/index.md
+++ b/org-cyf-itp/content/data-groups/success/index.md
@@ -29,7 +29,7 @@ weight = 11
 1. Make a new issue on your own Coursework Planner.
    - Follow this template for naming your issue: `<COHORT_NAME> | Data groups | <YOUR_NAME>`
 1. On the issue, add:
-    - Evidence that you have completed **at least 6 katas** in the [Data Group collection](https://github.com/CodeYourFuture/Module-Data-Groups/issues/31) and **at least 3 katas** in the [Array and Object Methods collection](https://github.com/CodeYourFuture/Module-Data-Groups/issues/33).
+    - Evidence that you have completed **at least 6 katas** in the [Data Groups collection](https://github.com/CodeYourFuture/Module-Data-Groups/issues/31) and **at least 9 katas in total** in the [Array and Object Methods collection](https://github.com/CodeYourFuture/Module-Data-Groups/issues/33).
     - A link to your _completed_ pull request for "[Alarm Clock App](https://github.com/CodeYourFuture/Module-Data-Groups/issues/26)".
     - A link to your _completed_ pull request for "[Sprint 2 Coursework](https://github.com/CodeYourFuture/Module-Data-Groups/issues/14)".
     - A link to your _completed_ pull request for "[Quote Generator App](https://github.com/CodeYourFuture/Module-Data-Groups/issues/20)".

--- a/org-cyf-itp/content/data-groups/success/index.md
+++ b/org-cyf-itp/content/data-groups/success/index.md
@@ -29,6 +29,7 @@ weight = 11
 1. Make a new issue on your own Coursework Planner.
    - Follow this template for naming your issue: `<COHORT_NAME> | Data groups | <YOUR_NAME>`
 1. On the issue, add:
+    - Evidence that you have completed **at least 6 katas** in the [Data Group collection](https://github.com/CodeYourFuture/Module-Data-Groups/issues/31) and **at least 3 katas** in the [Array and Object Methods collection](https://github.com/CodeYourFuture/Module-Data-Groups/issues/33).
     - A link to your _completed_ pull request for "[Alarm Clock App](https://github.com/CodeYourFuture/Module-Data-Groups/issues/26)".
     - A link to your _completed_ pull request for "[Sprint 2 Coursework](https://github.com/CodeYourFuture/Module-Data-Groups/issues/14)".
     - A link to your _completed_ pull request for "[Quote Generator App](https://github.com/CodeYourFuture/Module-Data-Groups/issues/20)".


### PR DESCRIPTION
## What does this change?

Added Codewars requirements to the Success criteria in the last two modules.

- In Module Data Groups:
  - At least 6 katas in Data Groups collections
  - At least 3 katas in Array and Object Methods collections
  
- In Module Data Flows
  - At least 6 katas in Data Flows collections
  - At least 6 katas  (3 more) in Array and Object Methods collections

I set the requirements to 9 katas per module to match the "3 katas per Sprint" originally suggested in the backlogs.

### Org Content?

Module Data Groups | Success
Module Data Flows | Success 

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?
@illicitonion