### PR TITLE
Add missing mandatory items to Data Flows end of module review

### DIFF
--- a/org-cyf/content/itp/data-flows/success/index.md
+++ b/org-cyf/content/itp/data-flows/success/index.md
@@ -53,8 +53,18 @@ weight = 11
       ---
    - A link to your _completed_ pull request for "[Book Library Project](https://github.com/CodeYourFuture/Module-Data-Flows/issues/31)".
 
+   - A link to your _completed_ pull request for "[Object Destructuring](https://github.com/CodeYourFuture/Module-Data-Flows/issues/24)".
+
+   - A link to your _completed_ pull request for "[Programmer Humour](https://github.com/CodeYourFuture/Module-Data-Flows/issues/25)".
+
       ---
    - A link to your issue for "[LinkedIn Social Selling Index](https://github.com/CodeYourFuture/Module-Data-Flows/issues/12)". Your issue must show your current index and actions you will take to improve it.
+
+   - A link to your issue for "[Your LinkedIn tips](https://github.com/CodeYourFuture/Module-Data-Flows/issues/8)". Your issue must show the link to your document.
+
+   - A link to your issue for "[Your SWOT analysis](https://github.com/CodeYourFuture/Module-Data-Flows/issues/13)". Your issue must show the link to your document, which anyone with the link can comment on.
+
+   - A link to your issue for "[Review your peers' LinkedIn profile](https://github.com/CodeYourFuture/Module-Data-Flows/issues/11)". Your issue must show the feedback you gave.
 
       ---
    - A screenshot showing that you [gave a demo in a demo session with particular members of staff present](https://github.com/CodeYourFuture/Module-Data-Flows/issues/323).\


### PR DESCRIPTION
Five mandatory items are not in the End of Module Review list:

- Object Destructuring (PR, sprint 1)
- Programmer Humour (PR, sprint 3)
- Your LinkedIn tips (sprint 2)
- Your SWOT analysis (sprint 2)
- Review your peers' LinkedIn profile (sprint 3)

Not added: mandatory items with nothing to link (Play the Bandit, sprints 1 and 3; Read about team roles, sprint 1; ITP end survey, sprint 3).

Do not merge before 22 August 2026, so requirements do not change mid-module for the current cohort.

Preview: https://deploy-preview-1984--cyf-curriculum.netlify.app/itp/data-flows/success/