### PR TITLE
Remind readers to check they've met learning objectives

### DIFF
--- a/common-theme/layouts/partials/block/data.html
+++ b/common-theme/layouts/partials/block/data.html
@@ -29,6 +29,7 @@
 {{ .Scratch.SetInMap "blockData" "hasBlocks" .hasBlocks| default "" }}
 {{/* Override any block time */}}
 {{ .Scratch.SetInMap "blockData" "time" .time | default "" }}
+{{ .Scratch.SetInMap "blockData" "pageLayout" $pageRef.Page.Params.layout}}
 
 {{/* Now let's do our headers */}}
 {{ $headers := partial "github-auth.html" }}

--- a/common-theme/layouts/partials/block/local.html
+++ b/common-theme/layouts/partials/block/local.html
@@ -46,5 +46,8 @@
         {{ end }}
       </section>
     {{ end }}
+    {{ if isset $block.Params "objectives" }}
+    {{ partial "review-objectives.html" $blockData }}
+    {{ end }}
   </div>
 </section>

--- a/common-theme/layouts/partials/block/readme.html
+++ b/common-theme/layouts/partials/block/readme.html
@@ -63,5 +63,8 @@
         {{ end }}
       </section>
     {{ end }}
+    {{ if gt (len $extractedObjectives) 0 }}
+    {{ partial "review-objectives.html" $blockData }}
+    {{ end }}
   </section>
 {{ end }}

--- a/common-theme/layouts/partials/review-objectives.html
+++ b/common-theme/layouts/partials/review-objectives.html
@@ -1,0 +1,4 @@
+{{ if eq .pageLayout "day-plan" }}
+<h3>Review</h3>
+Look back over the objectives of this activity - check you've met them all. If you haven't, make sure you have a plan for how to achieve them.
+{{ end }}

--- a/common-theme/layouts/partials/review-objectives.html
+++ b/common-theme/layouts/partials/review-objectives.html
@@ -1,4 +1,4 @@
 {{ if eq .pageLayout "day-plan" }}
 <h3>Review</h3>
-Look back over the objectives of this activity - check you've met them all. If you haven't, make sure you have a plan for how to achieve them.
+Look back over the objectives of this activity - check you've met them all. If you haven't, make sure you have a plan for how to achieve them - maybe checking in with a volunteer or a fellow trainee could help?
 {{ end }}


### PR DESCRIPTION
This shows up on every day-plan block which has learning objectives (but not tasks).

Currently only supported for local and readme blocks, but I think that's all of the relevant ones.

Doesn't show up on non-day-plan pages (e.g. prep).


