### PR TITLE
Add a demo Q&A workshop

### DIFF
--- a/common-content/en/blocks/demo-qa/index.md
+++ b/common-content/en/blocks/demo-qa/index.md
@@ -2,8 +2,10 @@
 title="Demo Questions & Answers"
 time=60
 objectives = [
-  "Practice thinking of good questions to ask after a demo",
-  "Get experience giving meaningful answers to questions",
+  "Think of a good question to ask after a demo",
+  "Explain what makes a question meaningful",
+  "Give a relevant answer to a question",
+  "Engage an audience in discussion through a Q&A session after a demo"
 ]
 [build]
   render = 'never'
@@ -29,8 +31,7 @@ There are 2 criteria we want to meet:
 Take a moment to read through the tips below before you begin.
 Feel free to refer to these tips during the Q&A if that would help.
 
-If you have a small group, you can have everyone work together.
-If you have a larger group, it may be better to break out into smaller teams, to ensure everyone has a chance to ask and answer.
+To ensure everyone has a chance to take part, get into groups of at most 5 trainees (and ideally at least one volunteer).
 
 Take turns: 
 - Each demo should be no more than 5 minutes long
@@ -49,6 +50,15 @@ The feedback and discussion for this workshop should focus on the questions and 
 - If the speaker says something you would like to know more about, you can remember it and ask at the end
 - If the speaker said something unclear, or that you disagree with, you can ask politely about it at the end
 - A good question is short and to the point. Remember: as the audience you're not the main focus
+
+The best questions to ask come from ideas the demo made you curious about.
+If you can't think of any, you can use or adapt one of these, if they're appropriate:
+- If you were to do it again, what would you do differently?
+- What did you enjoy the most about this?
+- What was your biggest challenge?
+- How does this compare to (some other way of doing something similar)?
+- Could you explain how (this idea) could be used or adapted for (some related setting or project)?
+- When I tried something similar, I encountered (this problem), how did you overcome that?
 
 # Tips for Giving Good Answers
 - Know that you will never be able to prepare for every possible question.

--- a/common-content/en/blocks/demo-qa/index.md
+++ b/common-content/en/blocks/demo-qa/index.md
@@ -1,0 +1,66 @@
++++
+title="Demo Questions & Answers"
+time=60
+objectives = [
+  "Practice thinking of good questions to ask after a demo",
+  "Get experience giving meaningful answers to questions",
+]
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+# Professional Q&A Experience Workshop
+
+In ITP you have practiced giving demos.
+These are short presentations that gave you practice speaking in a professional setting.
+In a professional setting, such as giving a presentation to colleagues or discussion during an interview, you will also be expected to ask or answer questions.
+The goal of this workshop is to give you practice in asking meaningful questions and giving good answers.
+
+# Plan
+To get the best out of this workshop, please use a short demo on a topic you are comfortable discussing.
+The goal here is to practice questions and answers, so you can re-use a demo you have previously given.
+
+There are 2 crtieria we want to meet:
+- Every presenter should answer at least 1 question during this workshop
+- Every listener should ask at least 1 question during this workshop
+
+Take a moment to read through the tips below before you begin.
+Feel free to refer to these tips throughout.
+
+If you have a small group, you can have everyone speak, listen and ask together.
+If you have a larger group, it may be better to break out into smaller teams, to ensure everyone has a chance to ask and answer.
+
+Take turns: 
+- Each demo should be no more than 5 minutes long
+- Give up to 3 minutes for questions and answers
+- Try to keep questions short, take up to 1 minute to answer
+
+After everyone has had a chance to practice asking and answering, have a discussion as a group about the process:
+- How did you find asking questions: Was there anything easy or difficult about it?
+- Give each other feedback on their Qs and As: Did any good examples stand out, could anything have been improved?
+- What would you change if you were in a similar Q&A situation in the future?
+The feedback and discussion for this workshop should focus on the questions and answers, not the content of the demos.
+
+# Tips for Asking Good Questions
+Asking good questions is a skill that takes time to practice and improve.
+- Unless the speaker made it very clear they are happy for you to do so, don't interrupt them mid-demo
+- If the speaker says something you would like to know more about, you can remember it and ask at the end
+- If the speaker said something unclear, or that you disagree with, you can ask politely about it at the end
+- A good question is short and to the point. Remember: as the audience you're not the main focus
+
+# Tips for Giving Good Answers
+Giving good answers to audience questions is can be a challenge if you have not done it before. It uses slightly different skills from presenting and demonstrating.
+- Recognise that you will never be able to prepare for every possible question.
+- Listen carefully to what is being asked - you don't want to answer the wrong thing.
+- Ask for clarification if you did not understand the question.
+- Take a moment to think about your answer before you start to speak, and then give it.
+- Repeating the question back in your own words gives you time to start forming an answer, and it confirms to the asker that you understood what they were asking.
+- If you can't think of a good answer, it is fine to say you don't know. This is better than giving an unclear long-winded reply.
+
+# Extra resources
+- [Asking questions at work](https://cdo.som.yale.edu/blog/2025/02/28/how-to-ask-good-questions-at-work-and-actually-get-the-info-you-need/)
+- [Asking follow-up questions](https://www.linkedin.com/pulse/asking-follow-up-questions-scott-baldwin)
+- [Using active listening](https://www.linkedin.com/advice/3/how-can-you-use-active-listening-ask-better-follow-up)
+- [Answering audience questions](https://umarcomm.umn.edu/blog/2020/01/23/become-pro-audience-qa-answering-questions)

--- a/common-content/en/blocks/demo-qa/index.md
+++ b/common-content/en/blocks/demo-qa/index.md
@@ -13,23 +13,23 @@ objectives = [
 
 # Professional Q&A Experience Workshop
 
-In ITP you have practiced giving demos.
-These are short presentations that gave you practice speaking in a professional setting.
-In a professional setting, such as giving a presentation to colleagues or discussion during an interview, you will also be expected to ask or answer questions.
+In ITP you have practised giving demos - short presentations to get practice speaking in a professional setting.
+Later on, during an interview, presentation, or other work discussion, you will also be expected to ask and answer questions.
 The goal of this workshop is to give you practice in asking meaningful questions and giving good answers.
 
 # Plan
 To get the best out of this workshop, please use a short demo on a topic you are comfortable discussing.
-The goal here is to practice questions and answers, so you can re-use a demo you have previously given.
+The goal here is not the quality of the demo.
+It is to practice questions and answers, so you can re-use a demo you have previously given.
 
-There are 2 crtieria we want to meet:
-- Every presenter should answer at least 1 question during this workshop
+There are 2 criteria we want to meet:
 - Every listener should ask at least 1 question during this workshop
+- Every presenter should answer at least 1 question during this workshop
 
 Take a moment to read through the tips below before you begin.
-Feel free to refer to these tips throughout.
+Feel free to refer to these tips during the Q&A if that would help.
 
-If you have a small group, you can have everyone speak, listen and ask together.
+If you have a small group, you can have everyone work together.
 If you have a larger group, it may be better to break out into smaller teams, to ensure everyone has a chance to ask and answer.
 
 Take turns: 
@@ -38,24 +38,23 @@ Take turns:
 - Try to keep questions short, take up to 1 minute to answer
 
 After everyone has had a chance to practice asking and answering, have a discussion as a group about the process:
-- How did you find asking questions: Was there anything easy or difficult about it?
-- Give each other feedback on their Qs and As: Did any good examples stand out, could anything have been improved?
-- What would you change if you were in a similar Q&A situation in the future?
+- How did you find asking and answering: Was there anything easy or difficult about it?
+- Give each other feedback on their Q&As: Did any good examples stand out, could any have been improved?
+- What would you do differently if you were in a similar Q&A situation in the future?
 The feedback and discussion for this workshop should focus on the questions and answers, not the content of the demos.
 
 # Tips for Asking Good Questions
-Asking good questions is a skill that takes time to practice and improve.
-- Unless the speaker made it very clear they are happy for you to do so, don't interrupt them mid-demo
+- This is different to the kind of rhetorical question you might have used when doing a demo
+- Unless the speaker made it clear they want you to, don't interrupt them mid-demo
 - If the speaker says something you would like to know more about, you can remember it and ask at the end
 - If the speaker said something unclear, or that you disagree with, you can ask politely about it at the end
 - A good question is short and to the point. Remember: as the audience you're not the main focus
 
 # Tips for Giving Good Answers
-Giving good answers to audience questions is can be a challenge if you have not done it before. It uses slightly different skills from presenting and demonstrating.
-- Recognise that you will never be able to prepare for every possible question.
+- Know that you will never be able to prepare for every possible question.
 - Listen carefully to what is being asked - you don't want to answer the wrong thing.
-- Ask for clarification if you did not understand the question.
-- Take a moment to think about your answer before you start to speak, and then give it.
+- If you did not understand the question, you can ask them to reword it.
+- Take a moment to think about your answer before you start to speak.
 - Repeating the question back in your own words gives you time to start forming an answer, and it confirms to the asker that you understood what they were asking.
 - If you can't think of a good answer, it is fine to say you don't know. This is better than giving an unclear long-winded reply.
 

--- a/common-content/en/blocks/demo-qa/index.md
+++ b/common-content/en/blocks/demo-qa/index.md
@@ -51,6 +51,7 @@ The feedback and discussion for this workshop should focus on the questions and 
 - If the speaker said something unclear, or that you disagree with, you can ask politely about it at the end
 - A good question is short and to the point. Remember: as the audience you're not the main focus
 
+## Example Questions
 The best questions to ask come from ideas the demo made you curious about.
 If you can't think of any, you can use or adapt one of these, if they're appropriate:
 - If you were to do it again, what would you do differently?

--- a/common-content/en/blocks/demo/index.md
+++ b/common-content/en/blocks/demo/index.md
@@ -31,6 +31,8 @@ After the demo, the group will give you feedback for up to 5 minutes. It's smart
 - I found X really confusing, did anyone else have the same problem?
 - I wasn't sure if I explained what an X was very clearly, how could I have explained it better?
 
+More tips: [A Good Question Can Be the Key to a Successful Presentation](https://www.gsb.stanford.edu/insights/matt-abrahams-good-question-can-be-key-successful-presentation).
+
 ## 💡 Tips:
 
 - **Practice** your demo before class.

--- a/org-cyf/content/itp/data-flows/sprints/2/day-plan/index.md
+++ b/org-cyf/content/itp/data-flows/sprints/2/day-plan/index.md
@@ -11,9 +11,13 @@ name="Morning orientation"
 src="blocks/morning-orientation"
 time=15
 [[blocks]]
+name="Demo Q&A Practice"
+src="blocks/demo-qa"
+time="60"
+[[blocks]]
 name= "Teamwork Project Sprint 2"
 src="blocks/teamwork-project-s2"
-time="140"
+time="80"
 [[blocks]]
 name="lunch"
 src="blocks/lunch"

--- a/org-cyf/content/itp/data-groups/sprints/2/day-plan/index.md
+++ b/org-cyf/content/itp/data-groups/sprints/2/day-plan/index.md
@@ -26,13 +26,9 @@ time=60
 name="lunch"
 src="blocks/lunch"
 [[blocks]]
-name="Demo Q&A Practice"
-src="blocks/demo-qa"
-time="60"
-[[blocks]]
 name="Study Group"
 src="blocks/study-group"
-time="90"
+time="150"
 [[blocks]]
 name="Retro"
 src="blocks/retro"

--- a/org-cyf/content/itp/data-groups/sprints/2/day-plan/index.md
+++ b/org-cyf/content/itp/data-groups/sprints/2/day-plan/index.md
@@ -26,9 +26,13 @@ time=60
 name="lunch"
 src="blocks/lunch"
 [[blocks]]
+name="Demo Q&A Practice"
+src="blocks/demo-qa"
+time="60"
+[[blocks]]
 name="Study Group"
 src="blocks/study-group"
-time="150"
+time="90"
 [[blocks]]
 name="Retro"
 src="blocks/retro"


### PR DESCRIPTION
For #1603 

Adds a workshop to sprint 2 of final ITP module

Do a demo, then spend time answering question, followed by discussion of the Q&A

Preview: https://deploy-preview-1836--cyf-curriculum.netlify.app/itp/data-flows/sprints/2/day-plan/

Q: Is the timing OK? Demos at 5 minutes can be a bit long, with up to 3 mins per q&a, with time for a discussion at the end you can have at most 6 people in a group for this if we want to hit 60 mins.