### PR TITLE
Update launch demo timings

### DIFF
--- a/org-cyf-launch/content/blocks/interview/index.md
+++ b/org-cyf-launch/content/blocks/interview/index.md
@@ -10,14 +10,14 @@ time = 10
 The interview will consist of:
 
 * An introduction - you should introduce yourself.
-* A project presentation - you are expected to demo a deployed project for about 10 minutes. You should:
+* A project presentation - you are expected to demo a deployed project for about 5 minutes. You should:
   * Introduce the purpose of their project
   * Explain why and how a user would use the project
   * Show the UI of the project working
   * Explain at least one technical detail of how the project works
   * Explain what they learned through doing the project
   * List at least one thing they would do differently if they did the project again
-* A technical discussion about your project
+* A technical discussion about your project, following on from your presentation
 * One or more competency interview questions
 * Time for any questions you have about The Launch.
 


### PR DESCRIPTION
We are expecting them to present for ~5 minutes not ~20.

This has already been messaged on Slack, and updated in the Evidenced rubric.