### PR TITLE
PR lister: Only look for open PRs

### DIFF
--- a/org-cyf-theme/assets/custom-scripts/reviews/common.mjs
+++ b/org-cyf-theme/assets/custom-scripts/reviews/common.mjs
@@ -84,7 +84,7 @@ async function fetchPrsWithoutLoadingReviews() {
     const prs = [];
     const responsePromises = [];
     for (const module of modules) {
-        responsePromises.push(fetch(`${apiPrefix}/${module}/pulls?state=all`).then((response) => response.json()));
+        responsePromises.push(fetch(`${apiPrefix}/${module}/pulls`).then((response) => response.json()));
     }
     const responsesByModule = await Promise.all(responsePromises);
     for (let i = 0; i < responsesByModule.length; i++) {


### PR DESCRIPTION
We used to also do some analysis over closed PRs, but we don't any more, so this just slows down requests for no good reason.