### PR TITLE
Standardise study group blocks

### DIFF
--- a/common-content/en/blocks/study-group/index.md
+++ b/common-content/en/blocks/study-group/index.md
@@ -10,7 +10,7 @@ time = 60
   publishResources = false
 +++
 
-## Trainees
+### Trainees
 
 This is time for you to get help with whatever you need help with.
 
@@ -24,14 +24,78 @@ If you don't have any problems, keep working through the backlog until you need 
 
 It can be useful to get into groups with others facing the same problem, or working on the same backlog item.
 
-## Volunteers
+### Volunteers
 
 Don't be scared to approach people and ask what they're working on - see if you can help them out, or stretch their understanding.
 
 If lots of people have the same problems, maybe you can put together a demonstration or a workshop to help them understand.
 
-If absolutely no one needs help, consider [reviewing some PRs](/prs-needing-review) using the process and guidelines in [the #cyf-code-review-team Slack channel](https://codeyourfuture.slack.com/archives/C07RZA0ERLN) canvas.
+If absolutely no one needs help, consider [reviewing some PRs](/prs-needing-review) using the process and guidelines in [the #cyf-code-review-volunteer-team Slack channel](https://codeyourfutur-yov6609.slack.com/archives/C0A1E83EZRP) canvas.
 
-## Breaks
+### Breaks
 
 No one can work solidly forever! Make sure to take breaks when you need.
+
+### Finished everything?
+
+If you have finished everything in the backlog you can use this time to practice some other skills which will be useful in your future careers. We have some suggestions below:
+
+<details>
+<summary>
+
+#### Pair programming
+
+</summary>
+
+Pair programming is very common in industry so it's good to practice it now! Find a partner and choose a problem to work on, for example a [Codewars](https://www.codewars.com) kata. One person will be the "driver" and the other will be the "navigator". Both of you will use the same laptop to complete the activity.
+
+- The "driver" is the person typing on the keyboard, just thinking about what needs to be written
+- The "navigator" reviews what the driver is doing and is thinking about to write next
+- Switch between driver and navigator roles after {{<timer>}}10{{</timer>}}
+- Don't dominate - this is teamwork
+
+</details>
+
+<details>
+<summary>
+
+#### Code review
+
+</summary>
+
+You will receive regular reviews of your work from volunteers when you submit a PR, but how comfortable are you _giving_ a review? Find a partner and give each other feedback on one of the PRs you submitted this week. After you have given your feedback you should consider:
+
+- How did you understand what the goal of the PR is? Did you read the title and description, look at the coursework exercises, etc.
+- How did you use the different tabs in the PR: `Conversation`, `Commits`, `Files changed`.
+- What made a PR easy or hard to review:
+  - Where unrelated files/lines changed?
+  - Was code consistently formatted? Did indentation help or hurt understanding?
+- How did you review the code? Did you read top-to-bottom? Did you jump around into and out-of functions? Did you look at tests? Did you clone the code locally and try running it?
+
+</details>
+
+<details>
+<summary>
+
+#### Prepare for your next demo
+
+</summary>
+
+You need to give regular demos to complete the course. Use this time to work on your next one. You could:
+
+- Prepare your slides
+- Discuss topics
+- Practice presenting
+
+</details>
+
+<details>
+<summary>
+
+#### Share resources you have found
+
+</summary>
+
+{{<our-name>}} aren't the only resource available to you! If you have discovered a new book, YouTube channel or anything else you are using to help you learn this is an excellent time to share it with your cohort.
+
+</details>

--- a/common-content/en/blocks/study-group/index.md
+++ b/common-content/en/blocks/study-group/index.md
@@ -54,6 +54,8 @@ Pair programming is very common in industry so it's good to practice it now! Fin
 - Switch between driver and navigator roles after {{<timer>}}10{{</timer>}}
 - Don't dominate - this is teamwork
 
+There are further details in our [Pair Programming Guide](/guides/pair-programming/#drivernavigator-pair-programming).
+
 </details>
 
 <details>

--- a/org-cyf/content/itp/onboarding/sprints/1/day-plan/index.md
+++ b/org-cyf/content/itp/onboarding/sprints/1/day-plan/index.md
@@ -48,15 +48,6 @@ src="blocks/afternoon-break"
 name="Study Group"
 src="blocks/study-group"
 time=85
-[[blocks.nested.blocks]]
-name="Optional structured activity: Pomodoro"
-src="module/onboarding/pomodoro"
-[[blocks.nested.blocks]]
-name="Optional structured activity: Pair Programming"
-src="module/onboarding/pairing"
-[[blocks.nested.blocks]]
-name="Bikes for Refugees Project"
-src="https://github.com/CodeYourFuture/Module-Onboarding/issues/22"
 [[blocks]]
 name="Wrap"
 src="blocks/wrap"

--- a/org-cyf/content/itp/onboarding/sprints/2/day-plan/index.md
+++ b/org-cyf/content/itp/onboarding/sprints/2/day-plan/index.md
@@ -28,19 +28,6 @@ src="blocks/working-with-others"
 name="Study Group"
 src="blocks/study-group"
 time=145
-[[blocks.nested.blocks]]
-name="Optional structured activity: Live Code Review"
-src="blocks/mentored-code-review"
-[[blocks.nested.blocks]]
-name="Optional structured activity for consolidating Git"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/git-day-1"
-time=0
-[[blocks.nested.blocks]]
-name="Optional structured activity for consolidating HTML forms"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/get-forms"
-[[blocks.nested.blocks]]
-name="Optional structured activity: Pair Programming"
-src="module/onboarding/pairing"
 [[blocks]]
 name="Wrap"
 src="module/onboarding/wrap"

--- a/org-cyf/content/itp/structuring-data/sprints/1/day-plan/index.md
+++ b/org-cyf/content/itp/structuring-data/sprints/1/day-plan/index.md
@@ -31,15 +31,6 @@ time=15
 name="Study Group"
 src="blocks/study-group"
 time=135
-[[blocks.nested.blocks]]
-name="Optional structured activity: Pair Programming"
-src="module/onboarding/pairing"
-[[blocks.nested.blocks]]
-name="Optional structured activity: Code Review"
-src="blocks/mentored-code-review"
-[[blocks.nested.blocks]]
-name="Optional structured activity: Know Your Computer"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/know-your-computer"
 [[blocks]]
 name="Retro"
 src="blocks/retro"

--- a/org-cyf/content/itp/structuring-data/sprints/2/day-plan/index.md
+++ b/org-cyf/content/itp/structuring-data/sprints/2/day-plan/index.md
@@ -33,16 +33,6 @@ time=30
 name="Study Group"
 src="blocks/study-group"
 time=120
-[[blocks.nested.blocks]]
-name="Optional structured activity: Code Review"
-src="blocks/mentored-code-review"
-[[blocks.nested.blocks]]
-name="Optional structured activity: Pair Programming"
-src="module/onboarding/pairing"
-[[blocks.nested.blocks]]
-name="Optional structured activity: Predict Explain exercises"
-src="https://github.com/CodeYourFuture/CYF-Workshops/tree/main/questions-and-reviews/"
-time=0
 [[blocks]]
 name="Retro"
 src="blocks/retro"

--- a/org-cyf/content/itp/structuring-data/sprints/3/day-plan/index.md
+++ b/org-cyf/content/itp/structuring-data/sprints/3/day-plan/index.md
@@ -33,18 +33,6 @@ time=15
 name="Study Group"
 src="blocks/study-group"
 time=135
-[[blocks.nested.blocks]]
-name="Optional structured activity: Pair Programming"
-src="module/onboarding/pairing"
-[[blocks.nested.blocks]]
-name="Optional structured activity: Code Review"
-src="blocks/mentored-code-review"
-[[blocks.nested.blocks]]
-name="Optional structured activity: Pomodoro"
-src="module/onboarding/pomodoro"
-[[blocks.nested.blocks]]
-name="Optional structured activity: Kata"
-src="blocks/kata"
 [[blocks]]
 name="Retro"
 src="blocks/retro"


### PR DESCRIPTION
Per [discussions in the curriculum team](https://curriculum.codeyourfuture.io/guides/contributing/minutes/#:~:text=is%20imported%20to-,2026%2D02%2D24,-Attendees%3A%20Anna%20Aitchison) this adds some suggested activities to the study group blocks and standardises them across all sprints. The activities are:

- Pair programming
- Code review
- Working on a demo
- Sharing resources

It also removes any nested study group blocks from day plans to avoid duplication. The blocks/workshops are still there if we want to use them elsewhere.