### PR TITLE
Fix missing sidebar title in SDC Decomp. Sprint 1

### DIFF
--- a/org-cyf-sdc/content/decomposition/sprints/1/prep/index.md
+++ b/org-cyf-sdc/content/decomposition/sprints/1/prep/index.md
@@ -5,7 +5,7 @@ layout = "prep"
 menu_level = ["sprint"]
 weight = 1
 [[blocks]]
-title = "Get on the CYF Hosted Environment"
+name = "Get on the CYF Hosted Environment"
 src = "blocks/cyf-hosting-onboarding"
 [[blocks]]
 name = "Overview"


### PR DESCRIPTION
## What does this change?

Very small fix. A sidebar item had a `title` specified instead of a `name` and so wasn't displaying correctly.

### Common Content?

No

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

No

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Sprint (SDC Decomposition Sprint 1)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

# Before:
<img width="1468" height="992" alt="CleanShot 2025-12-13 at 17 51 18@2x" src="https://github.com/user-attachments/assets/ed10db96-51e9-4812-a5d4-849ed3bc2ed5" />

# After:
<img width="1452" height="972" alt="CleanShot 2025-12-13 at 17 53 25@2x" src="https://github.com/user-attachments/assets/a542aa43-035f-448e-9dc4-32725c30ab90" />