### PR TITLE
ambigious instructions

### DIFF
--- a/common-content/en/module/tools/process-spelunking/index.md
+++ b/common-content/en/module/tools/process-spelunking/index.md
@@ -396,7 +396,8 @@ After that, if you run `echo $?`, you should get `0`, indicating the program ran
 
 {{<tabs>}}
 ===[[Exercise]]===
-Run `strace -o strace.output python3 exercise_3.py`.
+Run `strace -o strace.output python3 exercise_3.py`
+
 `strace` will write each and every *system call* that the process makes to the `strace.output` file.
 
 Look at the `strace.output` file.


### PR DESCRIPTION
/sdc/tools/sprints/3/day-plan/ - strace

clear up some ambiguity for trainees (originally this rendered on one line, trainees were copying out additional text thinking that's part of the command)