### PR TITLE
Fix blockdata Page reference

### DIFF
--- a/common-theme/layouts/partials/block/data.html
+++ b/common-theme/layouts/partials/block/data.html
@@ -30,8 +30,8 @@
 {{/* Override any block time */}}
 {{ .Scratch.SetInMap "blockData" "time" .time | default "" }}
 {{ .Scratch.SetInMap "blockData" "block" .block }}
-{{ .Scratch.SetInMap "blockData" "Page" .block.Page }}
-{{ .Scratch.SetInMap "blockData" "pageLayout" .block.Page.Params.layout }}
+{{ .Scratch.SetInMap "blockData" "Page" page }}
+{{ .Scratch.SetInMap "blockData" "pageLayout" page.Params.layout }}
 
 {{/* Now let's do our headers */}}
 {{ $headers := partial "github-auth.html" }}


### PR DESCRIPTION
In fa60b79dbd2654c921976ad35718a554a09333e0 this started often being set to `nil`. This led to never showing the "review-objectives.html" partial on workshops.


