### PR TITLE
feat: add filename label support for code blocks

### DIFF
--- a/common-theme/assets/styles/03-elements/misc-phrasing.scss
+++ b/common-theme/assets/styles/03-elements/misc-phrasing.scss
@@ -23,12 +23,15 @@ code,
 pre code .highlight pre {
   font: var(--theme-font--code);
 }
-p > code {
+
+p>code {
   line-height: 1.5; // prevent inline code from breaking paragraph layouts
 }
+
 code:not([class]) {
   color: var(--theme-color--pop);
 }
+
 //this .highlight is goldmark
 .highlight pre {
   display: block;
@@ -49,17 +52,19 @@ code:not([class]) {
 details {
   list-style: none;
 }
+
 summary {
   margin-bottom: var(--theme-spacing--1);
   cursor: pointer;
   list-style: none;
 }
-summary > * {
+
+summary>* {
   display: inline-block;
   margin: 0;
 }
 
-details > summary::before {
+details>summary::before {
   content: "▶";
   display: inline-block;
   color: var(--theme-color--accent);
@@ -67,19 +72,49 @@ details > summary::before {
   transition: transform 0.5s cubic-bezier(0.4, 2.08, 0.55, 0.44);
   margin: 0 var(--theme-spacing--1) 0 0;
 }
+
 details:hover summary::before {
   color: var(--theme-color--pop);
   transform: rotate(5deg) scale(1.1);
 }
 
-details[open] > summary::before {
+details[open]>summary::before {
   transform: rotate(90deg);
 }
+
 hr {
   border: 0;
   border-bottom: var(--theme-border--thick);
   border-image: var(--theme-border-image);
-  margin: var(--theme-spacing--6)
-    calc(3 * calc(-1 * var(--theme-spacing--gutter)));
+  margin: var(--theme-spacing--6) calc(3 * calc(-1 * var(--theme-spacing--gutter)));
   max-width: 50%;
+}
+
+.code-block-filename {
+  font-family: var(--theme-font--code);
+  font-size: var(--theme-type-size--5);
+  padding: var(--theme-spacing--1) var(--theme-spacing--2);
+  background: var(--theme-color--paper);
+  border: var(--theme-border);
+  border-bottom: 0;
+  display: inline-block;
+  margin-bottom: -1px;
+  /* Overlap with the code block border */
+  position: relative;
+  z-index: 1;
+}
+
+
+.code-block-filename {
+  font-family: var(--theme-font--code);
+  font-size: var(--theme-type-size--5);
+  padding: var(--theme-spacing--1) var(--theme-spacing--2);
+  background: var(--theme-color--paper);
+  border: var(--theme-border);
+  border-bottom: 0;
+  display: inline-block;
+  margin-bottom: -1px;
+  /* Overlap with the code block border */
+  position: relative;
+  z-index: 1;
 }

--- a/common-theme/layouts/_default/_markup/render-codeblock.html
+++ b/common-theme/layouts/_default/_markup/render-codeblock.html
@@ -1,0 +1,6 @@
+{{- $title := or .Attributes.title .Attributes.filename -}}
+
+{{- if $title -}}
+<div class="code-block-filename">{{ $title }}</div>
+{{- end -}}
+{{ (transform.HighlightCodeBlock .).Wrapped }}


### PR DESCRIPTION
## What does this change?

<!-- Add a description of what your PR changes here -->
This PR addresses issue #175 by adding support for displaying a filename label on code blocks, similar to Docusaurus.
It introduces a new Hugo render hook that intercepts standard code blocks and checks for title or filename attributes. If found, it renders a styled label above the code block.

### Common Content?

<!-- Does this PR add content to the common-content module? -->
- [ ] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [x] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #175 

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Platform / Theme Change

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [x] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [x] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [x] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?
@illicitonion
<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
