### PR TITLE
Fix how to get How Computers Really Work

### DIFF
--- a/org-cyf/content/blocks/get-how-computers-really-work/index.md
+++ b/org-cyf/content/blocks/get-how-computers-really-work/index.md
@@ -12,7 +12,7 @@ Throughout this course, we will reference the book [How Computers Really Work](h
 
 You will need a copy.
 
-The author, Matthew Justice, has kindly donated a pdf of this book for use by CodeYourFuture trainees. If you would like a copy of this PDF, you can find access details in the [#software-development-course slack channel](https://codeyourfuture.slack.com/archives/C0884D7GLS3).
+The author, Matthew Justice, has kindly donated a pdf of this book for use by CodeYourFuture trainees. If you would like a copy of this PDF, you can find access details in the canvas of your cohort channel.
 
 If you buy your own copy [from e.g. Amazon](https://www.amazon.co.uk/How-Computers-Work-Hands-Workings/dp/1718500661), {{<our-name>}} cannot pay for this.
 


### PR DESCRIPTION
The link was previously into the admin Slack, which most trainees don't have access to any more.

Instead, describe where they can find it in the Slack they're on. This will change each cohort, so remove the link.


