### PR TITLE
Add information on how to responded to automated review checks

### DIFF
--- a/org-cyf-guides/content/reviewing/trainee-pr-guide/index.md
+++ b/org-cyf-guides/content/reviewing/trainee-pr-guide/index.md
@@ -230,7 +230,7 @@ After you get feedback from a reviewer, you may make changes and have a back-and
 When the reviewer is happy that you have understood the task, and you have answered any questions they have, they will add the **`Complete`** label to your PR.
 Your backlog task is not complete until the reviewer adds this label.
 
-If you spend a long time waiting for the **`complete`** label to be added, check the PR to make sure there are no comments from the reviewer that you missed.
+If you spend a long time waiting for the **`Complete`** label to be added, check the PR to make sure there are no comments from the reviewer that you missed.
 If you think you have answered everything, and you are still waiting, you can ask for help on slack.
 
 You can work on other tasks while you are waiting for reviews or completion on one PR, remember to do other tasks on a different branch.


### PR DESCRIPTION
## What does this change?

Adds info about the actions bot to the PRs guide

From minutes in https://github.com/CodeYourFuture/curriculum/pull/1673/files

### Org Content?

Affects ITP Training Guide
Specifically here is the preview of the change: https://deploy-preview-1682--cyf-programming.netlify.app/guides/reviewing/trainee-pr-guide/#after-opening-a-pr

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

@illicitonion Can you take a look?