### PR TITLE
Code review cleanup

### DIFF
--- a/org-cyf-guides/content/reviewing/code-review-basics/index.md
+++ b/org-cyf-guides/content/reviewing/code-review-basics/index.md
@@ -109,6 +109,6 @@ If you want to dive deeper into code review, check out these resources:
 
 ## Practice Exercise
 
-Find an open pull request in the [#cyf-code-review](https://codeyourfutur-yov6609.slack.com/archives/C07QX99JK7B) channel and practice reviewing it using this guide.
+Find an open pull request by joining the [#cyf-code-review-volunteer-team](https://codeyourfutur-yov6609.slack.com/archives/C0A1E83EZRP) channel and following one of the links in the **Code Review Resources** tab. Once you've chosen one, practice reviewing it using this guide.
 
 Remember: Code review is a conversation, not a judgment. We're all learning!

--- a/org-cyf/content/itp/data-flows/success/index.md
+++ b/org-cyf/content/itp/data-flows/success/index.md
@@ -44,6 +44,6 @@ weight = 11
 1. Submit the issue link to step 4 of ITP on [CYF Course Portal](https://application-process.codeyourfuture.io/).
 
 > [!NOTE]
-> A pull request is _completed_ when a volunteer has added the "Complete" tag. If nobody has reviewed your PR after one week, please ask on Slack in #cyf-code-review.
+> A pull request is _completed_ when a volunteer has added the "Complete" tag.
 
 Celebrate your hard work by checking off the objectives below!

--- a/org-cyf/content/itp/data-groups/success/index.md
+++ b/org-cyf/content/itp/data-groups/success/index.md
@@ -41,6 +41,6 @@ weight = 11
 1. Submit the issue link to step 3 of ITP on [CYF Course Portal](https://application-process.codeyourfuture.io/).
 
 > [!NOTE]
-> A pull request is _completed_ when a volunteer has added the "Complete" tag. If nobody has reviewed your PR after one week, please ask on Slack in #cyf-code-review.
+> A pull request is _completed_ when a volunteer has added the "Complete" tag.
 
 Celebrate your hard work by checking off the objectives below!

--- a/org-cyf/content/itp/onboarding/success/index.md
+++ b/org-cyf/content/itp/onboarding/success/index.md
@@ -45,6 +45,6 @@ weight = 11
 1. **[Apply to enroll as a Trainee](https://forms.gle/vRuofa7aeL5DsbhGA)**.
 
 > [!NOTE]
-> A pull request is _completed_ when a volunteer has added the "Complete" tag. If nobody has reviewed your PR after one week, please ask on Slack in #cyf-code-review.
+> A pull request is _completed_ when a volunteer has added the "Complete" tag.
 
 Celebrate your hard work by checking off the objectives below!

--- a/org-cyf/content/itp/structuring-data/success/index.md
+++ b/org-cyf/content/itp/structuring-data/success/index.md
@@ -47,6 +47,6 @@ weight = 11
 1. Submit the issue link to step 2 of ITP on [CYF Course Portal](https://application-process.codeyourfuture.io/).
 
 > [!NOTE]
-> A pull request is _completed_ when a volunteer has added the "Complete" tag. If nobody has reviewed your PR after one week, please ask on Slack in #cyf-code-review.
+> A pull request is _completed_ when a volunteer has added the "Complete" tag.
 
 Celebrate your hard work by checking off the objectives below!


### PR DESCRIPTION
Upon closing the `#cyf-code-review` channel we are also removing the stipulation that trainees should notify us when their work hasn't been reviewed for a week, given that we have the capacity currently to basically always avoid this being an issue.

This PR:
- Removes the references to the one-week expectation for reviewing PRs
- Updates reference to `#cyf-code-review` to instead by `#cyf-code-review-volunteer-team` when inviting prospective new code reviewers