### PR TITLE
Remove study group screenshot requirement

### DIFF
--- a/org-cyf/content/itp/data-flows/success/index.md
+++ b/org-cyf/content/itp/data-flows/success/index.md
@@ -39,7 +39,6 @@ weight = 11
    - A link to your level 400 and level 500 pull requests for the "[TV Show Project](https://github.com/CodeYourFuture/Project-TV-Show)", to show both you and your partner contributed.
    - A link to your _completed_ pull request for "[Book Library Project](https://github.com/CodeYourFuture/Module-Data-Flows/issues/31)".
    - A link to your issue for "[LinkedIn Social Selling Index](https://github.com/CodeYourFuture/Module-Data-Flows/issues/12)". Your issue must show your current index and actions you will take to improve it.
-   - A screenshot showing that you took part in an online study session with at least one other trainee. This could be a video call, a Slack thread, or something else!
    - A screenshot showing that you [gave a demo in a demo session with particular members of staff present](https://github.com/CodeYourFuture/Module-Data-Flows/issues/323).\
      This must be at a different demo session than any submitted for previous modules.
 1. Submit the issue link to step 4 of ITP on [CYF Course Portal](https://application-process.codeyourfuture.io/).

--- a/org-cyf/content/itp/data-groups/success/index.md
+++ b/org-cyf/content/itp/data-groups/success/index.md
@@ -36,7 +36,6 @@ weight = 11
    - A link to your _completed_ pull request for "[Quote Generator App](https://github.com/CodeYourFuture/Module-Data-Groups/issues/20)".
    - A link to your "[Brag Diary](https://github.com/CodeYourFuture/Module-Data-Groups/issues/10)". (It's ok if this is a private document, you don't need to share it if you don't want to, but please include the link for your own reference).
    - An explanation of how you have used your "[Brag Diary](https://github.com/CodeYourFuture/Module-Data-Groups/issues/10)" to record your progress.
-   - A screenshot showing that you took part in an online study session with at least one other trainee. This could be a video call, a Slack thread, or something else!
    - A screenshot showing that you [gave a demo in a demo session with particular members of staff present](https://github.com/CodeYourFuture/Module-Data-Groups/issues/794).\
      This must be at a different demo session than any submitted for previous modules.
 1. Submit the issue link to step 3 of ITP on [CYF Course Portal](https://application-process.codeyourfuture.io/).

--- a/org-cyf/content/itp/onboarding/success/index.md
+++ b/org-cyf/content/itp/onboarding/success/index.md
@@ -38,7 +38,6 @@ weight = 11
    - Follow this template for naming your issue: `<COHORT_NAME> | Onboarding | <YOUR_NAME>`
 1. On the issue, add:
    - A screenshot showing that you [attended a demo session with particular members of the CYF team present](https://github.com/CodeYourFuture/Module-Onboarding/issues/918).
-   - A screenshot showing that you took part in an online study session with at least one other trainee. This could be a video call, a Slack thread, or something else!
    - A link to your _completed_ pull request for "[Wireframe to Web Code](https://github.com/CodeYourFuture/Module-Onboarding/issues/17)".
    - A link to your _completed_ pull request for "[Form Controls](https://github.com/CodeYourFuture/Module-Onboarding/issues/19)".
    - Your Codewars username which you created when you [joined Codewars](https://github.com/CodeYourFuture/Module-Onboarding/issues/39).

--- a/org-cyf/content/itp/structuring-data/success/index.md
+++ b/org-cyf/content/itp/structuring-data/success/index.md
@@ -42,7 +42,6 @@ weight = 11
      3. "[Sprint 3 "Implement and Rewrite Tests" Coursework Exercises](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/6)".
      4. "[Sprint 3 "Practice TDD" Coursework Exercises](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/695)".
    - A link to your "[Written Email for an Internship](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/20)".
-   - A screenshot showing that you took part in an online study session with at least one other trainee. This could be a video call, a Slack thread, or something else!
    - A screenshot showing that you [gave a demo in a demo session with particular members of staff present](https://github.com/CodeYourFuture/Module-Structuring-and-Testing-Data/issues/897).\
      This must be at a different demo session than any submitted for previous modules.
 1. Submit the issue link to step 2 of ITP on [CYF Course Portal](https://application-process.codeyourfuture.io/).


### PR DESCRIPTION
This isn't prompting the behaviour we're hoping for. People who are going to study together are doing so anyway, but those who aren't are setting up fake calls just to show they've had one.

Instead we will try to instill this culture better, but requiring evidence isn't proving useful.


