### PR TITLE
Add Slack setup to success criteria for ITP Welcome week

### DIFF
--- a/org-cyf-itp/content/welcome/success/index.md
+++ b/org-cyf-itp/content/welcome/success/index.md
@@ -9,6 +9,7 @@ objectives = [[
   "Name 5 people in your class.",
   "Have a plan for how to make progress, and how to get help.",
   "Find and begin your prep for the first sprint of the Onboarding Module.",
+  "Set up Slack and join your class channels.",
 ]]
 +++
 


### PR DESCRIPTION
Per issue #1431: Add Slack setup to success criteria so trainees know they need to join class channels


