### PR TITLE
Add links to the current sprint backlog

### DIFF
--- a/common-content/en/blocks/backlog/index.md
+++ b/common-content/en/blocks/backlog/index.md
@@ -21,7 +21,7 @@ A sprint backlog is like a to-do list. It lists what the team has decided to wor
 
 In this course, the backlog is a set of work designed to build understanding beyond the concepts introduced in the course prep. For your course, we have prepared a backlog of mandatory work for each sprint. You will copy these tasks into your own backlog. You can also add any other tickets you want to work on to your backlog, and schedule all of the tasks according to your own goals and capacity. Use your planning board to do this.
 
-You will find the backlog in the **Backlog** view on every sprint.
+You will find the backlog in [the **Backlog** view](../backlog/) on every sprint.
 
 Copy the tickets you are working on to your own backlog. Organise your tickets on your board and move them to the right column as you work through them. Here's a flowchart showing the stages a ticket goes through:
 
@@ -35,7 +35,7 @@ flowchart LR
 
 {{<note title="Backlog (30 minutes)" type="activity">}}
 
-1. Find the sprint backlog
+1. Find [the sprint backlog](../backlog/)
 2. Copy your tickets to your own backlog
 3. Organise your tickets on your board
 


### PR DESCRIPTION
There's a trade-off here - by including the links, we may make it harder for people to find the backlog _next time_ when there doesn't happen to be a link to it. But in the first week, "I can work out what I need to do" is probably more important than "I'll put in the work to be able to work it out next time".


