### PR TITLE
Fix: Remove premature INSERT command reference in Sprint 1

### DIFF
--- a/common-content/en/module/databases/communicating-with-db/index.md
+++ b/common-content/en/module/databases/communicating-with-db/index.md
@@ -617,6 +617,6 @@ Not all SQL implementations of SQL support LIMIT, some use TOP while Oracle uses
 
 ## Summary
 
-In this lesson you have learned the use of databases and how relational databases are structured. You've also learned how to use basic single-table query commands in SQL and some of the special 'backslash' commands in `psql`. You have used the SELECT command to control the columns and values that are returned, the DISTINCT, ORDER BY and LIMIT clauses to control the order and numbers of rows returned and you've used the WHERE clause to choose the rows that you access. You have learned the INSERT command to add new data to the database
+In this lesson you have learned the use of databases and how relational databases are structured. You've also learned how to use basic single-table query commands in SQL and some of the special 'backslash' commands in `psql`. You have used the SELECT command to control the columns and values that are returned, the DISTINCT, ORDER BY and LIMIT clauses to control the order and numbers of rows returned and you've used the WHERE clause to choose the rows that you access.
 
-Next time we shall go on to more complex query constructs including joins, updates and deletes along with incorporating SQL into a node.js server.
+Next time we shall go on to more complex query constructs including joins, insert, updates and deletes along with incorporating SQL into a node.js server.


### PR DESCRIPTION
## What does this change?

Removes premature reference to INSERT command from Sprint 1 Prep; 5. The text states "You have learned the INSERT command to add new data to the database" but INSERT is not taught until Sprint 2 Block 2 ("Inserting, Updating and Deleting Rows").

### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #issue-number

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Block Type

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [ ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
