### PR TITLE
Fix guides redirects

### DIFF
--- a/legacy-redirects/itd.codeyourfuture.io/netlify.toml
+++ b/legacy-redirects/itd.codeyourfuture.io/netlify.toml
@@ -1,4 +1,7 @@
-# TODO: Move this file into a less in-your-face directory once the curriculum merge settles.
+[[redirects]]
+from = "/guides/*"
+to = "https://curriculum.codeyourfuture.io/guides/:splat"
+status = 302
 
 [[redirects]]
 from = "/*"

--- a/legacy-redirects/itp.codeyourfuture.io/netlify.toml
+++ b/legacy-redirects/itp.codeyourfuture.io/netlify.toml
@@ -1,4 +1,7 @@
-# TODO: Move this file into a less in-your-face directory once the curriculum merge settles.
+[[redirects]]
+from = "/guides/*"
+to = "https://curriculum.codeyourfuture.io/guides/:splat"
+status = 302
 
 [[redirects]]
 from = "/*"

--- a/legacy-redirects/launch.codeyourfuture.io/netlify.toml
+++ b/legacy-redirects/launch.codeyourfuture.io/netlify.toml
@@ -1,4 +1,7 @@
-# TODO: Move this file into a less in-your-face directory once the curriculum merge settles.
+[[redirects]]
+from = "/guides/*"
+to = "https://curriculum.codeyourfuture.io/guides/:splat"
+status = 302
 
 [[redirects]]
 from = "/*"

--- a/legacy-redirects/piscine.codeyourfuture.io/netlify.toml
+++ b/legacy-redirects/piscine.codeyourfuture.io/netlify.toml
@@ -1,4 +1,7 @@
-# TODO: Move this file into a less in-your-face directory once the curriculum merge settles.
+[[redirects]]
+from = "/guides/*"
+to = "https://curriculum.codeyourfuture.io/guides/:splat"
+status = 302
 
 [[redirects]]
 from = "/*"

--- a/legacy-redirects/sdc.codeyourfuture.io/netlify.toml
+++ b/legacy-redirects/sdc.codeyourfuture.io/netlify.toml
@@ -1,4 +1,7 @@
-# TODO: Move this file into a less in-your-face directory once the curriculum merge settles.
+[[redirects]]
+from = "/guides/*"
+to = "https://curriculum.codeyourfuture.io/guides/:splat"
+status = 302
 
 [[redirects]]
 from = "/*"

--- a/legacy-redirects/tracks.codeyourfuture.io/netlify.toml
+++ b/legacy-redirects/tracks.codeyourfuture.io/netlify.toml
@@ -1,4 +1,7 @@
-# TODO: Move this file into a less in-your-face directory once the curriculum merge settles.
+[[redirects]]
+from = "/guides/*"
+to = "https://curriculum.codeyourfuture.io/guides/:splat"
+status = 302
 
 [[redirects]]
 from = "/*"


### PR DESCRIPTION
We don't re-mount these under each module, so change the redirects to all point to the top-level mount.


