### PR TITLE
Codewars success criteria amendments

### DIFF
--- a/org-cyf-itp/content/data-flows/success/index.md
+++ b/org-cyf-itp/content/data-flows/success/index.md
@@ -33,7 +33,7 @@ weight = 11
 1. Make a new issue on your own Coursework Planner.
    - Follow this template for naming your issue: `<COHORT_NAME> | Data flows | <YOUR_NAME>`
 1. On the issue, add:
-   - Evidence that you have completed **all katas** from across the Data Flows CodeWars Collections for [sprint 1](https://github.com/CodeYourFuture/Module-Data-Flows/issues/371), [sprint 2](https://github.com/CodeYourFuture/Module-Data-Flows/issues/372), and [sprint 3](https://github.com/CodeYourFuture/Module-Data-Flows/issues/373).
+   - A link to the [Codewars Progress Checker](https://codeyourfuture.github.io/Codewars-Progress-Checker/) showing you have completed **all katas** from across the Data Flows CodeWars Collections for [sprint 1](https://github.com/CodeYourFuture/Module-Data-Flows/issues/371), [sprint 2](https://github.com/CodeYourFuture/Module-Data-Flows/issues/372), and [sprint 3](https://github.com/CodeYourFuture/Module-Data-Flows/issues/373).
    - A link to your GitHub repo and deployed Netlify site for the "[TV Show Project](https://github.com/CodeYourFuture/Project-TV-Show)".
    - A link to your level 400 and level 500 pull requests for the "[TV Show Project](https://github.com/CodeYourFuture/Project-TV-Show)", to show both you and your partner contributed.
    - A link to your _completed_ pull request for "[Book Library Project](https://github.com/CodeYourFuture/Module-Data-Flows/issues/31)".

--- a/org-cyf-itp/content/data-groups/success/index.md
+++ b/org-cyf-itp/content/data-groups/success/index.md
@@ -29,7 +29,7 @@ weight = 11
 1. Make a new issue on your own Coursework Planner.
    - Follow this template for naming your issue: `<COHORT_NAME> | Data groups | <YOUR_NAME>`
 1. On the issue, add:
-   - Evidence that you have completed **all katas** from across the Data Groups CodeWars Collections for [sprint 1](https://github.com/CodeYourFuture/Module-Data-Groups/issues/936), [sprint 2](https://github.com/CodeYourFuture/Module-Data-Groups/issues/937), and [sprint 3](https://github.com/CodeYourFuture/Module-Data-Groups/issues/938).
+   - A link to the [Codewars Progress Checker](https://codeyourfuture.github.io/Codewars-Progress-Checker/) showing you have completed **all katas** from across the Data Groups CodeWars Collections for [sprint 1](https://github.com/CodeYourFuture/Module-Data-Groups/issues/936), [sprint 2](https://github.com/CodeYourFuture/Module-Data-Groups/issues/937), and [sprint 3](https://github.com/CodeYourFuture/Module-Data-Groups/issues/938).
    - A link to your _completed_ pull request for "[Alarm Clock App](https://github.com/CodeYourFuture/Module-Data-Groups/issues/26)".
    - A link to your _completed_ pull request for "[Sprint 2 Coursework](https://github.com/CodeYourFuture/Module-Data-Groups/issues/14)".
    - A link to your _completed_ pull request for "[Quote Generator App](https://github.com/CodeYourFuture/Module-Data-Groups/issues/20)".

--- a/org-cyf-itp/content/onboarding/success/index.md
+++ b/org-cyf-itp/content/onboarding/success/index.md
@@ -37,6 +37,7 @@ weight = 11
 1. Make a new issue on your own Coursework Planner.
    - Follow this template for naming your issue: `<COHORT_NAME> | Onboarding | <YOUR_NAME>`
 1. On the issue, add:
+   - A link showing you [completed **all the onboarding katas**](https://github.com/CodeYourFuture/Module-Onboarding/issues/935). This should be a link to your Codewars Progress Checker page in the form of: https://codeyourfuture.github.io/Codewars-Progress-Checker/#YOUR_CODEWARS_USERNAME
    - A link to your _completed_ pull request for "[Wireframe to Web Code](https://github.com/CodeYourFuture/Module-Onboarding/issues/17)".
    - A link to your _completed_ pull request for "[Form Controls](https://github.com/CodeYourFuture/Module-Onboarding/issues/19)".
    - Your Codewars username which you created when you [joined Codewars](https://github.com/CodeYourFuture/Module-Onboarding/issues/39).

--- a/org-cyf-itp/content/structuring-data/success/index.md
+++ b/org-cyf-itp/content/structuring-data/success/index.md
@@ -34,7 +34,7 @@ weight = 11
 1. Make a new issue on your own Coursework Planner.
    - Follow this template for naming your issue: `<COHORT_NAME> | Structuring and testing data | <YOUR_NAME>`
 1. On the issue, add:
-   - Evidence you have completed all of the Codewars katas for [sprint 1](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/899), [sprint 2](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/900), and [sprint 3](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/901) of this module.
+   - A link to the [Codewars Progress Checker](https://codeyourfuture.github.io/Codewars-Progress-Checker/) showing you have completed **all katas** for [sprint 1](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/899), [sprint 2](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/900), and [sprint 3](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/901) of this module. Link should be in the form https://codeyourfuture.github.io/Codewars-Progress-Checker/#YOUR_CODEWARS_USERNAME
    - Links to your _completed_ pull requests for each sprint:
      1. "[Sprint 1 Coursework Exercises](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/35)".
      2. "[Sprint 2 Coursework Exercises](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/7)".


### PR DESCRIPTION
## What does this change?

Success criteria for Data Groups and Data Flows (ITP) to reflect the fact that katas are now split by sprint. 

<!--Please reference the ticket you are addressing -->

Issue number: #1620

## Checklist

- [ x ] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [ x ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ x ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ x ] I have run my code to check it works
- [ x ] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?
@illicitonion 