### PR TITLE
removing AI reference in the PR guide

### DIFF
--- a/org-cyf-guides/content/reviewing/trainee-pr-guide/index.md
+++ b/org-cyf-guides/content/reviewing/trainee-pr-guide/index.md
@@ -10,16 +10,17 @@ A **pull request**, or **PR**, is a way to share your code for review.
 In professional projects, PRs are used to suggest changes and then merge them into the main project.
 
 At {{<our-name>}}, we use PRs mainly as a way for you to submit your work for review and feedback.
-Think of it like handing in an assignment - the PR is the place where you "submit" your code so 
+Think of it like handing in an assignment - the PR is the place where you "submit" your code so
 mentors and teammates can:
+
 - ✅ See what you changed (new code, fixes, or features)
 - 💬 Discuss the changes (comments, suggestions, or questions)
 - 👍 Review and provide feedback (approve or request improvements)
 
-For most coursework, merging will not happen. You will update your code based on feedback, learn 
+For most coursework, merging will not happen. You will update your code based on feedback, learn
 from the process, and keep practising.
 
-To get the most out of a PR, follow these steps to get 
+To get the most out of a PR, follow these steps to get
 clear feedback, show your progress, and learn more effectively.
 
 ## Preparing a PR Branch
@@ -34,14 +35,14 @@ To keep your exercise branch clean:
 1. **Create your branch from `main`**.
 
 2. **Keep `main` clean and updated**.
-    - _Clean_ -> no changes should be committed to `main`.
-    - _Updated_ -> regularly use
+   - _Clean_ -> no changes should be committed to `main`.
+   - _Updated_ -> regularly use
      [Sync Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)
      to keep your repo up-to-date with the upstream repository.
 
 3. **Make only related changes**.
-    - Add or modify only the files in the folder related to the exercise.
-    - If you accidentally change files for another task, you will need to [revert](https://stackoverflow.com/a/37972822) them before submitting your PR for review
+   - Add or modify only the files in the folder related to the exercise.
+   - If you accidentally change files for another task, you will need to [revert](https://stackoverflow.com/a/37972822) them before submitting your PR for review
 
 ### Keeping code clean
 
@@ -50,21 +51,6 @@ work with.
 
 Please read the [Code Style Guide](../style-guide/) carefully
 to learn how to keep your code professional.
-
-### Get a second opinion from AI tools
-
-Before submitting a PR, you can use AI tools to review your code, documentation, or explanations.
-
-AI can help you:
-- Spot typos, formatting issues, or unclear comments.
-- Suggest possible improvements to your code or approach.
-- Highlight missing edge cases or potential problems.
-
-Think of AI as a second pair of eyes -- helpful for polishing your work.  
-And don’t worry: using AI is **not cheating**. You can accept AI suggestions, but only if you 
-understand them well enough to explain the change. Once you can do that, the learning truly becomes 
-yours.
-
 
 ## Opening a PR
 
@@ -76,18 +62,21 @@ yours.
 - (2) **Source branch**: The branch in your fork where you prepared the files for the exercise.
 
 ### PR Title
+
 A consistent title format makes pull requests easier to track, search, and review.
 
 {{<note type="note" title="In CYF Courses">}}
 In {{<our-name>}} courses, you can typically find the title format in the PR template.
 
 For example,
+
 ```
   Region | Cohort | FirstName LastName | Sprint | Assignment Title
-```  
+```
+
 means the title should have 5 components separated by a vertical bar character (`|`)
 
-- **`Region`**: One of 
+- **`Region`**: One of
   - `Birmingham`
   - `Cape Town`
   - `Glasgow`
@@ -96,7 +85,7 @@ means the title should have 5 components separated by a vertical bar character (
   - `Sheffield`
 - **`Cohort`**: In the form `<Year>-<Course name>-<Cohort starting month>`
   - e.g., `25-ITP-Sep`
-- **`FirstName LastName`**: 🙄
+- **`FirstName LastName`**: E.g. `John Smith`
 - **`Sprint`**: `Sprint 1`, `Sprint 2`, ...
 - **`Assignment Title`**:
   - Project's name
@@ -115,32 +104,36 @@ The PR template in {{<our-name>}} courses typically contain the following sectio
 
 #### 1. Self-checklist
 
-The self-checklist helps you remember important steps, shows reviewers you've prepared your work, 
+The self-checklist helps you remember important steps, shows reviewers you've prepared your work,
 and speeds up the review process - while building good professional habits for real-world projects.
 
-You should only tick items you've truly completed, check every box before submitting, 
-and treat the checklist as both your responsibility and a learning tool - ask for help if you're 
+You should only tick items you've truly completed, check every box before submitting,
+and treat the checklist as both your responsibility and a learning tool - ask for help if you're
 unsure.
 
 {{<note type="note" title="In CYF Courses">}}
 Complete every task described in the checklist, and mark each one as done.
 
-To check a box in Markdown, write `[x]` (a lowercase '`x`' with no spaces inside the brackets) 
+To check a box in Markdown, write `[x]` (a lowercase '`x`' with no spaces inside the brackets)
 to mark it as checked.
 
 For example, change
+
 ```
 - [ ] My changes meet the requirements of the task
 ```
+
 to
+
 ```
 - [x] My changes meet the requirements of the task
 ```
+
 {{</note>}}
 
 #### 2. Changelist
 
-The **Changelist** section is a short, bullet-point summary of the key changes in your PR, 
+The **Changelist** section is a short, bullet-point summary of the key changes in your PR,
 helping reviewers quickly understand what you did and why.
 
 {{<note type="note" title="In CYF Courses">}}
@@ -149,7 +142,7 @@ Replace the placeholder text `Briefly explain your PR` by a brief description of
 
 #### 3. Questions
 
-The **Questions** section lets you highlight parts of your work you're unsure about, 
+The **Questions** section lets you highlight parts of your work you're unsure about,
 so reviewers can give you targeted feedback and help you learn.
 
 {{<note type="note" title="In CYF Courses">}}
@@ -159,13 +152,15 @@ Replace the placeholder text by your questions, or delete the section if you don
 ## After Opening a PR
 
 ### Use labels to communicate the PR status
+
 Reviewers will not check your PR unless it has the right label.
 
 - Add the **`Needs review`** label to the PR.
   - For details about how to use labels in a PR, please refer to the [Using Labels](./using-labels/)
-  Guide.
+    Guide.
 
 ### Check for automated feedback
+
 Learning how to respond to automated checks is important, because these kinds of tools are often used in software development work.
 
 At the bottom of the GitHub page there is a summary of automated checks.
@@ -192,41 +187,40 @@ If you see a comment in your PR from the user called **`github-actions`**, here'
 You might also see comments from **`netlify`**, these are used in tasks where you need to deploy a website.
 Read these comments carefully to see any issues with deployment or accessibility.
 
-
 ### Wait for Review
-  - It may take up to a week (sometimes longer) before someone starts reviewing your PR.
-  - Your PR will appear on one of the PRs Needing Review pages -- please do not post messages like 
-    "Please review my PR ..." on Slack.
-    - [ITP PRs needing review](https://programming.codeyourfuture.io/prs-needing-review/)
-    - [SDC PRs needing review](https://sdc.codeyourfuture.io/prs-needing-review/)
+
+- It may take up to a week (sometimes longer) before someone starts reviewing your PR.
+- Your PR will appear on one of the PRs Needing Review pages -- please do not post messages like
+  "Please review my PR ..." on Slack.
+  - [ITP PRs needing review](https://programming.codeyourfuture.io/prs-needing-review/)
+  - [SDC PRs needing review](https://sdc.codeyourfuture.io/prs-needing-review/)
 
 ## Addressing Reviewer Feedback
 
-Responding to PR feedback is like a conversation: **listen**, **reply thoughtfully**, and 
+Responding to PR feedback is like a conversation: **listen**, **reply thoughtfully**, and
 **show that you acted on feedback**.
 
 1. **Be respectful and collaborative**
-    - Treat comments as opportunities to learn, not criticism.
-    - Even if you disagree, respond politely and explain your reasoning.
+   - Treat comments as opportunities to learn, not criticism.
+   - Even if you disagree, respond politely and explain your reasoning.
 
 2. **Acknowledge feedback**
-    - If you agree -> say _"Good point, I'll fix it."_
-    - If you don't fully agree -> say _"I see your point. Here's why I approached it this way ..."_
-    - **Don't ignore comments** -- silence can feel dismissive.
+   - If you agree -> say _"Good point, I'll fix it."_
+   - If you don't fully agree -> say _"I see your point. Here's why I approached it this way ..."_
+   - **Don't ignore comments** -- silence can feel dismissive.
 
 3. **Make changes, then confirm**
-    - After addressing a comment, let the reviewer know (e.g., _"I've updated the variable name 
-      as suggested."_).
-    - This shows you're actively engaging in the review.
+   - After addressing a comment, let the reviewer know (e.g., _"I've updated the variable name
+     as suggested."_).
+   - This shows you're actively engaging in the review.
 
 4. **Ask questions if unclear**
-    - If you don't understand a suggestion, ask for clarification.
-    - Example: _"Could you explain what you mean by simplifying this function?"_
-    
+   - If you don't understand a suggestion, ask for clarification.
+   - Example: _"Could you explain what you mean by simplifying this function?"_
 5. **Respond Promptly**
-    - Our volunteers have a lot of PRs to keep on top of, so the quicker you respond, the sooner you will be finished with tasks
-    - But don't rush through, take the time to make sure your response meets what was being asked
-    - Try to respond within 2 days of a review, if something is blocking you, ask for help in slack
+   - Our volunteers have a lot of PRs to keep on top of, so the quicker you respond, the sooner you will be finished with tasks
+   - But don't rush through, take the time to make sure your response meets what was being asked
+   - Try to respond within 2 days of a review, if something is blocking you, ask for help in slack
 
 After you have taken action and replied to your feedback, you should add the **`Needs review`** label again, so the reviewer knows you are ready for your submission to be checked again.
 When you make changes, make them in the same branch and don't create a new pull request each time.
@@ -234,7 +228,7 @@ When you make changes, make them in the same branch and don't create a new pull 
 {{<note type="tip" title="Writing on GitHub">}}
 
 **Markdown** is a language for formatting plain text.
-You can use Markdown syntax, along with some additional HTML tags, to format your writing on GitHub, 
+You can use Markdown syntax, along with some additional HTML tags, to format your writing on GitHub,
 in places like repository READMEs and comments on pull requests and issues.
 
 To learn how to write in Markdown, embed image, tag users, and other advanced features,


### PR DESCRIPTION
Section about using AI to double check your work has been removed. It felt quite early to be actively pushing for AI when the core JS skills to be discerning about AI output just aren't present as much. 

Also a risk of AI use conflicting with future AI code checker tool. 