### PR TITLE
Update Checkpoint docs

### DIFF
--- a/common-content/en/module/checkpoint/group-day-plan/index.md
+++ b/common-content/en/module/checkpoint/group-day-plan/index.md
@@ -1,0 +1,21 @@
++++
+title="Checkpoint Group Day-Plan"
+time=415
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+This sprint you are working on a group project. We expect you to be present and working with your group all day - from 10:00 until 17:00. There will be a break for lunch at 13:00 - 14:00.
+
+At some point during the day you will be expected to give a demo. We will try to tell you in advance what time you will be giving demos, but be prepared to give them first thing. We expect you to prepare your demos before class, and to be available for demos all day.
+
+You will be split randomly into groups for the project. You will not get to choose your groups. Together you should:
+1. **Review** the project description together (which you should already have read).
+2. Work out **how you're going to work together** and plan.
+3. **Set up** your project on GitHub.
+4. **Break down** the project into tasks.
+5. **Assign** tasks to team members.
+6. **Agree** on a deadline for each task.
+7. **Execute** and **communicate**.

--- a/common-content/en/module/checkpoint/intentions/index.md
+++ b/common-content/en/module/checkpoint/intentions/index.md
@@ -19,6 +19,5 @@ Below is a list of learning objectives that are not currently taught in ITP, and
 
 | Learning Objective | How we handle it |
 | -------------------|------------------|
-| [Break down a project to work on as a group in parallel](https://github.com/CodeYourFuture/curriculum/issues/1441) | We teach this in a workshop in sprint 1 |
 | [Test a project reasonably thoroughly](https://github.com/CodeYourFuture/curriculum/issues/1616) | We only require one non-trivial test |
-| Anticipate and prevent time-zone and daylight-savings bugs | Time-related project briefings, contain warnings and guidance |
+| Anticipate and prevent time-zone and daylight-savings bugs | Time-related project briefings contain warnings and guidance |

--- a/common-content/en/module/checkpoint/interviewing/index.md
+++ b/common-content/en/module/checkpoint/interviewing/index.md
@@ -17,6 +17,8 @@ If something goes completely wrong (e.g. internet connections drop), try to reco
 
 Try to leave the interviewee feeling positive (that they could complete some tasks), but do not mislead them about outcomes. Do not share the outcome of their interview with them in the interview.
 
+Try to come to a clear yes/no conclusion, but it's ok if you can't - someone else can re-watch the interview and give a second opinion (or if needs be, we can even do a follow-up interview).
+
 After all of the interviews are completed, we gather (ideally on the same day) to make final decisions as a group.
 
 We record all interviews, so that we can get second opinions if needed. We make sure we're calibrated such that everyone would give the same pass/fail decision.

--- a/common-content/en/module/checkpoint/project-submission/index.md
+++ b/common-content/en/module/checkpoint/project-submission/index.md
@@ -11,6 +11,7 @@ objectives = [
 +++
 
 For all projects in the Checkpoint:
+* The project must be written in JavaScript.
 * The project must be in its own repository. That repository must not contain other projects. Do not fork this `CodeYourFuture/Checkpoint` repo - make a new repository for your project.
   * There should not be any dead code or unused code in your repository. All code should be used, all tests should run and pass.
 * For team projects, all members of the team should work in the same repository.

--- a/common-content/en/module/checkpoint/routines/index.md
+++ b/common-content/en/module/checkpoint/routines/index.md
@@ -15,7 +15,12 @@ To smoothly run a Checkpoint, we ask that that the volunteers running it:
   * Use the shared template for writing up feedback - this helps us to be consistent, to prepare for interviews, and to collate feedback to present to trainees at the end of the course.
 * Fill in the trainee tracker spreadsheet as we go.
 
-On class days, we:
+### Before class days
+
+* Tell the trainees what time they should expect to do demos, particularly if they're doing remote demos.
+
+### On class days
+
 * Attend each week.
 * Start punctually at 10:00.
 * Assign trainees to groups randomly. Make sure that trainees are working in different groups each week. Ideally there should be 0 overlap week-to-week.

--- a/common-content/en/module/checkpoint/solo-day-plan/index.md
+++ b/common-content/en/module/checkpoint/solo-day-plan/index.md
@@ -1,0 +1,12 @@
++++
+title="Checkpoint Solo Day-Plan"
+time=415
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
++++
+
+This sprint you are working on a solo project. You are free to work when/where/how you want.
+
+At some point during the day you will be expected to give a demo (which may be in person or remote). We will try to tell you in advance what time you will be giving demos, but be prepared to give them first thing. We expect you to prepare your demos before class, and to be available for demos all day.

--- a/common-content/en/module/checkpoint/solo-project/index.md
+++ b/common-content/en/module/checkpoint/solo-project/index.md
@@ -1,6 +1,5 @@
 +++
 title="Solo Project"
-time=8640
 [build]
   render = 'never'
   list = 'local'

--- a/common-content/en/module/checkpoint/solo-project/index.md
+++ b/common-content/en/module/checkpoint/solo-project/index.md
@@ -1,10 +1,6 @@
 +++
 title="Solo Project"
-time=45
-tasks = [
-    "Pick a project to work on on your own.",
-    "Start working on a solo project.",
-]
+time=8640
 [build]
   render = 'never'
   list = 'local'
@@ -14,3 +10,7 @@ tasks = [
 This sprint you will be working on a solo project. You will need to deliver an entire project, working on your own without a team.
 
 You can choose any one of these listed projects:
+
+* [Spaced Repetition Tracker](https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Spaced-Repetition-Tracker)
+* [Music Data](https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Music-Data)
+* [Codewars Leaderboard](https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Codewars-Leaderboard)

--- a/common-theme/layouts/partials/block/block.html
+++ b/common-theme/layouts/partials/block/block.html
@@ -1,5 +1,5 @@
 {{/* Call our scratch function */}}
-{{ partial "block/data.html" (dict "Scratch" .Page.Scratch "src" .block.src  "name" .block.name "time" .block.time "caption" .block.caption "picture" .block.picture "hasBlocks" .block.nested "block" .block) }}
+{{ partial "block/data.html" (dict "Scratch" .Page.Scratch "src" .block.src  "name" .block.name "time" .block.time "caption" .block.caption "picture" .block.picture "hasBlocks" .block.nested "block" .block "nestedTitle" .block.nestedTitle) }}
 {{/* Retrieve the blockData from Scratch */}}
 {{ $blockData := .Page.Scratch.Get "blockData" }}
 

--- a/common-theme/layouts/partials/block/data.html
+++ b/common-theme/layouts/partials/block/data.html
@@ -26,6 +26,7 @@
 {{ .Scratch.SetInMap "blockData" "isShortcode" false }}
 {{ .Scratch.SetInMap "blockData" "caption" .caption | default "" }}
 {{ .Scratch.SetInMap "blockData" "hasBlocks" .hasBlocks| default "" }}
+{{ .Scratch.SetInMap "blockData" "nestedTitle" (.nestedTitle | default "Options") }}
 {{/* Override any block time */}}
 {{ .Scratch.SetInMap "blockData" "time" .time | default "" }}
 {{ .Scratch.SetInMap "blockData" "block" .block }}

--- a/common-theme/layouts/partials/block/local.html
+++ b/common-theme/layouts/partials/block/local.html
@@ -37,7 +37,7 @@
     */}}
     {{ with $blockData.hasBlocks }}
       <section class="c-block__nested">
-        <h3>🗂️ Options</h3>
+        <h3>🗂️ {{ $blockData.nestedTitle }}</h3>
         {{ range . }}
           {{ range $block := . }}
             {{ $blockDict := dict "block" $block "Page" $.Page "Site" site }}

--- a/common-theme/layouts/partials/time.html
+++ b/common-theme/layouts/partials/time.html
@@ -24,15 +24,19 @@
   {{- $localBlock = $localBlock.Params.Time -}}
 {{- end -}}
 {{- $time := (int $blockData.time) | default $localBlock | default 60 -}}
-{{- $timeLabel := printf "%d\u00A0minutes" $time -}}
-{{- if and $time (gt $time 100) -}}
-  {{- $hours := int (math.Floor (math.Div $time 60)) -}}
-  {{- $minutes := int (math.Floor (math.Mod $time 60)) -}}
-  {{- $timeLabel = printf "%d\u00A0hours" $hours -}}
-  {{- if ne $minutes 0 -}}
-    {{- $timeLabel = printf "%s\u00A0%d\u00A0minutes" $timeLabel $minutes -}}
+{{/* Ideally we'd just hide 0s, but Go's default/fallback rules mean a missing time is a 0 time we we can't treat it specially.
+     Hide negative times, though. */}}
+{{- if gt $time 0 -}}
+  {{- $timeLabel := printf "%d\u00A0minutes" $time -}}
+  {{- if and $time (gt $time 100) -}}
+    {{- $hours := int (math.Floor (math.Div $time 60)) -}}
+    {{- $minutes := int (math.Floor (math.Mod $time 60)) -}}
+    {{- $timeLabel = printf "%d\u00A0hours" $hours -}}
+    {{- if ne $minutes 0 -}}
+      {{- $timeLabel = printf "%s\u00A0%d\u00A0minutes" $timeLabel $minutes -}}
+    {{- end -}}
   {{- end -}}
+  <!-- prettier-ignore --><time class="c-block__time" tabindex="0" role="timer" aria-label="{{ $time }} minutes countdown" datetime="P{{ $time }}M">{{- $timeLabel -}}&nbsp;⏱</time>
+  {{- $stopwatch := resources.GetMatch "/scripts/stop-watch.js" | resources.Minify -}}
+  <script type="module" defer>import StopWatch from "{{ $stopwatch.RelPermalink }}";</script>
 {{- end -}}
-<!-- prettier-ignore --><time class="c-block__time" tabindex="0" role="timer" aria-label="{{ $time }} minutes countdown" datetime="P{{ $time }}M">{{- $timeLabel -}}&nbsp;⏱</time>
-{{- $stopwatch := resources.GetMatch "/scripts/stop-watch.js" | resources.Minify -}}
-<script type="module" defer>import StopWatch from "{{ $stopwatch.RelPermalink }}";</script>

--- a/org-cyf/content/checkpoint/sprints/1/day-plan/index.md
+++ b/org-cyf/content/checkpoint/sprints/1/day-plan/index.md
@@ -13,7 +13,7 @@ src="module/checkpoint/demo"
 [[blocks.nested.blocks]]
 name="Group Project: Shared Bookmarks"
 src="https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Shared-Bookmarks"
-time=8640
+time=-1
 [[blocks]]
 name="Socialise"
 src="blocks/socialise"

--- a/org-cyf/content/checkpoint/sprints/1/day-plan/index.md
+++ b/org-cyf/content/checkpoint/sprints/1/day-plan/index.md
@@ -4,49 +4,17 @@ layout = 'day-plan'
 menu_level = ['sprint']
 weight = 3
 [[blocks]]
-name="Induction"
-src="module/checkpoint/induction"
-time=5
-[[blocks]]
-name="Energiser"
-src="energisers/zip-zap-boing"
-[[blocks]]
-name="Practice breaking down a requirement"
-src="module/checkpoint/practice-break-down"
-[[blocks]]
-name="Kickoff"
-src="module/checkpoint/kickoff"
-time=20
-[[blocks]]
-name="Morning break"
-src="blocks/morning-break"
-[[blocks]]
-name="Group Project: Shared Bookmarks"
-src="https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Shared-Bookmarks"
-time=30
-[[blocks]]
-name="Development"
-src="module/checkpoint/development"
-time="45"
-[[blocks]]
-name="lunch"
-src="blocks/lunch"
-[[blocks]]
-name="Development"
-src="module/checkpoint/development"
-time="75"
-[[blocks]]
-name="Afternoon break"
-src="blocks/afternoon-break"
-[[blocks]]
-name="Development"
-src="module/checkpoint/development"
-time="30"
-[[blocks]]
+name="Checkpoint Group Day-Plan"
+src="module/checkpoint/group-day-plan"
+nestedTitle = "Activities"
+[[blocks.nested.blocks]]
 name="Demo"
 src="module/checkpoint/demo"
-time="60"
+[[blocks.nested.blocks]]
+name="Group Project: Shared Bookmarks"
+src="https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Shared-Bookmarks"
+time=8640
 [[blocks]]
-name="Wrap"
-src="module/checkpoint/wrap"
+name="Socialise"
+src="blocks/socialise"
 +++

--- a/org-cyf/content/checkpoint/sprints/2/day-plan/index.md
+++ b/org-cyf/content/checkpoint/sprints/2/day-plan/index.md
@@ -4,49 +4,16 @@ layout = 'day-plan'
 menu_level = ['sprint']
 weight = 3
 [[blocks]]
-name="Energiser"
-src="energisers/wemoji"
-[[blocks]]
+name="Checkpoint Solo Day-Plan"
+src="module/checkpoint/solo-day-plan"
+nestedTitle = "Activities"
+[[blocks.nested.blocks]]
 name="Demo"
 src="module/checkpoint/demo"
-[[blocks]]
-name="Morning break"
-src="blocks/morning-break"
-[[blocks]]
+[[blocks.nested.blocks]]
 name="Solo project"
 src="module/checkpoint/solo-project"
-time=45
-[[blocks.nested.blocks]]
-name="Spaced Repetition Tracker"
-src="https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Spaced-Repetition-Tracker"
-time=0
-[[blocks.nested.blocks]]
-name="Music Data"
-src="https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Music-Data"
-time=0
-[[blocks.nested.blocks]]
-name="Codewars Leaderboard"
-src="https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Codewars-Leaderboard"
-time=0
 [[blocks]]
-name="Development"
-src="module/checkpoint/solo-development"
-time="60"
-[[blocks]]
-name="lunch"
-src="blocks/lunch"
-[[blocks]]
-name="Development"
-src="module/checkpoint/solo-development"
-time="75"
-[[blocks]]
-name="Afternoon break"
-src="blocks/afternoon-break"
-[[blocks]]
-name="Development"
-src="module/checkpoint/solo-development"
-time="75"
-[[blocks]]
-name="Wrap"
-src="module/checkpoint/wrap"
+name="Socialise"
+src="blocks/socialise"
 +++

--- a/org-cyf/content/checkpoint/sprints/2/day-plan/index.md
+++ b/org-cyf/content/checkpoint/sprints/2/day-plan/index.md
@@ -13,6 +13,7 @@ src="module/checkpoint/demo"
 [[blocks.nested.blocks]]
 name="Solo project"
 src="module/checkpoint/solo-project"
+time=-1
 [[blocks]]
 name="Socialise"
 src="blocks/socialise"

--- a/org-cyf/content/checkpoint/sprints/3/day-plan/index.md
+++ b/org-cyf/content/checkpoint/sprints/3/day-plan/index.md
@@ -4,41 +4,17 @@ layout = 'day-plan'
 menu_level = ['sprint']
 weight = 3
 [[blocks]]
-name="Energiser"
-src="energisers/blockers"
-[[blocks]]
+name="Checkpoint Group Day-Plan"
+src="module/checkpoint/group-day-plan"
+nestedTitle = "Activities"
+[[blocks.nested.blocks]]
 name="Demo"
 src="module/checkpoint/demo"
-[[blocks]]
-name="Kickoff"
-src="module/checkpoint/kickoff"
-time=20
-[[blocks]]
-name="Morning break"
-src="blocks/morning-break"
-[[blocks]]
+[[blocks.nested.blocks]]
 name="Group Project: Days Calendar"
 src="https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Days-Calendar"
-time=40
+time=8640
 [[blocks]]
-name="Development"
-src="module/checkpoint/development"
-time="30"
-[[blocks]]
-name="lunch"
-src="blocks/lunch"
-[[blocks]]
-name="Development"
-src="module/checkpoint/development"
-time="75"
-[[blocks]]
-name="Afternoon break"
-src="blocks/afternoon-break"
-[[blocks]]
-name="Development"
-src="module/checkpoint/development"
-time="75"
-[[blocks]]
-name="Wrap"
-src="module/checkpoint/wrap"
+name="Socialise"
+src="blocks/socialise"
 +++

--- a/org-cyf/content/checkpoint/sprints/3/day-plan/index.md
+++ b/org-cyf/content/checkpoint/sprints/3/day-plan/index.md
@@ -13,7 +13,7 @@ src="module/checkpoint/demo"
 [[blocks.nested.blocks]]
 name="Group Project: Days Calendar"
 src="https://github.com/CodeYourFuture/Checkpoint/tree/main/Project-Days-Calendar"
-time=8640
+time=-1
 [[blocks]]
 name="Socialise"
 src="blocks/socialise"

--- a/org-cyf/content/checkpoint/success/index.md
+++ b/org-cyf/content/checkpoint/success/index.md
@@ -1,5 +1,5 @@
 +++
-title = "End of Module Review"
+title = "End of Course Review"
 description = "What does it mean to pass the Checkpoint?"
 layout = "success"
 emoji= "✅"


### PR DESCRIPTION
Remove granular day-plans. We don't actually follow them. Instead, give "whole day" day plan items, with descriptions of what is expected during the day.

Also:
* Remove breaking down projects workshop - it's now covered in ITP.
* Spec that projects should be written in JavaScript.
* Clarify that you don't need a definite interview outcome.
* Guide towards scheduling demos in advance of the day.


