### PR TITLE
SDC demos can be 5 minutes not just 2

### DIFF
--- a/common-content/en/blocks/demo/index.md
+++ b/common-content/en/blocks/demo/index.md
@@ -14,13 +14,13 @@ At {{<our-name>}} we expect you to demo your work to the class. You must have ma
 
 The timekeeper will keep the groups on track.
 
-Split randomly into groups of no more than 5 people. Each person will have 2 minutes to demo their work to the group. After the demo, the group will give feedback for 5 minutes. Then the next person will demo their work.
+Split randomly into groups each with at least one volunteer - ideally no more than 5 trainees per group. Each person will have 5 minutes to demo their work to the group. After the demo, the group will give feedback for 5 minutes. Then the next person will demo their work.
 
 ## 🧑🏼‍🎓 Trainees
 
 ### 1. Demo
 
-You will demo your work to the group. You will have 2 minutes to explain what you did and why. It's ok to show broken code or code that doesn't work yet. Just make sure your demo is interesting.
+You will demo your work to the group. You will have up to 5 minutes to explain what you did and why. It's ok to show broken code or code that doesn't work yet. Just make sure your demo is interesting.
 
 ### 2. Feedback
 


### PR DESCRIPTION
We may want to extend the time in the day-plan we give to demos too, but for now, just give a clearer indication of the time expectation.


