### PR TITLE
docs: point devs to the running-locally guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Common is tightly integrated with GitHub. Really the main content should always 
 
 Each org or team configures its own Hugo site that mounts the common theme and content modules, and then makes any customisations they need and deploys it wherever they want. You can use any repo to do this and your site can be as simple as a `hugo.toml` and a `content/_index.md`. We'd love for you to use Common, too!
 
+## Running locally
+
+To build and run the curriculum on your own machine (install Hugo/Go/npm, create a GitHub token, and start the dev server), follow our [Building the Curriculum Locally](https://curriculum.codeyourfuture.io/guides/contributing/running-locally/) guide. The source for that guide lives at [`org-cyf-guides/content/contributing/running-locally/index.md`](org-cyf-guides/content/contributing/running-locally/index.md).
+
 ## Examples
 
 - https://curriculum.codeyourfuture.io/

--- a/common-theme/layouts/partials/github-auth.html
+++ b/common-theme/layouts/partials/github-auth.html
@@ -3,6 +3,6 @@
 {{ if ne $token "" }}
   {{ $headers = dict "headers" (dict "Authorization" (print "Bearer " $token)) }}
 {{ else }}
-  {{ errorf "🏷️ Site needs a HUGO_CURRICULUM_GITHUB_BEARER_TOKEN. Check the README" }}
+  {{ errorf "🏷️ Site needs a HUGO_CURRICULUM_GITHUB_BEARER_TOKEN. See https://curriculum.codeyourfuture.io/guides/contributing/running-locally/" }}
 {{ end }}
 {{ return $headers }}

--- a/org-cyf-guides/content/contributing/running-locally/index.md
+++ b/org-cyf-guides/content/contributing/running-locally/index.md
@@ -14,7 +14,7 @@ Our curriculum is built on top of [Hugo](https://gohugo.io/) and requires some p
 - `npm`
 
 > [!WARNING]
-> We require `v0.136.5-extended` of `hugo` which can be downloaded from [GitHub](https://github.com/gohugoio/hugo/releases/tag/v0.136.5) and manually added to your `$PATH`.
+> We require `v0.136.3-extended` of `hugo` (the version pinned in `netlify.toml`), which can be downloaded from [GitHub](https://github.com/gohugoio/hugo/releases/tag/v0.136.3) and manually added to your `$PATH`.
 > 
 > Later versions will induce an error and building will fail.
 > 


### PR DESCRIPTION
The missing-token build error tells you to "Check the README", but the README had no local setup instructions. This adds a pointer and fixes a version mismatch.

- **README:** add a "Running locally" section linking to the running-locally guide
- **github-auth.html:** change the missing-token error to point at the running-locally guide instead of the README
- **running-locally guide:** correct the required Hugo version (`0.136.5` -> `0.136.3`) to match `netlify.toml`