### PR TITLE
Add Prep quiz block to ITP day plans

### DIFF
--- a/common-content/en/blocks/prep-quiz/index.md
+++ b/common-content/en/blocks/prep-quiz/index.md
@@ -1,0 +1,31 @@
++++
+title = 'Prep quiz'
+description = 'Recap the prep as a quiz and find out what the room is stuck on'
+time = 15
+hide_from_overview = true
+[build]
+  render = 'never'
+  list = 'local'
+  publishResources = false
+
++++
+
+{{<note title="Prep quiz (15 minutes)" type="activity">}}
+
+This is the recap for the sprint, run as a quiz. Everyone has done the prep during the week. A quiz brings it back to the front of everyone's mind, gets the whole room involved rather than just listening, and shows straight away which parts people are still unsure of.
+
+🔗 <a href="https://quizitp.netlify.app/" target="_blank" rel="noopener">QuizIt</a> has a quiz for each sprint, with questions written from that sprint's prep, so there is nothing to prepare.
+
+1. The facilitator opens QuizIt on the screen and chooses the quiz for this sprint.
+2. Create a room and share the room code with the group.
+3. Everyone joins from their laptop and answers each question against a timer, like a game show.
+4. After each question, QuizIt shows the answer and a short explanation. Pause on any question the room got wrong and talk it through.
+5. The facilitator writes down any question the room got wrong, on the whiteboard or in the class Slack channel. Those topics are what Study Group starts with later today, along with any [backlog](../backlog/) exercise or coursework people are stuck on.
+
+Keep it light. Nobody is being graded. The aim is to remind people what the sprint was about and to help them notice what they still need to work on.
+
+{{</note>}}
+
+### If QuizIt is not available
+
+Open [the prep](../prep/) on the screen instead and go over what it covered. The learning objectives at the top of each block are a good guide: read them out, ask the room a question about each one, and note anything people are unsure of for Study Group.

--- a/org-cyf/content/itp/data-flows/sprints/1/day-plan/index.md
+++ b/org-cyf/content/itp/data-flows/sprints/1/day-plan/index.md
@@ -6,9 +6,14 @@ weight = 3
 [[blocks]]
 name="Energiser"
 src="blocks/energiser"
+time=15
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Teamwork Project Sprint 1"

--- a/org-cyf/content/itp/data-flows/sprints/2/day-plan/index.md
+++ b/org-cyf/content/itp/data-flows/sprints/2/day-plan/index.md
@@ -6,9 +6,14 @@ weight = 3
 [[blocks]]
 name="Energiser"
 src="blocks/energiser"
+time=15
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Demo Q&A Practice"

--- a/org-cyf/content/itp/data-flows/sprints/3/day-plan/index.md
+++ b/org-cyf/content/itp/data-flows/sprints/3/day-plan/index.md
@@ -6,9 +6,14 @@ weight = 3
 [[blocks]]
 name="Energiser"
 src="blocks/energiser"
+time=15
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name= "Teamwork Project"

--- a/org-cyf/content/itp/data-groups/sprints/1/day-plan/index.md
+++ b/org-cyf/content/itp/data-groups/sprints/1/day-plan/index.md
@@ -6,9 +6,14 @@ weight = 3
 [[blocks]]
 name="Energiser"
 src="blocks/energiser"
+time=15
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Giving Feedback"

--- a/org-cyf/content/itp/data-groups/sprints/2/day-plan/index.md
+++ b/org-cyf/content/itp/data-groups/sprints/2/day-plan/index.md
@@ -6,9 +6,14 @@ weight = 3
 [[blocks]]
 name="Energiser"
 src="blocks/energiser"
+time=15
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Objects"

--- a/org-cyf/content/itp/data-groups/sprints/3/day-plan/index.md
+++ b/org-cyf/content/itp/data-groups/sprints/3/day-plan/index.md
@@ -6,9 +6,14 @@ weight = 3
 [[blocks]]
 name="Energiser"
 src="blocks/energiser"
+time=15
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="DOM merge conflict"

--- a/org-cyf/content/itp/javascript-fundamentals/sprints/1/day-plan/index.md
+++ b/org-cyf/content/itp/javascript-fundamentals/sprints/1/day-plan/index.md
@@ -9,7 +9,7 @@ src="blocks/name-tags"
 [[blocks]]
 name="Energiser"
 src="energisers/in-person-and-online"
-time=20
+time=15
 [[blocks.nested.blocks]]
 name="In person: Zip Zap Boing"
 src="energisers/zip-zap-boing"
@@ -21,6 +21,10 @@ time=0
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Workshop: Using the Curriculum"

--- a/org-cyf/content/itp/javascript-fundamentals/sprints/2/day-plan/index.md
+++ b/org-cyf/content/itp/javascript-fundamentals/sprints/2/day-plan/index.md
@@ -6,9 +6,14 @@ weight = 3
 [[blocks]]
 name="Energiser"
 src="energisers/wemoji"
+time=5
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Workshop: Asking Questions"

--- a/org-cyf/content/itp/javascript-fundamentals/sprints/3/day-plan/index.md
+++ b/org-cyf/content/itp/javascript-fundamentals/sprints/3/day-plan/index.md
@@ -6,10 +6,15 @@ weight = 3
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Energiser"
 src="energisers/start-thinking-of-your-own"
+time=10
 [[blocks.nested.blocks]]
 name="Energiser: Telephone!"
 src="energisers/telephone"

--- a/org-cyf/content/itp/onboarding/day-plan/index.md
+++ b/org-cyf/content/itp/onboarding/day-plan/index.md
@@ -10,9 +10,14 @@ src="blocks/name-tags"
 [[blocks]]
 name="Energiser"
 src="energisers/favourite-dessert"
+time=15
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Welcome to Code Your Future"

--- a/org-cyf/content/itp/testing/sprints/1/day-plan/index.md
+++ b/org-cyf/content/itp/testing/sprints/1/day-plan/index.md
@@ -6,10 +6,15 @@ weight = 3
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
-time=10
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
+time=15
 [[blocks]]
 name="Screen Safari"
 src="energisers/screen-safari"
+time=15
 [[blocks]]
 name="Problem Solving Workshop"
 src="https://codewars-workshops.codeyourfuture.io/problem-01/"

--- a/org-cyf/content/itp/testing/sprints/2/day-plan/index.md
+++ b/org-cyf/content/itp/testing/sprints/2/day-plan/index.md
@@ -6,10 +6,14 @@ weight = 3
 [[blocks]]
 name="Energiser: Word Chain"
 src="energisers/word-chain"
-time=20
+time=15
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Problem Solving Workshop"

--- a/org-cyf/content/itp/testing/sprints/3/day-plan/index.md
+++ b/org-cyf/content/itp/testing/sprints/3/day-plan/index.md
@@ -6,11 +6,15 @@ weight = 3
 [[blocks]]
 name="Morning orientation"
 src="blocks/morning-orientation"
+time=5
+[[blocks]]
+name="Prep quiz"
+src="blocks/prep-quiz"
 time=15
 [[blocks]]
 name="Energiser: Introduce Yourself"
 src="energisers/introduce-yourself"
-time=20
+time=15
 [[blocks]]
 name="Workshop:Playing Computer"
 src="workshops/playing-computer"


### PR DESCRIPTION
Adds a 15 minute Prep quiz block after morning orientation in every ITP day plan (onboarding and all 12 sprints). The facilitator runs the sprint's QuizIt quiz as a recap of the prep, and notes anything the room got wrong for Study Group.

Morning orientation drops from 15 to 5 minutes and energisers lose 5, so days' length stays the same.

Preview:
- https://deploy-preview-2001--cyf-curriculum.netlify.app/itp/onboarding/day-plan/#prep-quiz
- https://deploy-preview-2001--cyf-curriculum.netlify.app/itp/data-flows/sprints/1/day-plan/#prep-quiz
- https://deploy-preview-2001--cyf-curriculum.netlify.app/itp/testing/sprints/1/day-plan/#prep-quiz