### PR TITLE
Change mermaid version from @latest to @11.16.0

### DIFF
--- a/common-theme/assets/scripts/mermaid-observer.js
+++ b/common-theme/assets/scripts/mermaid-observer.js
@@ -1,4 +1,4 @@
-import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs";
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.esm.min.mjs";
 
 mermaid.initialize({ startOnLoad: false });
 // Prevent automatic loading so that mermaid only renders on intersection


### PR DESCRIPTION
## Changelist
- Changed Mermaid CDN import from `@latest` to the a pinned version 11.16.0 to avoid potential 404 errors (which causes diagrams not showing).
