### PR TITLE
Install the CodeYourFuture Extension Pack during onboarding

### DIFF
--- a/common-content/en/blocks/linting/index.md
+++ b/common-content/en/blocks/linting/index.md
@@ -14,7 +14,7 @@ hide_from_overview=true
 
 - [ ] You must have a UNIX operating system (MacOS or Linux). Don't use Windows.
 - [ ] You must have [VSCode](https://code.visualstudio.com/) installed. Don't use another editor.
-- [ ] You must have the **CYF [VS Code extension pack](https://marketplace.visualstudio.com/items?itemName=CodeYourFuture.cyf-extension-pack)** installed and Prettier enabled. Don't use another formatter.
+- [ ] You must have the **[CodeYourFuture Extension Pack](https://marketplace.visualstudio.com/items?itemName=CodeYourFuture.cyf-extension-pack)** installed (you set this up during onboarding) and Prettier enabled. Don't use another formatter.
 
 ### 🧹 Linting and formatting
 

--- a/common-content/en/module/induction/install-vscode/index.md
+++ b/common-content/en/module/induction/install-vscode/index.md
@@ -5,6 +5,7 @@ time = 15
 [objectives]
     1='Download and install VSCode'
     2='Identify the key parts of the VSCode interface'
+    3='Install the CodeYourFuture Extension Pack'
 [build]
   render = 'never'
   list = 'local'
@@ -15,6 +16,10 @@ time = 15
 We use VS Code to write all of our code in the course. It is known as an Integrated Development Environment (IDE) and really helps you write great code.
 
 > [🔗 Download and install VSCode now](https://code.visualstudio.com/)
+
+Once VS Code is installed, add the CodeYourFuture Extension Pack. It installs the extensions you will use throughout the course and sets up sensible editor defaults.
+
+> [🔗 Install the CodeYourFuture Extension Pack now](https://marketplace.visualstudio.com/items?itemName=CodeYourFuture.cyf-extension-pack)
 
 {{<columns>}}
 


### PR DESCRIPTION
Adds the extension pack to the VS Code install step so trainees set it up on day one. Note the shared install-vscode block also renders on the SDC tools prep page. The linting block is not currently embedded by any page; its edit is for consistency if it gets reused.

Previews:

- [ITP onboarding sprint 1 prep](https://deploy-preview-1945--cyf-curriculum.netlify.app/itp/onboarding/sprints/1/prep/#install-vs-code)
- [SDC tools prep](https://deploy-preview-1945--cyf-curriculum.netlify.app/sdc/tools/prep/#install-vs-code)