### PR TITLE
Fill in Legacy Code sprints 1 and 2 content

### DIFF
--- a/common-content/en/module/legacy/familiarising-with-a-codebase/index.md
+++ b/common-content/en/module/legacy/familiarising-with-a-codebase/index.md
@@ -1,0 +1,35 @@
++++
+title = "Familiarising Yourself With a Codebase"
+time = 30
+objectives = [
+    "Explain the purpose of README files.",
+    "Identify the directory structure of an existing project.",
+    "Explain why and how project documentation may go out of date.",
+]
+[build]
+  render = "never"
+  list = "local"
+  publishResources = false
++++
+
+Before we can debug or fix anything in our new codebase, we need to understand what we have.
+
+Different projects document things differently. Some common conventions are:
+* In a README.md file at the root of the repository.
+* In a README.md file in the directory of each component.
+* In comments across the codebase.
+* In a wiki, or standalone website, for the project.
+* In a file named DEVELOPING.md, CONTRIBUTING.md, or similar, in the root of the repository.
+* Assuming you'll ask someone who already knows how things work to help you get started.
+
+{{<note type="exercise">}}
+Work out which of these approaches the Purple Forest application uses.
+{{</note>}}
+
+Sometimes documentation goes out of date! Most of the time the documentation was correct _at the time it was written_, but something changed in the application and no one remembered to update the documentation.
+
+This is unfortunate, but the reality of the world. Sometimes there will be gaps. Sometimes you need to work out how to fill them. Sometimes you need to understand error messages to fill in those gaps. Sometimes you will need to ask someone. Sometimes you can look through the git history to work out what changed since the documentation was written.
+
+{{<note type="exercise">}}
+Work out what software you need installed on your computer to run Purple Forest, and how it's intended to be run.
+{{</note>}}

--- a/common-content/en/module/legacy/getting-purple-forest-running-day-plan/index.md
+++ b/common-content/en/module/legacy/getting-purple-forest-running-day-plan/index.md
@@ -1,0 +1,19 @@
++++
+title = "Getting Up and Running"
+time = 30
+tasks = [
+    "Run all of the components of Purple Forest.",
+]
+[build]
+  render = "never"
+  list = "local"
+  publishResources = false
++++
+
+In the prep, you should already have gotten Purple Forest running.
+
+This is time to:
+1. Finish off / get help if you got stuck.
+2. Discuss what challenges you ran into, and how you approached them. How may you approach them differently working at a company vs working on your own?
+
+Ad the end of this session, you should have running system which you can open in your browser and log in to.

--- a/common-content/en/module/legacy/getting-up-and-running/index.md
+++ b/common-content/en/module/legacy/getting-up-and-running/index.md
@@ -1,0 +1,19 @@
++++
+title = "Getting Up and Running"
+time = 30
+objectives = [
+    "Run a multi-process system despite missing/incorrect/out-of-date instructions.",
+]
+[build]
+  render = "never"
+  list = "local"
+  publishResources = false
++++
+
+Now that we've gotten to know the shape of our repository a bit, let's try to run it. The goal of this is to end up with a running system which we can open in our browser and log in to.
+
+You should have found README.md files in different top-level directories of Purple Forest. Follow their instructions to get all of the components you need running.
+
+You may run into errors due to out of date documentation. You will need to debug these by reading error messages - you may even need to reach out for help from others.
+
+When you have successfully opened the front page of Purple Forest in your web browser, and logged in as a sample user, continue onto the next step.

--- a/common-content/en/module/legacy/practices-to-remember/index.md
+++ b/common-content/en/module/legacy/practices-to-remember/index.md
@@ -1,15 +1,15 @@
 +++
 title = "Practices to remember"
 time = 30
-[build]
-  render = "never"
-  list = "local"
-  publishResources = false
 objectives = [
     "Explain differences in approaching formatting of legacy vs greenfield projects.",
     "List what should be included in a PR description and why.",
     "Consider risk trade-offs when changing legacy code.",
 ]
+[build]
+  render = "never"
+  list = "local"
+  publishResources = false
 +++
 
 Some of our standard development practices are _even more important_ when working with legacy code. These are things you should already be doing, but you should remember.

--- a/common-content/en/module/legacy/understanding/index.md
+++ b/common-content/en/module/legacy/understanding/index.md
@@ -20,6 +20,12 @@ Legacy code isn't necessarily bad or even that old. It's code that:
 1. **Powers important systems** - It can't simply be deleted or replaced.
 1. **Contains institutional knowledge** - Sometime undocumented! Decisions were often made for good reasons which we may not remember any more, and changing those decisions may be risky.
 
+In this module, you'll be working with an application called [Purple Forest](https://github.com/CodeYourFuture/Module-Legacy-Code) - an basic application much like Twitter or BlueSky.
+
+{{<note type="exercise">}}
+Clone Purple Forest onto your computer now.
+{{</note>}}
+
 The Purple Forest application is now your legacy code. Someone else designed and built it, and you need to maintain and extend it.
 
 ## Working with Purple Forest
@@ -28,6 +34,7 @@ Purple Forest has:
 
 - **Established architecture** - It follows defined patterns
 - **Functional system** - It mostly works, even if you don't understand how
+- **Bugs** - Not _everything_ works!
 - **Multiple components** - Changes might have unexpected side effects
 - **Documented design** - But the documentation might be incomplete or out of date
 

--- a/common-theme/layouts/partials/block/issues-list-as-blocks-portal.html
+++ b/common-theme/layouts/partials/block/issues-list-as-blocks-portal.html
@@ -17,14 +17,6 @@
   {{ $moduleName = "Structuring and testing data" }}
 {{ end }}
 
-{{ if eq $moduleName "Legacy-Code" }}
-  {{ $moduleName = "Legacy code" }}
-  {{/* TODO: Remove this when there are actually issues for Legacy Code sprint 2 */}}
-  {{ if eq $sprintName "Sprint 2"}}
-    {{ $sprintName = "Sprint 1" }}
-  {{ end }}
-{{ end }}
-
 {{ $issueBlocks := slice }}
 
 {{ with resources.GetRemote "https://portal-backend.codeyourfuture.io/functions/v1/coursework-index" }}

--- a/org-cyf/content/sdc/legacy-code/sprints/1/backlog/index.md
+++ b/org-cyf/content/sdc/legacy-code/sprints/1/backlog/index.md
@@ -3,6 +3,6 @@ title = "Backlog"
 layout = "backlog"
 menu_level = ["sprint"]
 weight = 2
-backlog = "Module-Legacy-Code"
+backlog = "Legacy code"
 backlog_filter = "📅 Sprint 1"
 +++

--- a/org-cyf/content/sdc/legacy-code/sprints/1/day-plan/index.md
+++ b/org-cyf/content/sdc/legacy-code/sprints/1/day-plan/index.md
@@ -4,7 +4,31 @@ layout = "day-plan"
 menu_level = ["sprint"]
 weight = 3
 [[blocks]]
-name = "Coming soon"
-src = "blocks/coming-soon"
-time = "420"
+name = "Demo"
+src = "blocks/demo"
+time = "30"
+[[blocks]]
+name = "Getting Purple Forest running"
+src = "module/legacy/getting-purple-forest-running-day-plan"
+time = "60"
+[[blocks]]
+name = "Morning break"
+src = "blocks/morning-break"
+[[blocks]]
+name = "Refining poorly specified bugs"
+src = "workshops/reporting-bugs"
+time = "70"
+[[blocks]]
+name = "Lunch"
+src = "blocks/lunch"
+[[blocks]]
+name = "Refining Purple Forest bugs"
+src = "module/legacy/refining-purple-forest-bugs"
+[[blocks]]
+name = "Study Group"
+src = "blocks/study-group"
+time = "130"
+[[blocks]]
+name = "Retro"
+src = "blocks/retro"
 +++

--- a/org-cyf/content/sdc/legacy-code/sprints/1/prep/index.md
+++ b/org-cyf/content/sdc/legacy-code/sprints/1/prep/index.md
@@ -5,6 +5,27 @@ layout = "prep"
 menu_level = ["sprint"]
 weight = 1
 [[blocks]]
-name = "Coming soon"
-src = "blocks/coming-soon"
+name = "Introduction"
+src = "module/legacy/introduction"
+[[blocks]]
+name = "Understanding"
+src = "module/legacy/understanding"
+[[blocks]]
+name = "Practices to remember"
+src = "module/legacy/practices-to-remember"
+[[blocks]]
+name = "Familiarising yourself with a codebase"
+src = "module/legacy/familiarising-with-a-codebase"
+[[blocks]]
+name = "Getting up and running"
+src = "module/legacy/getting-up-and-running"
+[[blocks]]
+name = "Finding things"
+src = "module/legacy/navigation"
+[[blocks]]
+name = "Debugging"
+src = "module/legacy/debugging"
+[[blocks]]
+name = "Fixing"
+src = "module/legacy/fixing"
 +++

--- a/org-cyf/content/sdc/legacy-code/sprints/2/backlog/index.md
+++ b/org-cyf/content/sdc/legacy-code/sprints/2/backlog/index.md
@@ -3,6 +3,6 @@ title = "Backlog"
 layout = "backlog"
 menu_level = ["sprint"]
 weight = 2
-backlog = "Module-Legacy-Code"
+backlog = "Legacy code"
 backlog_filter = "📅 Sprint 2"
 +++

--- a/org-cyf/content/sdc/legacy-code/sprints/2/day-plan/index.md
+++ b/org-cyf/content/sdc/legacy-code/sprints/2/day-plan/index.md
@@ -4,38 +4,27 @@ layout = "day-plan"
 menu_level = ["sprint"]
 weight = 3
 [[blocks]]
-name = "Coming soon"
-src = "blocks/coming-soon"
-time = "420"
-[[blocks]]
 name = "Demo"
 src = "blocks/demo"
 time = "30"
 [[blocks]]
-name = "Refining poorly specified bugs"
-src = "workshops/reporting-bugs"
+name = "Discussion: Behavioural Interviews"
+src = "blocks/discuss-behavioural-interviews"
 time = "60"
 [[blocks]]
 name = "Morning break"
 src = "blocks/morning-break"
 [[blocks]]
-name = "Refining Purple Forest bugs"
-src = "module/legacy/refining-purple-forest-bugs"
-[[blocks]]
 name = "Study Group"
 src = "blocks/study-group"
-time = "25"
+time = "70"
 [[blocks]]
 name = "Lunch"
 src = "blocks/lunch"
 [[blocks]]
-name = "Discussion: Behavioural Interviews"
-src = "blocks/discuss-behavioural-interviews"
-time = "30"
-[[blocks]]
 name = "Study Group"
 src = "blocks/study-group"
-time = "130"
+time = "160"
 [[blocks]]
 name = "Retro"
 src = "blocks/retro"

--- a/org-cyf/content/sdc/legacy-code/sprints/2/prep/index.md
+++ b/org-cyf/content/sdc/legacy-code/sprints/2/prep/index.md
@@ -5,39 +5,17 @@ layout = "prep"
 menu_level = ["sprint"]
 weight = 1
 [[blocks]]
-name = "Introduction"
-src = "module/legacy/introduction"
-[[blocks]]
-name = "Practices to remember"
-src = "module/legacy/practices-to-remember"
-[[blocks]]
-src = "https://github.com/CodeYourFuture/Module-Legacy-Code"
-name = "Purple Forest"
-time = 60
-[[blocks]]
-name = "Understanding"
-src = "module/legacy/understanding"
-[[blocks]]
 name = "Fear and logic"
 src = "module/legacy/fear"
 [[blocks]]
-name = "Finding things"
-src = "module/legacy/navigation"
-[[blocks]]
 name = "Patterns"
 src = "module/legacy/patterns"
-[[blocks]]
-name = "Debugging"
-src = "module/legacy/debugging"
 [[blocks]]
 name = "Reproduction Steps"
 src = "module/legacy/reproduction-steps"
 [[blocks]]
 name = "Testing"
 src = "module/legacy/testing"
-[[blocks]]
-name = "Fixing"
-src = "module/legacy/fixing"
 [[blocks]]
 name = "Extending"
 src = "module/legacy/adding"


### PR DESCRIPTION
Previously we had one very congested sprint - the work was way too much.

Now we:
1. Split into two sprints
2. Give extra time and prompts in the prep and the day-plan of the first sprint to make sure people actually get the app running - because we have intentionally missing steps in the instructions, people often get stuck on this, so let's call it out more and give more support.
3. Front-load most of the "debug an issue" topics into sprint 1, and most of the "write a new feature" into sprint 2.

Ideally at some point we'd like to have a second project, but we don't currently, so instead just give more time to do the existing one.