### PR TITLE
Fix ITP description – remove Python and SQL

### DIFF
--- a/org-cyf-sdc/content/overview/_index.md
+++ b/org-cyf-sdc/content/overview/_index.md
@@ -9,7 +9,7 @@ menus = ["start here"]
 
 The objective of this course is to train people to get a good job in technology.
 
-Pre-requisites of this course is having completed Code Your Future's [Intro to Programming course](https://programming.codeyourfuture.io/overview/) which teaches the basics of programming with JavaScript, Python, and SQL.
+Pre-requisites of this course is having completed Code Your Future's [Intro to Programming course](https://programming.codeyourfuture.io/overview/) which teaches the basics of programming with JavaScript.
 
 Outcomes of this course are that you can write high quality code in multiple languages, are able to consider trade-offs, can design systems that involve multiple components, and can get a job as a Software Engineer.
 


### PR DESCRIPTION

## What does this change?

<!-- Add a description of what your PR changes here -->

This PR updates the course description to reflect the current ITP curriculum. Python and SQL were removed since they are not covered in the Intro to Programming course anymore.

### Common Content?

<!-- Does this PR add content to the common-content module? -->

- [] Block/s

### Common Theme?

<!-- Does this PR add a feature or bugfix to the common-theme module? -->

- [ ] Yes

<!--Please reference the ticket you are addressing -->

Issue number: #issue-number

### Org Content?

<!-- Does this PR change a whole module, a sprint, a page, or a block on a single organisation's module? Please delete as appropriate. -->

Module

## Checklist

- [X] I have read the [contributing guidelines](CONTRIBUTING.MD)
- [X] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [X] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [X] I have run my code to check it works
- [X] My changes follow our [Style Guide](https://curriculum.codeyourfuture.io/guides/code-style-guide)

## Who needs to know about this?

<!-- Now bring this PR to the attention of the team. Assign reviewers. @mention specific people in comments. -->
