### PR TITLE
Merge multiple backlogs together

### DIFF
--- a/common-theme/layouts/_default/backlog.html
+++ b/common-theme/layouts/_default/backlog.html
@@ -23,16 +23,16 @@
     })
     </script>
 
+    {{ $setupTasks := slice }}
+    {{ $recurringTasks := slice }}
+    {{ $mandatoryTasks := slice }}
+    {{ $optionalTasks := slice }}
+
     {{/* you can have multiple repos but probably for sanity let's just stick with one label filter
       for each repo, grab the issues that match the filter
     */}}
     {{ range $repos }}
-      {{ $setupTasks := slice }}
-      {{ $recurringTasks := slice }}
-      {{ $mandatoryTasks := slice }}
-      {{ $optionalTasks := slice }}
       {{ $issueBlocks := partial "block/issues-list-as-blocks.html" (dict "backlog" . "backlog_filter" $backlog_filter "path" $currentPath) }}
-      {{ $repo := . }}    
       {{ range $issueBlocks }}
         {{ $issue := . }}
         {{ range .labels.nodes }}
@@ -47,62 +47,58 @@
           {{ end }}
         {{ end }}
       {{ end }}
-      {{ if lt 0 ($setupTasks | len) }}
-        <h2>Start Here</h2>
-        <p>These tasks should be completed before attempting anything else.</p>
-        {{range $setupTasks}} 
-          {{ partial "block/backlog-issue.html" (dict 
-            "block" . 
-            "Page" $.Page 
-            "Site" site 
-            "repo" $repo
-            "sprint" $backlog_filter
-            "path" $currentPath
-          ) }}
-        {{ end }}
-      {{ end }}
-      {{ if lt 0 ($recurringTasks | len) }}
-        <h2>Recurring Tasks</h2>
-        <p>These tasks need to be completed in every sprint.</p>
-        {{range $recurringTasks}} 
-          {{ partial "block/backlog-issue.html" (dict 
-            "block" . 
-            "Page" $.Page 
-            "Site" site 
-            "repo" $repo
-            "sprint" $backlog_filter
-            "path" $currentPath
-          ) }}
-        {{ end }}
-      {{ end }}
-      {{ if lt 0 ($mandatoryTasks | len) }}
-        <h2>Mandatory Tasks</h2>
-        <p>These tasks will help consolidate your learning for this sprint. You should complete as many of these as possible before class on Saturday.</p>
-        {{range $mandatoryTasks}}
-          {{ partial "block/backlog-issue.html" (dict
-            "block" .
-            "Page" $.Page
-            "Site" site
-            "repo" $repo
-            "sprint" $backlog_filter
-            "path" $currentPath
-          ) }}
-        {{ end }}
-      {{ end }}
-      {{ if lt 0 ($optionalTasks | len) }}
-        <h2>Optional Tasks</h2>
-        <p>These are optional "stretch goals" to attempt when you have finished the mandatory tasks. They may be more challenging or require some additional research.</p>
-        {{range $optionalTasks}}
-          {{ partial "block/backlog-issue.html" (dict
-            "block" .
-            "Page" $.Page
-            "Site" site
-            "repo" $repo
-            "sprint" $backlog_filter
-            "path" $currentPath
-          ) }}
-        {{ end }}
+    {{ end }}
+    {{ if lt 0 ($setupTasks | len) }}
+      <h2>Start Here</h2>
+      <p>These tasks should be completed before attempting anything else.</p>
+      {{range $setupTasks}}
+        {{ partial "block/backlog-issue.html" (dict
+          "block" .
+          "Page" $.Page
+          "Site" site
+          "sprint" $backlog_filter
+          "path" $currentPath
+        ) }}
       {{ end }}
     {{ end }}
-  </article>
+    {{ if lt 0 ($recurringTasks | len) }}
+      <h2>Recurring Tasks</h2>
+      <p>These tasks need to be completed in every sprint.</p>
+      {{range $recurringTasks}}
+        {{ partial "block/backlog-issue.html" (dict
+          "block" .
+          "Page" $.Page
+          "Site" site
+          "sprint" $backlog_filter
+          "path" $currentPath
+        ) }}
+      {{ end }}
+    {{ end }}
+    {{ if lt 0 ($mandatoryTasks | len) }}
+      <h2>Mandatory Tasks</h2>
+      <p>These tasks will help consolidate your learning for this sprint. You should complete as many of these as possible before class on Saturday.</p>
+      {{range $mandatoryTasks}}
+        {{ partial "block/backlog-issue.html" (dict
+          "block" .
+          "Page" $.Page
+          "Site" site
+          "sprint" $backlog_filter
+          "path" $currentPath
+        ) }}
+      {{ end }}
+    {{ end }}
+    {{ if lt 0 ($optionalTasks | len) }}
+      <h2>Optional Tasks</h2>
+      <p>These are optional "stretch goals" to attempt when you have finished the mandatory tasks. They may be more challenging or require some additional research.</p>
+      {{range $optionalTasks}}
+        {{ partial "block/backlog-issue.html" (dict
+          "block" .
+          "Page" $.Page
+          "Site" site
+          "sprint" $backlog_filter
+          "path" $currentPath
+        ) }}
+      {{ end }}
+    {{ end }}
+</article>
 {{ end }}

--- a/common-theme/layouts/partials/block/backlog-issue.html
+++ b/common-theme/layouts/partials/block/backlog-issue.html
@@ -2,7 +2,7 @@
     <summary class="c-issue__title e-heading__3">
         {{ .block.name }}
         <a class="c-issue__link" href="{{ .block.src }}">🔗</a>
-        <a href="https://curriculum.codeyourfuture.io/api/clone?state={{ dict "issue" .block.number "module" .repo "sprint"
+        <a href="https://curriculum.codeyourfuture.io/api/clone?state={{ dict "issue" .block.number "module" .block.repo "sprint"
             .sprint "prevURL" (urls.AbsLangURL .path) | jsonify }}" class="e-button"
             data-props="{{ .Page.RelPermalink }}">
             Clone

--- a/common-theme/layouts/partials/block/issues-list-as-blocks.html
+++ b/common-theme/layouts/partials/block/issues-list-as-blocks.html
@@ -7,9 +7,10 @@
   We did that because PD kept making partially matching labels, but maybe we should be stricter
   TODO But it means someone has to go round and clean up
 */}}
+{{ $repo := .backlog }}
 {{ $variables := dict
   "owner" site.Params.owner
-  "repo" .backlog
+  "repo" $repo
 }}
 {{ $currentPath := .path }}
 {{ if .backlog_filter }}
@@ -59,7 +60,7 @@
     {{ else }}
       {{ with .data.repository.issues.nodes }}
         {{ range sort . "title" "asc" }}
-          {{ $issueBlocks = $issueBlocks | append (dict "name" .title "src" .url "number" .number "labels" .labels) }}
+          {{ $issueBlocks = $issueBlocks | append (dict "name" .title "src" .url "number" .number "labels" .labels "repo" $repo) }}
         {{ end }}
       {{ end }}
     {{ end }}


### PR DESCRIPTION
We support pulling in issues from multiple backlogs - currently they end up being shown separately (with separate "Setup"/"Mandatory"/... sections).

Instead, merge them into one list of issues before rendering.


