### PR TITLE
Switch github-issue-proxy to CYF-hosted version

### DIFF
--- a/org-cyf-theme/assets/custom-scripts/reviews/common.mjs
+++ b/org-cyf-theme/assets/custom-scripts/reviews/common.mjs
@@ -13,7 +13,7 @@ function identifyAge(date) {
     }
 }
 
-const apiPrefix = "https://github-issue-proxy.illicitonion.com/cached/2/repos/CodeYourFuture/";
+const apiPrefix = "https://github-issue-proxy.hosting.codeyourfuture.io/cached/2/repos/CodeYourFuture";
 
 class PR {
     // status: one of: "Needs Review", "Reviewed", "Complete", "Closed", "Unknown"

--- a/org-cyf-theme/hugo.toml
+++ b/org-cyf-theme/hugo.toml
@@ -52,9 +52,9 @@ root = "curriculum"
 googleFonts="https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap"
 
 # We use a proxy which concatenates paginated responses, otherwise we miss results.
-# Daniel is currently hosting this code https://github.com/illicitonion/github-issue-proxy but we should work out a long-term maintainable solution to this problem.
+# CYF is currently hosting this code https://github.com/illicitonion/github-issue-proxy but we should work out a long-term maintainable solution to this problem.
 # The /cached/120 path prefix here caches results for 2 hours to avoid rate limits. Drop the /cached/120 if you need fresh results.
-orgapi = "https://github-issue-proxy.illicitonion.com/cached/120/repos/CodeYourFuture/"
+orgapi = "https://github-issue-proxy.hosting.codeyourfuture.io/cached/120/repos/CodeYourFuture/"
 
 [caches.getresource]
 # Disable caching of fetches - we want every build to get up to date content for issues, so that if people make clarifications or fixes to issues, we pick them up.


### PR DESCRIPTION
Recently the token on this expired, and it's hosted on my personal VPS. Now that we have a convenient place to host this that CYF owns, move it there.