### PR TITLE
refactor: Modules get their children directly

### DIFF
--- a/common-theme/layouts/_default/module.html
+++ b/common-theme/layouts/_default/module.html
@@ -4,12 +4,12 @@
   {{/* timeline of module: prep, sprints, backlog, success
     if there are blocks on this page, pop them in a deselected tab
   */}}
-  {{ $parent := .Section }}
+  {{ $parent := .CurrentSection }}
   {{ if .Params.blocks }}
     {{ partial "module-tabs" . }}
   {{ else }}
     <ol class="c-timeline">
-      {{ range where .Site.Pages "Section" $parent }}
+      {{ range $parent.Pages }}
         {{ if in .Params.menu_level
           "module"
         }}


### PR DESCRIPTION
The old code worked out what section we're in, then tries to find all of teh pages in that section.

This worked, except it doesn't work with nested Sections. If you have `/section/subsection`, `.Section` returns `/section` and iterating all site pages to find things in the section returns all pages in `/section`.

`.CurrentSection` gets the sub-section, not the parent section. But `where .Site.Pages "Section"` filtering doesn't work for a subsection, because the "Section" of any page is its top-level section, not its sub-section. There doesn't appear to be a way to filter based on subsection like this.

The new code instead gets the current sub-section, an enumerates the pages in it directly, instead of looking at all of the site pages and filtering them.

This _should_ have absolutely no effect on our generated output, it should be a complete no-op. I do think it's slightly simpler to reason about, but also, this whole behaviour is wild.

But it opens up better ability to nest things. I'm experimenting with nesting the ITP and SDC content in one site, rather than having them be separate top-level sites, and this fixes a bug there where a going to `/itp/onboarding` would show all ITP sprints, not just the Onboarding sprints, because it was filtering all pages in the `/itp` section not the `/itp/onboarding` subsection.

I've manually verified that the build output doesn't change between the commit before this one, and this one, other than timestamps and random numbers which we embed in pages.