### PR TITLE
restructure feedback workshop

### DIFF
--- a/common-content/en/workshops/feedback/index.md
+++ b/common-content/en/workshops/feedback/index.md
@@ -55,9 +55,9 @@ For the person receiving feedback, remember to:
 
 The [SBI Framework](https://www.revolutionlearning.co.uk/article/the-sbi-feedback-model/) structures feedback in the following order:
 
-- Situation: Describe the situation
-- Behavior: Describe the behavior observed
-- Impact: Explain the effect of the behavior on you, your team, or the organization
+- **Situation**: Describe the situation. This should be objective - no personal interpretations or feelings.
+- **Behavior**: Describe the behavior observed. This should also be objective.
+- **Impact**: Explain the effect of the behavior on you, your team, or the organization. This can be subjective - it's ok to talk about how things made you feel. But don't guess _why_ someone else did something.
 
 **Scenario**: A teammate consistently misses deadlines and when they finally do deliver their tasks, they are often not of good quality tasks requiring the rest of the team to redo portions of their work.
 

--- a/common-content/en/workshops/feedback/index.md
+++ b/common-content/en/workshops/feedback/index.md
@@ -2,7 +2,10 @@
 title = "Giving Feedback"
 time = 60
 objectives = [
-    "Give actionable feedback using a structured framework.",
+    "Choose a framework for giving clear, direct feedback depending on the scenario",
+    "Reflect on the impact of feedback on personal growth and team dynamics",
+    "Apply feedback techniques to real-world situations, balancing critique with encouragement",
+    "Apply techniques for receiving tough feedback",
 ]
 [build]
   list = "local"
@@ -13,15 +16,6 @@ objectives = [
 Feedback is the foundation of effective collaboration. Both giving and receiving feedback are important communication skills to master.
 
 We will practice giving and receiving feedback today.
-
-## Learning Objectives 💡
-
-After the workshop today, participants will be able to:
-
-- [ ] Choose a framework for giving clear, direct feedback depending on the scenario.
-- [ ] Reflect on the impact of feedback on personal growth and team dynamics
-- [ ] Apply feedback techniques to real-world situations, balancing critique with encouragement
-- [ ] Apply techniques for receiving tough feedback
 
 ## Set up 🌼
 

--- a/common-content/en/workshops/feedback/index.md
+++ b/common-content/en/workshops/feedback/index.md
@@ -10,22 +10,11 @@ objectives = [
   render = "never"
 +++
 
-Feedback is the foundation of effective collaboration. Both giving and receiving feedback are important communication skills to master. 
-
-### Tips for Giving Feedback: 
-* Give feedback in the right context, being mindful of tone and its impact on the receiver. 
-* Give feedback in a timely fashion, be direct, and non-accusatory (assume positive intent).
-* Give feedback privately.
-* Sometimes it is also better to ask if someone would like feedback.
-
-### Tips for Receiving Feedback: 
-* Receiving feedback is crucial for measuring your progress and understanding unspoken expectations.
-* Ask for feedback early and often. [Asking for feedback late on a project or presentation can lead us to be less receptive to criticism](https://hbr.org/2023/06/the-right-time-to-ask-for-feedback#:~:text=The%20best%20approach%20is%20to,annual%20performance%20review%20rolls%20around).
-* Not all feedback will always be positive, it is important to learn to take good and bad feedback in stride.
+Feedback is the foundation of effective collaboration. Both giving and receiving feedback are important communication skills to master.
 
 We will practice giving and receiving feedback today.
 
-## Learning Objective 💡
+## Learning Objectives 💡
 
 After the workshop today, participants will be able to:
 
@@ -38,112 +27,101 @@ After the workshop today, participants will be able to:
 
 - Pair up into groups of 2
 
-## The Activity 🏆 
-
-First, read [this article](https://tanzu.vmware.com/content/blog/mastering-feedback-in-the-workplace) on mastering feedback in the workplace. 
+## The Activity 🏆
 
 Read the following scenarios and role-play each. One person will be giving the feedback and one person will be receiving the feedback. After each scenario switch who is giving the feedback and who is receiving it.
 
 For the person giving feedback, remember to:
+
 - Be direct
 - Use clear language
 - Talk about behavior, not personality
 - Be kind
 
 For the person receiving feedback, remember to:
+
 - Be available and approachable
-- Accountable
+- Be accountable
 - Steer clear of defensiveness
 - Take a moment to reflect before responding
 - Assume positive intent
 
-### Practice Giving Feedback [20 mins]
+### Practice Giving Feedback [15 mins]
 
-* Spend 3 mins on each of these scenarios.
-* One person will be giving the feedback and one person will be receiving the feedback. After each scenario switch who is giving the feedback and who is receiving it.
+- Spend 3 mins on each of these tasks, applying the given framework to the given scenario.
+- One person will be giving the feedback and one person will be receiving the feedback. After each scenario switch who is giving the feedback and who is receiving it.
 
-1. Situation, Behavior, Impact (SBI) Framework
+#### 1. Situation, Behavior, Impact (SBI) framework
 
 The [SBI Framework](https://www.revolutionlearning.co.uk/article/the-sbi-feedback-model/) structures feedback in the following order:
-* Situation: Describe the situation
-* Behavior: Describe the behavior observed
-* Impact: Explain the effect of the behavior on you, your team, or the organization
 
-Try Applying the SBI method to the following scenario: A teammate consistently misses deadlines and when they finally do deliver their tasks, they are often not of good quality tasks requiring the rest of the team to redo portions of their work.
+- Situation: Describe the situation
+- Behavior: Describe the behavior observed
+- Impact: Explain the effect of the behavior on you, your team, or the organization
 
-Objective: Use the SBI framework for giving feedback. Practice addressing issues of accountability, responsibility, and time management without demotivating the person. 
+**Scenario**: A teammate consistently misses deadlines and when they finally do deliver their tasks, they are often not of good quality tasks requiring the rest of the team to redo portions of their work.
 
-2. Observation, Feelings, Needs, and Request (OFNR) framework
+#### 2. Observation, Feelings, Needs, and Request (OFNR) framework
 
 The [OFNR framework](https://andyblumenthal.wordpress.com/2019/09/21/ofnr-communications-model/) consists of four parts:
-* Observation: Tell the other person the behavior you observe from them that is making you uncomfortable. "When I Observe…"
-* Feelings: Explain how the person’s behavior makes you feel (happy, sad, angry, annoyed, excited, worried, scared, hurt, embarrassed, confused) "I feel…"
-* Needs: Describe what you need from the other person (physiological, safety, social, esteem, self-actualization) "Because I need…"
-* Request: Ask them specifically what you’d like them to do. "Would you be willing to…"
 
-Try Applying the ONFR method to the following scenario: A team member gives an informative presentation that is too long-winded, going over an hour causing the audience to lose focus. This presentation will be used at the next client meeting which is only 1 hour long and needs to cover many other topics. 
+- Observation: Tell the other person the behavior you observe from them that is making you uncomfortable. "When I Observe…"
+- Feelings: Explain how the person’s behavior makes you feel (happy, sad, angry, annoyed, excited, worried, scared, hurt, embarrassed, confused) "I feel…"
+- Needs: Describe what you need from the other person (physiological, safety, social, esteem, self-actualization) "Because I need…"
+- Request: Ask them specifically what you’d like them to do. "Would you be willing to…"
 
-Objective: Use the (OFNR) framework to give the team member feedback. Practice providing feedback on communication skills, structuring information, and presentation techniques.
+**Scenario**: A team member gives an informative presentation that is too long-winded, going over an hour causing the audience to lose focus. This presentation will be used at the next client meeting which is only 1 hour long and needs to cover many other topics.
 
-3. Actionable, Specific, Kind (ASK) framework
+#### 3. Actionable, Specific, Kind (ASK) framework
 
 The [ASK framework](https://www.stride.build/blog/using-ask-framework-to-give-feedback) focuses on the following attributes:
-* Actionable: Address the actionable issue
-* Specific: Be specific in your request.
-* Kind
 
-Scenario: A colleague dominates team discussions, interrupting others or dismissing alternative ideas without considering them. His behavior is often seen as grating or rude by the team.
+- Actionable: Address the actionable issue
+- Specific: Be specific in your request.
+- Kind
 
-Objective: Use the ASK framework to give feedback. Start by addressing the actionable issue and be specific in your request. Make sure it is delivered in a kind and understanding manner. Address how their behavior affects group dynamics and encourage a more inclusive approach, allowing others to share their thoughts.
+**Scenario**: A colleague dominates team discussions, interrupting others or dismissing alternative ideas without considering them. His behavior is often seen as grating or rude by the team.
 
-4. Goal, Reality, Options, Will (GROW) model
+#### 4. Goal, Reality, Options, Will (GROW) framework
 
 The [Grow framework](https://www.mindtools.com/an0fzpz/the-grow-model-of-coaching-and-mentoring) focuses on mentoring and guidance to give feedback
-* Goal: Explore the individual's goals
-* Reality: Assess the current reality
-* Options: Brainstorm options
-* Will: Create a list of actions to commit to to achieve the goal
 
-Scenario: A colleague is working towards a promotion to senior software engineer and has asked you for feedback on their performance. Although they have great technical proficiency you have noticed that they do not speak up during meetings unless directly asked and often wait for tasks to be assigned instead of taking initiative.
+- Goal: Explore the individual's goals
+- Reality: Assess the current reality
+- Options: Brainstorm options
+- Will: Create a list of actions to commit to to achieve the goal
 
-Objective: Use the GROW model to speak with your colleague.
+**Scenario**: A colleague is working towards a promotion to senior software engineer and has asked you for feedback on their performance. Although they have great technical proficiency you have noticed that they do not speak up during meetings unless directly asked and often wait for tasks to be assigned instead of taking initiative.
 
-### Choose a Framework for Giving Feedback [10 mins]
+### Choose a Framework for Giving Feedback [15 mins]
 
 We have looked at the following frameworks for giving feedback:
+
 - Situation, Behavior, Impact (SBI) - Describe the situation, detail the specific behavior observed, and explain the impact it had.
 - Actionable, Specific, Kind (ASK) - Start with an actionable issue, be specific in your request and make sure it is delivered in a kind manner.
 - Observation, Feelings, Needs and Actions (OFNA) - discuss an observation, how it made you feel, what needs to happen to rectify this behavior and the actions they can take.
-- Goal, Reality, Options, Will (GROW) model. Explore the individual's goals, assess the current reality, brainstorm options, and commit to action. This model is best suited when the individual is already aware of the area to improve. 
+- Goal, Reality, Options, Will (GROW) model. Explore the individual's goals, assess the current reality, brainstorm options, and commit to action. This model is best suited when the individual is already aware of the area to improve.
 
-For the following scenarios, discuss with your partner which framework you think should be applied. 
+Spend **10 minutes** working through the following scenarios, discussing with your partner which framework you think should be applied.
 
-1. Behavioral Feedback
+1. **Behavioural Feedback** - A team member frequently arrives late to meetings, affecting the team's schedule.
 
-Scenario: A team member frequently arrives late to meetings, affecting the team's schedule.
+2. **Positive Feedback for Improvement** - A colleague made significant improvements in their work, but there’s still room for further development.
 
-2. Positive Feedback for Improvement
+3. **Conflict Resolution** - Two team members have a disagreement about how to approach a project, leading to tension in meetings.
 
-Scenario: A colleague made significant improvements in their work, but there’s still room for further development.
+4. **Performance Review** - You are giving a formal performance review to a team member whose work has been solid but lacks creativity or initiative.
 
-3. Conflict Resolution
+5. **Cross-Team Collaboration** - A team member from another department is not communicating well with your team, leading to delays and confusion.
 
-Scenario: Two team members have a disagreement about how to approach a project, leading to tension in meetings.
-
-4. Performance Review
-
-Scenario: You are giving a formal performance review to a team member whose work has been solid but lacks creativity or initiative.
-
-5. Cross-Team Collaboration
-
-Scenario: A team member from another department is not communicating well with your team, leading to delays and confusion.
-
+Come together as a group and spend **5 minutes** discussing which frameworks were chosen for each scenario and why. Your answers are unlikely to all be the same!
 
 ## Reflection 🧘‍♂️ [10 mins]
 
 Come together as a group and discuss the following:
 
 When giving feedback:
+
 - What challenges did you face when delivering feedback?
 - How did you decide which feedback framework to use? Would you choose the same framework in real life?
 - Which framework do you find the most useful? Which did you struggle with the most?
@@ -152,7 +130,27 @@ When giving feedback:
 - How do you think feedback methods can differ depending on the person or context?
 
 When receiving feedback:
+
 - How did the feedback make you feel? Was it easy to remain open to feedback?
 - Were there any moments when you felt defensive? How did you manage those feelings? How might you manage those feelings in real-world scenarios?
 - Was the feedback clear and actionable? How would you apply it to improve?
 - How can you proactively seek out more feedback from your peers or mentors?
+
+## Wrap-up
+
+In this session we've practised giving feedback in a variety of different scenarios and have explored several frameworks we can use to help us do it. Each of them provides us with a possible new approach we can take when figuring out how to give feedback constructively and effectively.
+
+When you are giving feedback in the future, you should refer back to the frameworks discussed here and - just as we did in the activity - think about which one would be appropriate for the situation you're in. After giving out this feedback, consider what went well and what didn't. How succesfully did you adhere the framework you chose? Did it fit the situation as well as you had hoped? Carry your answers forward and use them to give even better feedback next time.
+
+### Tips for Giving Feedback:
+
+- Give feedback in the right context, being mindful of tone and its impact on the receiver.
+- Give feedback in a timely fashion, be direct, and non-accusatory (assume positive intent).
+- Give feedback privately.
+- Sometimes it is also better to ask if someone would like feedback.
+
+### Tips for Receiving Feedback:
+
+- Receiving feedback is crucial for measuring your progress and understanding unspoken expectations.
+- Ask for feedback early and often. [Asking for feedback late on a project or presentation can lead us to be less receptive to criticism](https://hbr.org/2023/06/the-right-time-to-ask-for-feedback#:~:text=The%20best%20approach%20is%20to,annual%20performance%20review%20rolls%20around).
+- Not all feedback will always be positive, it is important to learn to take good and bad feedback in stride.


### PR DESCRIPTION
I really liked this workshop, but I thought it would benefit from a bit of a restructure. This PR aims to streamline the activity tasks by chopping some words and doing a bit of reformatting, and generally restructures the document slightly.

This involves:

- Removing the "objective" section from each of the framework tasks - the objective is just to practise using the framework in question
- Moving tips for feedback giving/receiving to the end as they make more sense as parting advice
- Removing the stipulation to read a 1,800 word article before starting
- Slight timing tweaks to include a discussion of framework choices
- Adding a short conclusion
- General formatting

**Note:** given that I've removed the expectation of reading the article at the start, do we think it ought to be added to prep/backlog?