### PR TITLE
Add scroll indicator gradient to table of contents

### DIFF
--- a/common-theme/assets/styles/04-components/toc.scss
+++ b/common-theme/assets/styles/04-components/toc.scss
@@ -9,18 +9,17 @@
     var(--theme-spacing--4);
   overflow-y: auto;
   counter-reset: item;
-  position: relative;
-
   // Gradient fade at bottom to indicate scrollable content (closes #1799)
   &::after {
     content: "";
-    position: absolute;
+    position: sticky;
     bottom: 0;
-    left: 0;
-    right: 0;
+    display: block;
     height: 2em;
+    margin-top: -2em;
     background: linear-gradient(transparent, var(--theme-color--paper));
     pointer-events: none;
+    flex-shrink: 0;
   }
 
   ol {

--- a/common-theme/assets/styles/04-components/toc.scss
+++ b/common-theme/assets/styles/04-components/toc.scss
@@ -9,6 +9,19 @@
     var(--theme-spacing--4);
   overflow-y: auto;
   counter-reset: item;
+  position: relative;
+
+  // Gradient fade at bottom to indicate scrollable content (closes #1799)
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 2em;
+    background: linear-gradient(transparent, var(--theme-color--paper));
+    pointer-events: none;
+  }
 
   ol {
     color: var(--theme-color--ink);


### PR DESCRIPTION
On mobile, the TOC container clips content at max-height without visually indicating there is more below. Adds a CSS gradient fade at the bottom to signal scrollable content.

Fixes #1799


