### PR TITLE
update backlog issue presentation

### DIFF
--- a/common-theme/layouts/partials/block/issue.html
+++ b/common-theme/layouts/partials/block/issue.html
@@ -25,7 +25,7 @@
       {{/* extract objectives */}}
       {{ $extractedObjectives := partial "strings/extract-github-objectives.html" $response.body }}
       {{/* remove "Learning Objectives" heading from remaining text */}}
-      {{ $strippedBody := replace $response.body "Learning Objectives" "" }}
+      {{ $strippedBody := replace $response.body "### Learning Objectives" "" }}
 
       {{ if gt (len $extractedObjectives) 0 }}
         <details open class="c-block__objectives">


### PR DESCRIPTION
When the backlog pages are built learning objectives are stripped from the issues and nicely formatted with checkboxes, but the "Learning Objectives" heading is left behind. This removes the heading too.
