### PR TITLE
Rename Slack Libs block

### DIFF
--- a/org-cyf-itp/content/onboarding/sprints/1/day-plan/index.md
+++ b/org-cyf-itp/content/onboarding/sprints/1/day-plan/index.md
@@ -35,7 +35,7 @@ src="blocks/using-github"
 name="lunch"
 src="blocks/lunch"
 [[blocks]]
-name="Energiser"
+name="Slack Libs"
 src="energisers/slack-libs"
 [[blocks]]
 name="Blockers! Getting Unstuck"


### PR DESCRIPTION
This isn't just an energiser, and also because there's already an energiser, this leads to duplicate anchors which means the TOC links don't work.